### PR TITLE
feat(suspender-ledger): port content script watch.ts (PR 3)

### DIFF
--- a/extensions/suspender-ledger/src/content/watch.test.ts
+++ b/extensions/suspender-ledger/src/content/watch.test.ts
@@ -1,0 +1,140 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Importing for its side effects: registers the page listeners and installs the
+// `window.isReceivingFormInput` / `window.lastVisit` contract. A content script
+// is injected exactly once, so the module is imported once here too.
+import "./watch"
+
+/** Dispatch a keydown carrying a specific `key` value. */
+function fireKeydown(target: EventTarget, key: string): void {
+  target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }))
+}
+
+/** Dispatch a bubbling visibilitychange so the window-level listener sees it. */
+function fireVisibilityChange(): void {
+  document.dispatchEvent(new Event("visibilitychange", { bubbles: true }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  document.body.innerHTML = ""
+  // a submit clears the dirty-input latch the same way a real form would.
+  window.dispatchEvent(new Event("submit"))
+})
+
+describe("watch — unsaved form input", () => {
+  it("starts clean", () => {
+    expect(window.isReceivingFormInput).toBe(false)
+  })
+
+  it("latches when a printable key is typed into an input with content", () => {
+    const input = document.createElement("input")
+    input.value = "draft"
+    document.body.appendChild(input)
+
+    fireKeydown(input, "a")
+
+    expect(window.isReceivingFormInput).toBe(true)
+  })
+
+  it("ignores non-printable keys (e.g. arrow/escape)", () => {
+    const input = document.createElement("input")
+    input.value = "draft"
+    document.body.appendChild(input)
+
+    fireKeydown(input, "Escape") // multi-char key name — not printable
+
+    expect(window.isReceivingFormInput).toBe(false)
+  })
+
+  it("ignores typing into a non-editable element", () => {
+    const div = document.createElement("div")
+    document.body.appendChild(div)
+
+    fireKeydown(div, "a")
+
+    expect(window.isReceivingFormInput).toBe(false)
+  })
+
+  it("clears the latch on submit", () => {
+    const input = document.createElement("input")
+    input.value = "draft"
+    document.body.appendChild(input)
+    fireKeydown(input, "a")
+    expect(window.isReceivingFormInput).toBe(true)
+
+    window.dispatchEvent(new Event("submit"))
+
+    expect(window.isReceivingFormInput).toBe(false)
+  })
+
+  it("stops blocking once the tracked field is emptied", () => {
+    const input = document.createElement("input")
+    input.value = "draft"
+    document.body.appendChild(input)
+    fireKeydown(input, "a")
+    expect(window.isReceivingFormInput).toBe(true)
+
+    input.value = ""
+
+    expect(window.isReceivingFormInput).toBe(false)
+  })
+})
+
+describe("watch — visibility / activity", () => {
+  afterEach(() => {
+    // restore the default jsdom `document.hidden` getter between tests.
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    })
+  })
+
+  it("refreshes window.lastVisit on visibility change", () => {
+    const before = window.lastVisit
+    vi.spyOn(Date, "now").mockReturnValue(before + 1000)
+
+    fireVisibilityChange()
+
+    expect(window.lastVisit).toBe(before + 1000)
+  })
+
+  it("sends TAB_ACTIVE with a timestamp when foregrounded", () => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    })
+
+    fireVisibilityChange()
+
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "TAB_ACTIVE",
+      timestamp: window.lastVisit,
+    })
+  })
+
+  it("sends TAB_IDLE when backgrounded", () => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    })
+
+    fireVisibilityChange()
+
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "TAB_IDLE",
+    })
+  })
+
+  it("does not throw when sendMessage rejects (no receiver)", () => {
+    vi.mocked(chrome.runtime.sendMessage).mockRejectedValueOnce(
+      new Error("Could not establish connection")
+    )
+
+    expect(() => fireVisibilityChange()).not.toThrow()
+  })
+})

--- a/extensions/suspender-ledger/src/content/watch.ts
+++ b/extensions/suspender-ledger/src/content/watch.ts
@@ -5,6 +5,155 @@
 // Ported from auto-tab-discard v3/data/inject/watch.js (MPL-2.0)
 // Copyright (C) auto-tab-discard contributors
 
-// Skeleton — full port implemented in story #256 (content script)
+import type { ContentToWorkerMessage } from "@suspender/types/messages"
+
+/**
+ * Page-context content script injected into every frame (`document_idle`). It
+ * watches for two things the worker must not suspend through:
+ *
+ *   1. **Unsaved form input** — exposed as `window.isReceivingFormInput`, a live
+ *      getter the worker's meta collector reads via `executeScript` before
+ *      discarding a tab. Set true while a typed-into INPUT/TEXTAREA/FORM/
+ *      contentEditable/PDF element still holds content; cleared on `submit`.
+ *   2. **Last foreground time** — `window.lastVisit`, refreshed on every
+ *      `visibilitychange`, used by the worker to age tabs.
+ *
+ * Port notes:
+ *   - Upstream read the deprecated, Chrome-only `event.path` to reach into
+ *     shadow/custom-element trees. Firefox has no `event.path`; this uses the
+ *     standard `event.composedPath()` instead.
+ *   - In addition to the upstream `window` contract, each visibility transition
+ *     emits a typed `ContentToWorkerMessage` (see `@suspender/types/messages`).
+ *     This is purely additive — the property contract above is unchanged.
+ *   - This module touches DOM/runtime APIs only; it never imports worker code.
+ */
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- `interface` is required to merge into the built-in Window type
+  interface Window {
+    /** True while the page holds unsaved/in-progress form input. */
+    isReceivingFormInput: boolean
+    /** Epoch milliseconds of the most recent visibility change. */
+    lastVisit: number
+  }
+}
+
+/**
+ * Whether a keydown represents a printable alphanumeric character — the modern,
+ * non-deprecated equivalent of upstream's `keyCode` 48–90 ('0'–'9', 'A'–'Z')
+ * gate. Modifier/navigation keys report multi-character `key` names ("Shift",
+ * "ArrowLeft", "Escape") and are excluded.
+ */
+function isPrintableKey(key: string): boolean {
+  return key.length === 1 && /[0-9a-zA-Z]/.test(key)
+}
+
+/** Elements that have received input and may hold unsaved content. */
+const dirtyElements = new Set<Element>()
+/** Latched once any tracked element is edited; reset by `submit`. */
+let receivingInput = false
+
+/** The editable text currently held by an element, "" if it holds none. */
+function elementValue(el: Element): string {
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return el.value
+  }
+  return el.textContent ?? ""
+}
+
+/**
+ * `window.isReceivingFormInput`: true only while at least one tracked element is
+ * still connected and non-empty. Mirrors upstream — an emptied field stops
+ * blocking suspension even before submit.
+ */
+Object.defineProperty(window, "isReceivingFormInput", {
+  configurable: true,
+  get(): boolean {
+    try {
+      const stillDirty = [...dirtyElements].some(
+        (el) => el.isConnected && elementValue(el) !== ""
+      )
+      if (!stillDirty) {
+        return false
+      }
+    } catch {
+      // defensive: a detached/cross-origin node can throw on access — ignore.
+    }
+    return receivingInput
+  },
+})
+
+/** Latch an element if it is one we treat as holding unsaved input. */
+function trackIfEditable(node: EventTarget | undefined): void {
+  if (!(node instanceof Element)) {
+    return
+  }
+  if (node instanceof HTMLElement && node.isContentEditable) {
+    dirtyElements.add(node)
+    receivingInput = true
+  }
+  if (
+    node.tagName === "INPUT" ||
+    node.tagName === "TEXTAREA" ||
+    node.tagName === "FORM"
+  ) {
+    dirtyElements.add(node)
+    receivingInput = true
+  }
+  // embedded PDF viewers (<embed>/<object>) report type="application/pdf"
+  if (node.getAttribute("type") === "application/pdf") {
+    receivingInput = true
+  }
+}
+
+// Reset input tracking once the form is submitted.
+addEventListener("submit", () => {
+  receivingInput = false
+  dirtyElements.clear()
+})
+
+// Capture-phase keydown: a printable key into an editable element marks the
+// page as holding unsaved input.
+addEventListener(
+  "keydown",
+  (e: KeyboardEvent) => {
+    if (!isPrintableKey(e.key)) {
+      return
+    }
+    trackIfEditable(e.target ?? undefined)
+    // custom elements / shadow DOM: inspect the composed path's deepest node.
+    const top = e.composedPath()[0]
+    if (top !== undefined && top !== e.target) {
+      trackIfEditable(top)
+    }
+  },
+  true
+)
+
+/** Best-effort, fire-and-forget notification to the worker. */
+function notifyWorker(message: ContentToWorkerMessage): void {
+  try {
+    // sendMessage rejects when no receiver exists or the context was
+    // invalidated; neither is fatal for the page, so swallow it.
+    void Promise.resolve(chrome.runtime.sendMessage(message)).catch(
+      () => undefined
+    )
+  } catch {
+    // runtime gone (extension reloaded) — nothing to do.
+  }
+}
+
+// Track foreground time and announce the activity transition.
+addEventListener("visibilitychange", () => {
+  window.lastVisit = Date.now()
+  notifyWorker(
+    document.hidden
+      ? { type: "TAB_IDLE" }
+      : { type: "TAB_ACTIVE", timestamp: window.lastVisit }
+  )
+})
+
+// Seed lastVisit at injection time (document_idle ⇒ the page is freshly loaded).
+window.lastVisit = Date.now()
 
 export {}

--- a/extensions/suspender-ledger/src/types/messages.ts
+++ b/extensions/suspender-ledger/src/types/messages.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 paulgsc — MIT License
+//
+// Content ↔ worker message protocol.
+//
+// This file is original work (not a port): upstream auto-tab-discard never
+// messaged the worker from the page — its `watch.js` exposed `window`
+// properties (`isReceivingFormInput`, `lastVisit`) that the worker read on
+// demand via `executeScript`. That property contract is preserved (see
+// `src/content/watch.ts`); these typed messages are an additive, push-based
+// activity channel layered on top of it.
+
+/**
+ * Messages emitted by the content script (`watch.ts`) toward the service
+ * worker. A tab announces when it becomes foregrounded (`TAB_ACTIVE`, carrying
+ * the focus timestamp) or backgrounded (`TAB_IDLE`). The worker-side handler is
+ * out of scope for the content-script story and lands separately; until then
+ * these messages are emitted and harmlessly ignored.
+ */
+export type ContentToWorkerMessage =
+  | { type: "TAB_ACTIVE"; timestamp: number }
+  | { type: "TAB_IDLE" }
+
+/** Narrowing guard for the content→worker activity protocol. */
+export function isContentToWorkerMessage(
+  value: unknown
+): value is ContentToWorkerMessage {
+  if (value === null || typeof value !== "object" || !("type" in value)) {
+    return false
+  }
+  return value.type === "TAB_ACTIVE" || value.type === "TAB_IDLE"
+}

--- a/extensions/suspender-ledger/vitest.setup.ts
+++ b/extensions/suspender-ledger/vitest.setup.ts
@@ -33,6 +33,7 @@ const mockRuntimeApi = {
   onStartup: { addListener: vi.fn() },
   onMessage: { addListener: vi.fn() },
   onMessageExternal: { addListener: vi.fn() },
+  sendMessage: vi.fn(),
   getURL: (path: string): string => `moz-extension://testid/${path}`,
   getManifest: (): { name: string; version: string } => ({
     name: "Suspender Ledger",


### PR DESCRIPTION
## PR 3 — Content script (`watch.ts`)

Closes #256. Ports `auto-tab-discard` `v3/data/inject/watch.js` to a typed Firefox MV3 content script. Isolated from the worker bundle (PR 2 / #267) — page context only, own MPL-2.0 file.

### What it does
The content script is injected into every frame at `document_idle` and exposes the two page signals the worker's meta collector reads via `chrome.scripting.executeScript`:

- **`window.isReceivingFormInput`** — a live getter, `true` while a typed-into `INPUT`/`TEXTAREA`/`FORM`/`contentEditable`/embedded-PDF element still holds content. Latched on a printable keydown, cleared on `submit`, and released automatically once the tracked field is emptied (mirrors upstream).
- **`window.lastVisit`** — epoch ms, refreshed on every `visibilitychange` (seeded at injection).

### Port notes (deviations from upstream, kept faithful where it matters)
- Upstream reached into shadow/custom-element trees via the deprecated, Chrome-only `event.path`. Firefox has no `event.path`, so this uses the standard **`event.composedPath()`**.
- The deprecated **`keyCode` 48–90** gate is replaced with a `key`-based printable-character check (same intent: alphanumeric typing).
- **Additive activity channel:** each visibility transition now emits a typed `ContentToWorkerMessage` (`TAB_ACTIVE` / `TAB_IDLE`) via `chrome.runtime.sendMessage`. This is purely additive — the `window` property contract above is unchanged, and the worker-side handler lands in a later story. Sends are best-effort (a missing receiver / invalidated context is swallowed).
- Touches DOM/runtime APIs only — never imports worker code.

### Files
- `src/content/watch.ts` — full port (MPL-2.0 header).
- `src/types/messages.ts` — `ContentToWorkerMessage` protocol + narrowing guard (original work, MIT).
- `src/content/watch.test.ts` — jsdom unit suite (10 tests): form-input latching, non-printable/non-editable rejection, submit reset, emptied-field release, `lastVisit` refresh, and `TAB_ACTIVE`/`TAB_IDLE` messaging incl. the no-receiver path.
- `vitest.setup.ts` — adds `chrome.runtime.sendMessage` to the shared mock.

### Verification
- `pnpm -F @some-extension/suspender-ledger typecheck` ✅
- `pnpm -F @some-extension/suspender-ledger test` ✅ (27 passed; 10 new)
- `pnpm check:headers` ✅ (MPL-2.0 verified)
- `eslint` on changed files ✅ (no `any`)
- `pnpm -F @some-extension/suspender-ledger build` ✅ (`watch.js` → 1.03 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7MqeEp22Lbe2z8rNUQnJg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7MqeEp22Lbe2z8rNUQnJg)_