### PR TITLE
[suspender-ledger] Finalize Firefox build gate + AMO sign workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ packages/ui/**/public/
 # Test artifacts
 extensions/**/test-results/
 
+# Signed extension artifacts (web-ext sign) — never commit credentials or .xpi
+extensions/**/artifacts/
+*.xpi
+
 
 # Misc
 .fix

--- a/extensions/suspender-ledger/.env.example
+++ b/extensions/suspender-ledger/.env.example
@@ -1,0 +1,11 @@
+# AMO (addons.mozilla.org) API credentials for `pnpm sign:firefox`.
+#
+# Generate a key/secret pair at:
+#   https://addons.mozilla.org/en-US/developers/addon/api/key/
+#
+# Copy this file to `.env.local` and fill in the values. NEVER commit
+# `.env.local` or the signed `.xpi` files in `artifacts/` — both are
+# gitignored. The credentials below are placeholders only.
+
+WEB_EXT_API_KEY=
+WEB_EXT_API_SECRET=

--- a/extensions/suspender-ledger/.gitignore
+++ b/extensions/suspender-ledger/.gitignore
@@ -1,0 +1,6 @@
+# Local AMO credentials — never commit
+.env.local
+
+# Signed extension artifacts produced by `pnpm sign:firefox` — never commit
+artifacts/
+*.xpi

--- a/extensions/suspender-ledger/NOTICE
+++ b/extensions/suspender-ledger/NOTICE
@@ -29,3 +29,8 @@ under the MIT License.
 
 The package.json declares "license": "MPL-2.0 AND MIT" to reflect this
 dual-license structure. License scope is file-level per MPL-2.0 § 3.3.
+
+Signing credentials
+-------------------
+Never commit `.env.local` (AMO API key/secret) or signed `.xpi` files.
+Both are gitignored. See README.md for the signing workflow.

--- a/extensions/suspender-ledger/README.md
+++ b/extensions/suspender-ledger/README.md
@@ -79,9 +79,19 @@ pnpm -F @some-extension/suspender-ledger build:firefox
 # unit tests (Vitest)
 pnpm -F @some-extension/suspender-ledger test
 
+# suspend-page E2E smoke (Playwright, headless Chromium against the built bundle)
+pnpm -F @some-extension/suspender-ledger test:e2e
+
 # full local gate: eslint, web-ext lint, MPL headers, typecheck
 pnpm -F @some-extension/suspender-ledger lint
 ```
+
+The `test:e2e` suite builds `dist/`, serves it over HTTP, and drives the
+suspend page (URL-param render, favicon injection, click/Enter restore) in
+headless Chromium — the one surface that is pure web and so CI-portable
+without loading an extension. It uses the Playwright-managed browser by
+default; set `PW_CHROMIUM_PATH` to point at a system Chromium when the
+Playwright CDN is unreachable.
 
 Individual checks:
 

--- a/extensions/suspender-ledger/README.md
+++ b/extensions/suspender-ledger/README.md
@@ -1,0 +1,156 @@
+# Suspender Ledger
+
+> Firefox MV3 tab suspender — pause background tabs to reclaim RAM without
+> losing history. A TypeScript port of [auto-tab-discard](https://github.com/rNeomy/auto-tab-discard)
+> v3, rebuilt for the Manifest V3 background-script model.
+
+---
+
+## Overview
+
+Suspender Ledger watches your open tabs and, after a configurable idle
+period, _discards_ (suspends) the ones you are not using. A discarded tab
+keeps its place in the tab strip and its position in history, but releases
+the memory its page was holding. Activating the tab transparently reloads
+it.
+
+The extension never closes tabs. Suspension is always reversible: a
+suspended tab either restores in place via the browser's native discard
+mechanism, or — for tabs that were navigated to the bundled suspend page —
+restores by replaying the saved URL.
+
+---
+
+## Architecture
+
+The extension is split into four runtime surfaces, each built as a flat
+entry point by `vite.config.firefox.ts`:
+
+| Surface        | Entry                                   | Output       | Role                                                                            |
+| -------------- | --------------------------------------- | ------------ | ------------------------------------------------------------------------------- |
+| Service worker | `src/worker/worker.ts`                  | `worker.js`  | Background logic: discard scheduling, prefs, context menu, keyboard commands    |
+| Content script | `src/content/watch.ts`                  | `watch.js`   | Per-page activity detection (input/scroll/visibility) reported to the worker    |
+| Popup          | `popup.html` → `src/popup/index.ts`     | `popup.js`   | Toolbar UI: per-tab actions, whitelist toggle, settings form                    |
+| Suspend page   | `suspend.html` → `src/suspend/index.ts` | `suspend.js` | Lightweight stand-in page shown for navigated suspends; restores on click/Enter |
+
+Supporting modules:
+
+- `src/worker/core/` — `discard`, `navigate`, `prefs`, `startup`, `utils`
+  (the suspension engine and storage layer)
+- `src/worker/menu.ts`, `src/worker/modes/number.ts` — context menu and the
+  "keep N most-recent tabs loaded" mode
+- `src/lib/platform/firefox.ts` — the platform shim (aliased as
+  `@suspender/platform`) isolating browser-API differences
+- `src/lib/safe-url.ts` — URL validation shared by popup and suspend page
+- `src/types/messages.ts` — the typed, validated message protocol used at
+  every popup ↔ worker ↔ content boundary
+
+### MV3 build constraints
+
+Firefox MV3 background scripts cannot be code-split, so the worker is
+emitted as a single flat file (`manualChunks: () => {}` in the Vite
+config). The manifest uses `background.scripts: ["worker.js"]` (array
+form), and `web_accessible_resources` carry the required `matches` array.
+The HTML surfaces (popup, suspend) are ESM and may share chunks
+(`safe-url.js`); only the worker must be flat.
+
+### Key invariants
+
+- **Never close a tab.** There is no `tabs.remove()` anywhere in the
+  source — suspension is always reversible.
+- **No frame breakage.** The suspend page never breaks out of its frame or
+  redirects to itself.
+- **Storage resilience.** Missing or corrupted preferences fall back to
+  defaults rather than throwing.
+- **Message isolation.** All cross-surface messages are typed and
+  validated at the boundary (`src/types/messages.ts`).
+
+---
+
+## Development
+
+```bash
+# from the repo root (workspace deps must be built once)
+pnpm install
+
+# build the Firefox bundle into dist/
+pnpm -F @some-extension/suspender-ledger build:firefox
+
+# unit tests (Vitest)
+pnpm -F @some-extension/suspender-ledger test
+
+# full local gate: eslint, web-ext lint, MPL headers, typecheck
+pnpm -F @some-extension/suspender-ledger lint
+```
+
+Individual checks:
+
+| Command         | Checks                                         |
+| --------------- | ---------------------------------------------- |
+| `typecheck`     | `tsc --noEmit`                                 |
+| `test`          | Vitest unit suite                              |
+| `lint:js`       | ESLint                                         |
+| `check:headers` | MPL-2.0 headers present on ported files        |
+| `build:firefox` | Production Vite build → `dist/`                |
+| `lint:ext`      | `web-ext lint --source-dir dist --self-hosted` |
+
+To load the unsigned build for manual testing: Firefox →
+`about:debugging#/runtime/this-firefox` → **Load Temporary Add-on** →
+select `dist/manifest.json`. Temporary add-ons do not survive a restart —
+for persistence, sign and install the `.xpi` (below).
+
+---
+
+## Signing for Firefox (private unlisted)
+
+Firefox only persists an extension across restarts if it is signed. For a
+private, unlisted add-on, signing goes through AMO with
+`--channel=unlisted`: no public listing and no review queue — just a
+cryptographically signed `.xpi` returned within minutes.
+
+1. Get AMO API credentials:
+   https://addons.mozilla.org/en-US/developers/addon/api/key/
+2. Copy `.env.example` → `.env.local` and fill in `WEB_EXT_API_KEY` /
+   `WEB_EXT_API_SECRET`.
+3. Build: `pnpm -F @some-extension/suspender-ledger build:firefox`
+4. Sign: `pnpm -F @some-extension/suspender-ledger sign:firefox`
+   (writes the signed `.xpi` to `artifacts/`)
+5. Install: Firefox → `about:addons` → gear icon → **Install Add-on From
+   File** → select `artifacts/*.xpi`
+6. Verify: restart Firefox completely and confirm the extension is still
+   listed in `about:addons` with status **Enabled**, and that tab
+   suspension still works.
+
+> **Never commit `.env.local` or signed `.xpi` files.** Both are
+> gitignored. AMO API credentials must never enter the repository.
+>
+> The extension ID (`browser_specific_settings.gecko.id`) must stay stable
+> across signs — changing it makes AMO treat the upload as a brand-new
+> extension.
+
+`sign:firefox` is intentionally **not** wired into `turbo.json` or CI: it
+requires credentials and is a manual, local-only step.
+
+---
+
+## AMO submission checklist
+
+- [ ] `pnpm -F @some-extension/suspender-ledger build:firefox` exits 0
+- [ ] `pnpm -F @some-extension/suspender-ledger lint:ext` reports 0 errors
+      and 0 warnings
+- [ ] `dist/worker.js` is a single flat file with no `import`/`import()`
+- [ ] `dist/manifest.json` is Firefox MV3 (`background.scripts`, MV3
+      `web_accessible_resources`, stable `gecko.id`)
+- [ ] Typecheck, unit tests, ESLint, and MPL-header check all pass
+- [ ] `.env.local` populated with valid AMO credentials (local only)
+- [ ] `sign:firefox` produces a signed `.xpi` in `artifacts/`
+- [ ] Signed `.xpi` installs via `about:addons` and persists across a full
+      Firefox restart
+
+---
+
+## License
+
+Dual-licensed **MPL-2.0 AND MIT**. Files ported from auto-tab-discard v3
+carry MPL-2.0 headers; all original code is MIT. See [`NOTICE`](./NOTICE)
+and [`COPYING.MPL-2.0`](./COPYING.MPL-2.0) for the full breakdown.

--- a/extensions/suspender-ledger/package.json
+++ b/extensions/suspender-ledger/package.json
@@ -25,9 +25,9 @@
     "clean:build": "rimraf ./dist && rimraf tsconfig.tsbuildinfo",
     "check:headers": "node scripts/check-mpl-headers.js",
     "lint": "pnpm lint:js && pnpm lint:ext && pnpm check:headers && pnpm typecheck",
-    "lint:ext": "web-ext lint --source-dir dist",
+    "lint:ext": "web-ext lint --source-dir dist --self-hosted",
     "lint:js": "cross-env NODE_OPTIONS='--max_old_space_size=4096' eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
-    "sign:firefox": "web-ext sign --source-dir dist --channel=unlisted --api-key=$WEB_EXT_API_KEY --api-secret=$WEB_EXT_API_SECRET",
+    "sign:firefox": "web-ext sign --source-dir dist --artifacts-dir artifacts --channel=unlisted --api-key=$WEB_EXT_API_KEY --api-secret=$WEB_EXT_API_SECRET",
     "test": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/extensions/suspender-ledger/package.json
+++ b/extensions/suspender-ledger/package.json
@@ -3,6 +3,7 @@
     "url": "https://github.com/paulgsc/some-ui/issues"
   },
   "devDependencies": {
+    "@playwright/test": "1.60.0",
     "@some-ui/tsconfig": "workspace:*",
     "@types/chrome": "^0.0.293",
     "@types/firefox-webext-browser": "^120.0.4",
@@ -29,6 +30,9 @@
     "lint:js": "cross-env NODE_OPTIONS='--max_old_space_size=4096' eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
     "sign:firefox": "web-ext sign --source-dir dist --artifacts-dir artifacts --channel=unlisted --api-key=$WEB_EXT_API_KEY --api-secret=$WEB_EXT_API_SECRET",
     "test": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
     "typecheck": "tsc --noEmit"
   },
   "sideEffects": [

--- a/extensions/suspender-ledger/playwright.config.ts
+++ b/extensions/suspender-ledger/playwright.config.ts
@@ -1,0 +1,71 @@
+/**
+ * suspender-ledger — Playwright E2E configuration.
+ *
+ * Scope: the suspend page (`dist/suspend.html` + `suspend.js`) only.
+ *
+ * Why this is CI-portable (unlike the sibling extensions' E2E suites):
+ *   The suspend page is pure web — it reads `url`/`title`/`favicon` from the
+ *   page address and renders/restores entirely through DOM + `location`, with
+ *   zero `browser.*` API usage. So there is nothing to load into a browser as
+ *   an extension: we just serve the built `dist/` over HTTP and drive the page
+ *   in headless Chromium. No `--load-extension`, no signing, no nix shell.
+ *
+ * What this covers that vitest/jsdom cannot:
+ *   - real URLSearchParams parsing of query + hash on a real Location
+ *   - favicon `<link rel="icon">` injection into a real document <head>
+ *   - click / Enter → `location.replace(url)` actually navigating the tab
+ *   all against the PRODUCTION bundle, not the TS source.
+ *
+ * The popup/worker surfaces are intentionally NOT covered here — they depend
+ * on the `browser.*` API and are already exercised by the vitest component
+ * suite; an E2E mock would only duplicate that coverage.
+ */
+
+import { defineConfig, devices } from "@playwright/test"
+
+const PORT = 4318
+const BASE_URL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: "**/*.spec.ts",
+
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+  ],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        // Allow pointing at a system / pre-provisioned Chromium when the
+        // Playwright CDN is unreachable (e.g. locked-down CI). Falls back to
+        // the Playwright-managed browser when unset.
+        launchOptions: process.env.PW_CHROMIUM_PATH
+          ? { executablePath: process.env.PW_CHROMIUM_PATH }
+          : {},
+      },
+    },
+  ],
+
+  // Build the Firefox bundle, then serve dist/ as a static site so the
+  // page's absolute asset paths (`/suspend.js`, `/safe-url.js`) resolve.
+  webServer: {
+    command: `pnpm build:firefox && pnpm exec vite preview --config vite.config.firefox.ts --port ${PORT} --strictPort`,
+    url: `${BASE_URL}/suspend.html`,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/extensions/suspender-ledger/public/manifest.firefox.json
+++ b/extensions/suspender-ledger/public/manifest.firefox.json
@@ -60,7 +60,10 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "suspender-ledger@paulgsc.com",
-      "strict_min_version": "115.0"
+      "strict_min_version": "115.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
     }
   }
 }

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { discard, inprogress } from "./discard"
+import { prefs } from "./prefs"
 
 type DiscardCb = () => void
 
@@ -108,6 +109,36 @@ describe("discard", () => {
     await flush()
 
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
+  })
+
+  it("logs chrome.runtime.lastError when the browser rejects a discard", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined)
+    prefs.log = true
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    vi.mocked(chrome.tabs.discard).mockImplementation(((
+      _id: number,
+      cb: DiscardCb
+    ) => {
+      Object.assign(chrome.runtime, {
+        lastError: { message: "Tab cannot be discarded." },
+      })
+      cb()
+      Object.assign(chrome.runtime, { lastError: undefined })
+    }) as never)
+
+    await discard(tab({ id: 50 }))
+
+    expect(
+      consoleSpy.mock.calls.some((c) =>
+        c.some((a) => String(a).includes("Tab cannot be discarded."))
+      )
+    ).toBe(true)
+
+    consoleSpy.mockRestore()
+    prefs.log = false
   })
 
   it("never calls chrome.tabs.remove across any path", async () => {

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -44,7 +44,10 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
     }
     try {
       chrome.tabs.discard(tab.id, () => {
-        void chrome.runtime.lastError
+        const err = chrome.runtime.lastError
+        if (err) {
+          log("discard rejected by browser", err.message ?? err)
+        }
         resolve()
       })
     } catch (e) {

--- a/extensions/suspender-ledger/src/worker/core/startup.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/startup.test.ts
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+type GetCb = (items: Record<string, unknown>) => void
+type Listener = () => void
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(chrome.storage.local.get).mockImplementation(
+    (_keys: unknown, cb: GetCb) => cb({})
+  )
+})
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+describe("starters", () => {
+  it("becomes ready on module load without needing onStartup or onInstalled", async () => {
+    const { starters } = await import("./startup")
+
+    await flush()
+
+    expect(starters.ready).toBe(true)
+    expect(chrome.runtime.onStartup.addListener).toHaveBeenCalled()
+    expect(chrome.runtime.onInstalled.addListener).toHaveBeenCalled()
+  })
+
+  it("drains cached callbacks that were pushed before ready", async () => {
+    // Delay storage so we can push a callback before ready fires.
+    let resolve!: () => void
+    vi.mocked(chrome.storage.local.get).mockImplementation(
+      (_keys: unknown, cb: GetCb): void => {
+        resolve = (): void => {
+          cb({})
+        }
+      }
+    )
+
+    const { starters } = await import("./startup")
+    const cb = vi.fn()
+    starters.push(cb)
+
+    expect(starters.ready).toBe(false)
+    expect(cb).not.toHaveBeenCalled()
+
+    resolve()
+    await flush()
+
+    expect(starters.ready).toBe(true)
+    expect(cb).toHaveBeenCalledOnce()
+  })
+
+  it("runs a callback pushed after ready immediately", async () => {
+    const { starters } = await import("./startup")
+    await flush()
+
+    const cb = vi.fn()
+    starters.push(cb)
+
+    expect(cb).toHaveBeenCalledOnce()
+  })
+
+  it("does not double-fire callbacks when onStartup fires after module load", async () => {
+    const onStartupListeners: Array<Listener> = []
+    vi.mocked(chrome.runtime.onStartup.addListener).mockImplementation(
+      (fn: Listener) => {
+        onStartupListeners.push(fn)
+      }
+    )
+
+    const { starters } = await import("./startup")
+    await flush() // module-level once() resolves → ready = true
+
+    const cb = vi.fn()
+    starters.push(cb) // pushed after ready: fires immediately once
+    expect(cb).toHaveBeenCalledOnce()
+
+    // Simulate onStartup firing (e.g. browser restart while extension is loaded)
+    onStartupListeners.forEach((fn) => fn())
+    await flush()
+
+    // once() is idempotent — cb is not called a second time
+    expect(cb).toHaveBeenCalledOnce()
+  })
+})

--- a/extensions/suspender-ledger/src/worker/core/startup.ts
+++ b/extensions/suspender-ledger/src/worker/core/startup.ts
@@ -32,13 +32,20 @@ const starters: Starters = {
 
 {
   // preferences are only hydrated once here; everywhere else, call storage().then()
-  const once = (): Promise<void> =>
-    storage(prefs).then((ps) => {
+  const once = (): Promise<void> => {
+    if (starters.ready) return Promise.resolve()
+    return storage(prefs).then((ps) => {
       Object.assign(prefs, ps)
       starters.ready = true
       starters.cache.forEach((c) => c())
       starters.cache.length = 0
     })
+  }
+
+  // MV3 SW respawn: neither onStartup nor onInstalled fires when the worker is
+  // respawned by an event — call once() at module evaluation so the gate opens
+  // regardless of how the worker started.
+  void once()
 
   chrome.runtime.onStartup.addListener(() => {
     void once()

--- a/extensions/suspender-ledger/tests/e2e/specs/suspend-page.spec.ts
+++ b/extensions/suspender-ledger/tests/e2e/specs/suspend-page.spec.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 paulgsc — MIT License
+//
+// suspend-page.spec.ts — E2E smoke for the suspend page against the built
+// bundle (dist/suspend.html + suspend.js), served over HTTP and driven in
+// headless Chromium. See playwright.config.ts for why this is CI-portable.
+//
+// These assertions cover the seams jsdom can't: real Location parsing, real
+// <head> favicon injection, and real navigation via location.replace().
+
+import { expect, test } from "@playwright/test"
+
+/** Build a suspend-page URL with the given params. */
+function suspendUrl(params: Record<string, string>): string {
+  const qs = new URLSearchParams(params).toString()
+  return `/suspend.html?${qs}`
+}
+
+test.describe("suspend page", () => {
+  test("renders a restorable card from query params", async ({ page }) => {
+    const target = "https://example.com/article"
+    const favicon = "https://example.com/favicon.ico"
+    await page.goto(suspendUrl({ url: target, title: "My Tab", favicon }))
+
+    const card = page.locator("main.suspend-card")
+    await expect(card).toBeVisible()
+    await expect(card).toHaveAttribute("data-recovery", "false")
+    await expect(page.locator(".suspend-card__title")).toHaveText("My Tab")
+    await expect(page.locator(".suspend-card__url")).toHaveText(target)
+    await expect(page.locator(".suspend-card__restore")).toBeVisible()
+
+    // Tab chrome is reflected onto the real document.
+    await expect(page).toHaveTitle("My Tab")
+    await expect(page.locator('link[rel="icon"]')).toHaveAttribute(
+      "href",
+      favicon
+    )
+  })
+
+  test("falls back to the host name when no title is given", async ({
+    page,
+  }) => {
+    await page.goto(suspendUrl({ url: "https://news.example.org/path" }))
+    await expect(page.locator(".suspend-card__title")).toHaveText(
+      "news.example.org"
+    )
+  })
+
+  test("enters recovery state when the url is missing", async ({ page }) => {
+    await page.goto(suspendUrl({ title: "Orphaned tab" }))
+
+    const card = page.locator("main.suspend-card")
+    await expect(card).toHaveAttribute("data-recovery", "true")
+    await expect(page.locator(".suspend-card__title")).toHaveText(
+      "Nothing to restore"
+    )
+    await expect(page.locator(".suspend-card__note")).toBeVisible()
+    // A recovery card has no restore affordance.
+    await expect(page.locator(".suspend-card__restore")).toHaveCount(0)
+  })
+
+  test("rejects an unsafe favicon scheme", async ({ page }) => {
+    await page.goto(
+      suspendUrl({
+        url: "https://example.com/",
+        favicon: "javascript:alert(1)",
+      })
+    )
+    // The guard keeps the payload out of both the <head> and the card <img>.
+    await expect(page.locator('link[rel="icon"]')).toHaveCount(0)
+    await expect(page.locator(".suspend-card__favicon")).toHaveCount(0)
+  })
+
+  test("restores by navigating to the original url on click", async ({
+    page,
+    baseURL,
+  }) => {
+    // Restore to a real, served page so the navigation actually lands.
+    const target = new URL("/popup.html", baseURL).href
+    await page.goto(suspendUrl({ url: target, title: "Restore me" }))
+
+    await page.locator(".suspend-card__restore").click()
+    await page.waitForURL("**/popup.html")
+    expect(page.url()).toBe(target)
+  })
+
+  test("restores on Enter as well as click", async ({ page, baseURL }) => {
+    const target = new URL("/popup.html", baseURL).href
+    await page.goto(suspendUrl({ url: target, title: "Keyboard restore" }))
+
+    await page.keyboard.press("Enter")
+    await page.waitForURL("**/popup.html")
+    expect(page.url()).toBe(target)
+  })
+})

--- a/extensions/suspender-ledger/tsconfig.json
+++ b/extensions/suspender-ledger/tsconfig.json
@@ -26,6 +26,8 @@
   },
   "include": [
     "src",
+    "tests",
+    "playwright.config.ts",
     "vite.config.ts",
     "vite.config.firefox.ts",
     "vitest.setup.ts",

--- a/extensions/suspender-ledger/vitest.config.ts
+++ b/extensions/suspender-ledger/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
-    exclude: ["**/node_modules/**"],
+    // tests/** holds Playwright E2E specs (*.spec.ts); keep vitest scoped to
+    // the unit suite under src/ so it does not try to run them.
+    exclude: ["**/node_modules/**", "**/tests/**"],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,6 +650,9 @@ importers:
 
   extensions/suspender-ledger:
     devDependencies:
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@some-ui/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig


### PR DESCRIPTION
## Summary

Closes #259 and Closes #260 — finalizes the build and signing pipeline for Beta v0.1.0.
Closes #299 and Closes #302 — fixes two runtime no-ops discovered in field testing.

**#259 (build gate):**
- Added `data_collection_permissions: { required: ["none"] }` to manifest → cleared last web-ext lint NOTICE
- `web-ext lint` now reports **0 errors, 0 warnings, 0 notices**
- Added `--self-hosted` to `lint:ext` for unlisted distribution

**#260 (sign workflow):**
- `sign:firefox` now writes to `artifacts/` via `--artifacts-dir`
- New workspace `.env.example` documenting AMO API credentials
- Gitignored `artifacts/`, `*.xpi`, `.env.local` at root and workspace
- Added credential safety note to NOTICE
- New README with architecture, dev/build/test commands, AMO unlisted sign workflow, and submission checklist

**#299 (lastError swallowed in discard):**
- `discard.ts perform()`: read `chrome.runtime.lastError` into a variable and log it when set, so Firefox rejections (audible/active tab) are visible in extension DevTools instead of being silently swallowed

**#302 (startup gate misses SW respawn):**
- `startup.ts once()`: added idempotent guard (`if starters.ready return`) and call `once()` at module evaluation time, so MV3 service-worker respawns — which fire neither `onStartup` nor `onInstalled` — still open the gate and drain queued callbacks

## Test plan

- [x] `pnpm -F @some-extension/suspender-ledger build:firefox` → 0 exit, single-file worker
- [x] `pnpm -F @some-extension/suspender-ledger lint:ext` → 0 errors, 0 warnings, 0 notices
- [x] `pnpm -F @some-extension/suspender-ledger test` → **53 tests pass** (+5: lastError logging, startup module-load gate, pre-ready drain, post-ready immediate fire, idempotency on onStartup)
- [x] `pnpm -F @some-extension/suspender-ledger typecheck` → clean
- [x] `pnpm -F @some-extension/suspender-ledger lint:js` → clean
- [x] `pnpm -F @some-extension/suspender-ledger check:headers` → 13 files verified
- [x] All gates pass independently and via `pnpm lint`

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3ZiiqBy6rDsmmo8gjmjab)_