### PR TITLE
Wire prepends title marker and suspend.html into discard flow

### DIFF
--- a/extensions/suspender-ledger/docs/design-notes.md
+++ b/extensions/suspender-ledger/docs/design-notes.md
@@ -1,0 +1,186 @@
+# Suspender Ledger — Design Notes
+
+> **Beta.** The core auto-suspension path (time-based → `suspend.html`) is
+> functional. The gaps and footguns below are things to be aware of before
+> signing for public AMO listing. See the paired acceptance-checklist issue
+> for the gate criteria.
+
+---
+
+## Inherited decisions from auto-tab-discard
+
+These exist because the upstream (auto-tab-discard v3) did them, not because
+they were designed fresh for this project. Know them before debugging
+surprising behaviour.
+
+### `number` threshold is a floor, not a budget
+
+`prefs.number` (default **6**) is the minimum number of _eligible_ background
+tabs that must be open before auto-discard fires at all. Nothing is suspended
+unless at least `N + 1` eligible tabs exist. With the default, you need 7+
+background tabs. This surprises users expecting it to mean "keep at most N
+tabs loaded."
+
+### `icon-update` inverts evaluation order
+
+When `prefs["icon-update"]` is `false` (default), the tab-count check happens
+_before_ metadata is collected — tabs are rejected early and
+`executeScript` is never called for any tab. When `true`, metadata is
+collected for _all_ tabs first (to populate per-tab toolbar icons), then the
+count check re-runs. The inversion is intentional (icon accuracy vs. CPU cost)
+but counter-intuitive when reading `number.check` top-to-bottom.
+
+### Battery gate is a no-op
+
+`prefs.battery` appears in the settings UI and is stored, but the Battery
+Status API is deprecated and absent from Firefox. The guard was not ported. The
+preference persists harmlessly; if you ever restore it, `navigator.getBattery()`
+is async — it cannot be read inline.
+
+### `tmp_disable` stores hours, not seconds
+
+`prefs.tmp_disable` is a number of _hours_. The alarm is set to
+`value × 60 × 60 × 1000` ms. Do not confuse it with `period`, which is in
+_seconds_.
+
+### `url-based` mode is lightly tested
+
+The extension supports `time-based` (default) and `url-based` (only suspend
+tabs matching the whitelist). The `url-based` branch through `number.check` was
+ported but is not part of the primary user story or acceptance testing.
+
+### `whitelist.session` is not persisted across browser restarts
+
+Session-storage whitelisted domains vanish when the browser closes. There is no
+sync from `whitelist.session` → `whitelist` on session end. Users must
+re-add them manually, or use the permanent whitelist instead.
+
+---
+
+## Browser API footguns
+
+### Service worker can be killed at any time
+
+Firefox MV3 service workers are event-driven and may be terminated after
+~30 s of inactivity. In-memory state reset on restart:
+
+| State                | Consequence if worker restarts mid-operation       |
+| -------------------- | -------------------------------------------------- |
+| `inprogress` Set     | 2 s dedup window lost → duplicate suspend possible |
+| `discard.count`      | Concurrency counter reset → may over-schedule      |
+| `discard.tabs` queue | Queued-but-unstarted suspensions silently lost     |
+
+The `chrome.alarms` wake-up mechanism survives worker termination — periodic
+checks keep working. But anything held only in module-scope memory is
+ephemeral.
+
+### `executeScript` with `func:` must be fully self-contained
+
+`collectMeta()` is serialised by Firefox via `Function.prototype.toString()`
+and re-parsed in the content script context. Rules:
+
+- **No closure captures.** Any non-global referenced inside the function body
+  must be a browser built-in (`document`, `window`, `Notification`, `Array`,
+  etc.). Module-scope imports are not available at call time.
+- **No value-level module references.** TypeScript types are erased (fine);
+  actual imported values are not serialised and will be `undefined` at runtime.
+- **Self-contained helpers.** If you split the collector into helpers, either
+  inline them into the function body or inject them as separate `func:` calls
+  first.
+
+Violations fail silently — `executeScript` resolves with `undefined` results
+rather than rejecting. The tab is skipped as "not ready."
+
+### `allFrames: true` and the frame-0 time fix
+
+`executeScript({ allFrames: true })` returns one result per frame. Child
+iframes lack the `watch.ts` injection, so they return `time: Date.now()`. The
+naive `Object.assign({}, ...ms)` merge (last-write-wins) would overwrite the
+main frame's meaningful `lastVisit` with the iframe's fresh timestamp, making
+every multi-frame tab look "too young." The explicit `results.find(r => r.frameId === 0)`
+restore in `number.ts` fixes this. **Do not remove it.**
+
+### `tab.lastAccessed` is focus time, not idle time
+
+`tab.lastAccessed` (Firefox/Chrome) records when the user last _activated_ the
+tab. It has no minimum dwell threshold — a 200 ms cmd+tab resets it. For tabs
+with `watch.ts` injected, `window.lastVisit` (set on `visibilitychange`) is
+used instead and better reflects attention. `lastAccessed` is the fallback for
+pre-existing tabs that missed content-script injection.
+
+### `tabs.query({ audible: false })` is coarser than it looks
+
+This removes tabs the browser reports as _currently producing audio_. A tab
+with a paused video, a muted video, or a video that just finished is **not**
+audible and passes the query filter. The separate `prefs.paused` guard (via
+`collectMeta`'s media scan) catches paused players. A tab playing silent
+autoplay video slips past both.
+
+### Chrome alarm granularity
+
+Firefox enforces a minimum alarm period of 1 minute. `number.install(period)`
+sets the interval to `period / 3`, clamped to 1–20 min. For the default
+10-minute period, checks fire roughly every 3–4 minutes. Alarm timing is
+advisory — the browser may delay delivery under load or after machine sleep.
+The `idle.onStateChanged` listener reschedules stale alarms on wake.
+
+### `watch.ts` and `collectMeta` must share the same world
+
+`watch.ts` sets `window.lastVisit` and `window.isReceivingFormInput` in the
+extension's _isolated_ world. `collectMeta` is injected into the same isolated
+world (default `world: "ISOLATED"`). Changing either to `world: "MAIN"` breaks
+the link — the properties become invisible across the world boundary and the
+collector falls back to `undefined`/`Date.now()`.
+
+### `isSuspendTab` and the ephemeral dev extension ID
+
+`isSuspendTab(tab)` checks whether `tab.url` starts with
+`chrome.runtime.getURL("suspend.html")`. In production this URL is stable
+(Firefox derives the extension ID from `gecko.id`). In development (temporary
+add-on), the ID is randomised on each reload, so `isSuspendTab` may miss
+suspend pages from a previous load session. Stale suspend tabs accumulate in
+the strip during dev. This is cosmetic and harmless in production.
+
+### `location.replace()` is required for some-filter interop
+
+The suspend-page restore calls `location.replace(params.url)`. This is a full
+top-level navigation, which fires `document_start` in content scripts and lets
+`some-filter` apply its prepaint veil before the page paints. `history.pushState()`
+or in-place DOM swaps bypass `document_start` entirely — do not use them as
+an alternative restore mechanism.
+
+### Suspend URL embeds the `prepends` marker at suspend time
+
+The `💤` prefix is baked into the `title` query parameter of the suspend URL
+(`?title=%F0%9F%92%A4+My+Tab`). Changing `prefs.prepends` after tabs are
+already suspended does not update their displayed titles — the marker only
+refreshes when a tab is next suspended.
+
+### "No tab to switch to" is not an audio/video bug
+
+When the user suspends the active tab via the popup and there are no other
+non-suspended, non-highlighted tabs in the window, `onClicked` shows a
+notification and does nothing. This is intentional — the browser cannot be
+left with no focused tab. It appears as a silent failure when the user has only
+one non-suspended tab open. It is **not** related to audio or video guards; the
+`discard-tab` path never checks audibility.
+
+### `web_accessible_resources` exposes `suspend.html`
+
+`suspend.html` is declared in `web_accessible_resources` with
+`matches: ["*://*/*"]`, so any web page can iframe it. The suspend page
+validates its `url` parameter through `isRestorableUrl()` (http/https only)
+before calling `location.replace`. Do not weaken that validation — it is the
+only defence against open-redirect misuse.
+
+---
+
+## Known gaps
+
+| Area                      | Gap                                                                                                                                                                                                            | Severity                                                                   |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Worker queue durability   | `discard.tabs` concurrency queue is in-memory; lost on worker restart. No storage-backed queue.                                                                                                                | Low — only affects bulk-suspend scenarios where the worker dies mid-flight |
+| Battery guard             | `prefs.battery` stored but not checked; API deprecated in Firefox.                                                                                                                                             | Cosmetic — preference appears in UI but has no effect                      |
+| Memory pressure reporting | `prefs["memory-enabled"]` path reads `window.performance.memory` via `collectMeta`, but that is a Chrome-only non-standard API. Firefox returns `undefined`. Memory-based forced discard silently never fires. | Low for Firefox-only beta                                                  |
+| `open-tab-then-discard`   | Uses `browser.tabs.create({ discarded: true })`, Firefox-only. No Chrome fallback.                                                                                                                             | N/A for Firefox-only beta                                                  |
+| `url-based` mode coverage | Second discard mode present but not acceptance-tested.                                                                                                                                                         | Deferred                                                                   |

--- a/extensions/suspender-ledger/public/manifest.firefox.json
+++ b/extensions/suspender-ledger/public/manifest.firefox.json
@@ -53,7 +53,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["suspend.html", "data/inject/meta.js"],
+      "resources": ["suspend.html"],
       "matches": ["*://*/*"]
     }
   ],

--- a/extensions/suspender-ledger/public/manifest.firefox.json
+++ b/extensions/suspender-ledger/public/manifest.firefox.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Suspender Ledger",
+  "name": "Suspender Ledger (Beta)",
   "version": "0.1.0",
-  "description": "Tab suspender — pause tabs to reclaim RAM without losing history.",
+  "description": "Beta — Tab suspender: pause background tabs to reclaim RAM without losing history. Navigate to suspend.html for a themed placeholder; restore on explicit click.",
   "permissions": [
     "idle",
     "storage",

--- a/extensions/suspender-ledger/src/content/meta.ts
+++ b/extensions/suspender-ledger/src/content/meta.ts
@@ -21,7 +21,9 @@
 /** Metadata the worker reads from a tab before deciding to suspend it. */
 export type CollectedMeta = {
   ready: boolean
-  time: number
+  /** Undefined when watch.ts was not injected (pre-existing tab). The worker
+   *  falls back to tab.lastAccessed in that case. */
+  time: number | undefined
   forms: boolean
   audible: boolean
   paused: boolean
@@ -35,7 +37,10 @@ export function collectMeta(): CollectedMeta {
   )
   return {
     ready: true,
-    time: typeof window.lastVisit === "number" ? window.lastVisit : Date.now(),
+    // undefined when watch.ts has not yet injected window.lastVisit (e.g. tabs
+    // that were open before the extension was installed).  The worker falls back
+    // to tab.lastAccessed so these tabs are not permanently stuck as "too young".
+    time: typeof window.lastVisit === "number" ? window.lastVisit : undefined,
     forms: window.isReceivingFormInput === true,
     audible: media.some((m) => !m.paused && !m.muted && m.volume > 0),
     paused: media.some((m) => m.paused),

--- a/extensions/suspender-ledger/src/content/meta.ts
+++ b/extensions/suspender-ledger/src/content/meta.ts
@@ -5,25 +5,40 @@
 // Ported from auto-tab-discard v3/data/inject/meta.js (MPL-2.0)
 // Copyright (C) auto-tab-discard contributors
 //
-// Classic-script meta collector: injected into each frame by the worker via
-// executeScript({ files: ["/data/inject/meta.js"] }).
-// The return value of the last expression is captured by the worker as TabMeta.
-// No imports/exports — this file is a global script, not an ES module.
-// window.lastVisit and window.isReceivingFormInput are declared globally in
-// watch.ts and available here via the shared tsconfig.
+// Per-frame metadata collector. The worker injects this via
+// `chrome.scripting.executeScript({ func: collectMeta, ... })` rather than as a
+// bundled file: a bundler (Rollup) tree-shakes the side-effect-free payload of a
+// classic completion-value script, which silently broke metadata collection and
+// disabled auto-discard. Passing the function directly is serialized verbatim
+// (`Function.prototype.toString`) and is immune to that.
+//
+// IMPORTANT: this function is serialized and executed in the page's content
+// sandbox. It must be fully self-contained — only page/runtime globals
+// (`document`, `window`, `Notification`, `Array`), no module-scope references.
+// `window.lastVisit` / `window.isReceivingFormInput` are set by watch.ts in the
+// same isolated world and declared globally there.
 
-const _media = Array.from(
-  document.querySelectorAll<HTMLMediaElement>("audio, video")
-)
+/** Metadata the worker reads from a tab before deciding to suspend it. */
+export type CollectedMeta = {
+  ready: boolean
+  time: number
+  forms: boolean
+  audible: boolean
+  paused: boolean
+  permission: boolean
+}
 
-// The object literal is the last expression; executeScript captures its value
-// as InjectionResult.result for this frame.
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-;({
-  ready: true,
-  time: typeof window.lastVisit === "number" ? window.lastVisit : Date.now(),
-  forms: window.isReceivingFormInput === true,
-  audible: _media.some((m) => !m.paused && !m.muted && m.volume > 0),
-  paused: _media.some((m) => m.paused),
-  permission: Notification.permission === "granted",
-})
+/** Collect suspend-relevant metadata for the frame it runs in. */
+export function collectMeta(): CollectedMeta {
+  const media = Array.from(
+    document.querySelectorAll<HTMLMediaElement>("audio, video")
+  )
+  return {
+    ready: true,
+    time: typeof window.lastVisit === "number" ? window.lastVisit : Date.now(),
+    forms: window.isReceivingFormInput === true,
+    audible: media.some((m) => !m.paused && !m.muted && m.volume > 0),
+    paused: media.some((m) => m.paused),
+    permission: Notification.permission === "granted",
+  }
+}

--- a/extensions/suspender-ledger/src/suspend/components/suspend-card/index.ts
+++ b/extensions/suspender-ledger/src/suspend/components/suspend-card/index.ts
@@ -5,7 +5,6 @@
 
 import { isSafeFaviconUrl } from "@suspender/lib/safe-url"
 
-
 /** Presentational model for the suspended-tab card. */
 export type SuspendCardProps = {
   /** Original page title (falls back to the host, then a placeholder). */
@@ -94,7 +93,7 @@ export function SuspendCard({
 
   const hint = document.createElement("p")
   hint.className = "suspend-card__hint"
-  hint.textContent = "Click anywhere or press Enter to restore"
+  hint.textContent = "Press Enter or Space to restore"
 
   card.append(button, hint)
   return card

--- a/extensions/suspender-ledger/src/suspend/index.ts
+++ b/extensions/suspender-ledger/src/suspend/index.ts
@@ -94,8 +94,7 @@ function main(): void {
 
   if (recovery) return
 
-  // The whole page is a restore target — click or keyboard.
-  document.body.addEventListener("click", restore)
+  // Keyboard shortcut mirrors the explicit button for power users.
   document.addEventListener("keydown", (e) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault()

--- a/extensions/suspender-ledger/src/suspend/suspend.css
+++ b/extensions/suspender-ledger/src/suspend/suspend.css
@@ -3,20 +3,30 @@
  *
  * Suspend page styling. The critical background/colour is already inlined in
  * suspend.html so the first paint is dark (anti-flash-bang); this sheet layers
- * the card presentation on top once it loads. All colours flow through the
- * --sl-* custom properties some-filter injects, with safe dark fallbacks so an
- * absent filter never produces a white frame.
+ * the card presentation on top once it loads.
+ *
+ * some-filter cannot reach this moz-extension:// page (its content scripts only
+ * match http/https), so the suspend page can never be dark-themed by the filter
+ * at runtime — it must carry the filter's look itself. The --sl-* tokens below
+ * are therefore pinned to some-filter's canonical dark palette (the --sw-*
+ * tokens in theme-apply.ts): --sw-bg-0 #0d1117 canvas, --sw-surface #1e222b
+ * card, --sw-text-* foregrounds, --sw-link accent. A suspended tab then looks
+ * byte-identical to a filtered page.
+ *
+ * There is intentionally NO `prefers-color-scheme: light` branch: the surface
+ * is unconditionally dark so an OS in light mode can never produce the white
+ * flash-bang this owned page exists to eliminate.
  */
 
 :root {
-  --sl-bg: #1a1a1a;
-  --sl-bg-card: #232326;
-  --sl-fg: #e0e0e0;
-  --sl-fg-dim: #9a9aa2;
-  --sl-fg-faint: #6a6a72;
-  --sl-border: rgb(255 255 255 / 8%);
-  --sl-accent: #6aa6ff;
-  --sl-accent-dim: rgb(106 166 255 / 16%);
+  --sl-bg: #0d1117; /* --sw-bg-0 */
+  --sl-bg-card: #1e222b; /* --sw-surface */
+  --sl-fg: #e2e8f0; /* --sw-text-0 */
+  --sl-fg-dim: #94a3b8; /* --sw-text-1 */
+  --sl-fg-faint: #475569; /* --sw-text-2 */
+  --sl-border: rgb(255 255 255 / 8%); /* --sw-border */
+  --sl-accent: #7aa2f7; /* --sw-link */
+  --sl-accent-dim: rgb(122 162 247 / 16%); /* --sw-link @ 16% */
 }
 
 *,
@@ -125,15 +135,4 @@ body {
 .suspend-card__hint {
   color: var(--sl-fg-faint);
   font-size: 12px;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --sl-bg: #f3f3f5;
-    --sl-bg-card: #fff;
-    --sl-fg: #1c1c1f;
-    --sl-fg-dim: #55555c;
-    --sl-fg-faint: #8a8a90;
-    --sl-border: rgb(0 0 0 / 10%);
-  }
 }

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -7,6 +7,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "./discard"
 import { prefs } from "./prefs"
 
+type UpdateCb = (tab?: chrome.tabs.Tab) => void
+
 const flush = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -36,60 +38,37 @@ beforeEach(() => {
   vi.mocked(chrome.storage.local.get).mockImplementation(
     (_keys: unknown, cb: (items: Record<string, unknown>) => void) => cb({})
   )
-  // scripting.executeScript for title injection resolves immediately
-  vi.mocked(chrome.scripting.executeScript).mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    () => Promise.resolve([])
-  )
-  // tabs.discard succeeds by default (native discard happy path)
-  vi.mocked(chrome.tabs.discard).mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    () => Promise.resolve()
+  // tabs.update resolves its callback immediately by default.
+
+  vi.mocked(chrome.tabs.update).mockImplementation(
+    (_id: number, _props: chrome.tabs.UpdateProperties, cb: UpdateCb) =>
+      cb(undefined)
   )
 })
 
 describe("discard", () => {
-  it("suspends an eligible tab via native discard", async () => {
+  it("suspends an eligible tab by navigating to the suspend page", async () => {
     await discard(tab({ id: 1, url: "https://example.com/", title: "Example" }))
-
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(1)
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
-    expect(chrome.tabs.remove).not.toHaveBeenCalled()
-  })
-
-  it("injects the prepends marker into the tab title before discarding", async () => {
-    prefs.prepends = "💤"
-    await discard(tab({ id: 1, url: "https://example.com/", title: "My Tab" }))
-
-    expect(chrome.scripting.executeScript).toHaveBeenCalledWith(
-      expect.objectContaining({ target: { tabId: 1 } })
-    )
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(1)
-  })
-
-  it("falls back to the suspend page when native discard is rejected", async () => {
-    vi.mocked(chrome.tabs.discard).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      () => Promise.reject(new Error("Cannot discard tab."))
-    )
-
-    await discard(
-      tab({ id: 1, url: "https://example.com/article", title: "A" })
-    )
 
     expect(chrome.tabs.update).toHaveBeenCalledWith(
       1,
-      expect.objectContaining({ url: expect.stringContaining("suspend.html") })
+      expect.objectContaining({ url: expect.stringContaining("suspend.html") }),
+      expect.any(Function)
     )
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
-  it("includes the original URL in the fallback suspend page URL", async () => {
-    vi.mocked(chrome.tabs.discard).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      () => Promise.reject(new Error("fail"))
-    )
+  it("includes the prepends marker in the suspend URL title", async () => {
+    prefs.prepends = "💤"
+    await discard(tab({ id: 1, url: "https://example.com/", title: "My Tab" }))
 
+    const call = vi.mocked(chrome.tabs.update).mock.calls[0]
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
+    expect(url.searchParams.get("title")).toBe("💤 My Tab")
+  })
+
+  it("includes the original URL in the suspend URL params", async () => {
     await discard(
       tab({ id: 1, url: "https://example.com/article", title: "A" })
     )
@@ -100,16 +79,28 @@ describe("discard", () => {
     expect(url.searchParams.get("url")).toBe("https://example.com/article")
   })
 
+  it("includes the favicon in the suspend URL params when present", async () => {
+    const favicon = "https://example.com/favicon.ico"
+    await discard(
+      tab({ id: 1, url: "https://example.com/", favIconUrl: favicon })
+    )
+
+    const call = vi.mocked(chrome.tabs.update).mock.calls[0]
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
+    expect(url.searchParams.get("favicon")).toBe(favicon)
+  })
+
   it("skips an active tab", async () => {
     await discard(tab({ id: 2, active: true }))
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("skips an already-discarded tab (idempotency)", async () => {
     await discard(tab({ id: 3, discarded: true }))
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("skips a tab already showing the suspend page", async () => {
@@ -117,21 +108,15 @@ describe("discard", () => {
       "moz-extension://testid/suspend.html?url=https%3A%2F%2Fexample.com%2F"
     await discard(tab({ id: 4, url: suspendUrl }))
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("ignores a duplicate request while a suspend is in progress", async () => {
-    // Make discard hang so the second call arrives while the first is in-flight
-    vi.mocked(chrome.tabs.discard).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      () => new Promise(() => {})
-    )
-
     discard(tab({ id: 4, url: "https://example.com/" }))
     discard(tab({ id: 4, url: "https://example.com/" }))
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledTimes(1)
+    expect(chrome.tabs.update).toHaveBeenCalledTimes(1)
   })
 
   it("queues beyond the concurrency limit and drains the queue", async () => {
@@ -140,13 +125,12 @@ describe("discard", () => {
       (_keys: unknown, cb: (items: Record<string, unknown>) => void) =>
         cb({ "simultaneous-jobs": 0 })
     )
-    const resolvers: Array<() => void> = []
-    vi.mocked(chrome.tabs.discard).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      () =>
-        new Promise<void>((resolve) => {
-          resolvers.push(resolve)
-        })
+    const cbs: Array<UpdateCb> = []
+
+    vi.mocked(chrome.tabs.update).mockImplementation(
+      (_id: number, _props: chrome.tabs.UpdateProperties, cb: UpdateCb) => {
+        cbs.push(cb)
+      }
     )
 
     discard(tab({ id: 10, url: "https://a.example.com/" }))
@@ -154,20 +138,48 @@ describe("discard", () => {
     await flush()
 
     // first is in-flight, second is parked in the queue
-    expect(chrome.tabs.discard).toHaveBeenCalledTimes(1)
+    expect(chrome.tabs.update).toHaveBeenCalledTimes(1)
     expect(discard.tabs.length).toBe(1)
 
-    resolvers[0]?.() // complete the first discard
+    cbs[0]?.() // complete the first suspend
     await flush()
 
-    // queue drained: second tab now discarded
-    expect(chrome.tabs.discard).toHaveBeenCalledTimes(2)
+    // queue drained: second tab now suspended
+    expect(chrome.tabs.update).toHaveBeenCalledTimes(2)
     expect(discard.tabs.length).toBe(0)
 
-    resolvers[1]?.()
+    cbs[1]?.()
     await flush()
 
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
+  })
+
+  it("logs chrome.runtime.lastError when the browser rejects navigation", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined)
+    prefs.log = true
+
+    vi.mocked(chrome.tabs.update).mockImplementation(
+      (_id: number, _props: chrome.tabs.UpdateProperties, cb: UpdateCb) => {
+        Object.assign(chrome.runtime, {
+          lastError: { message: "Cannot update tab." },
+        })
+        cb(undefined)
+        Object.assign(chrome.runtime, { lastError: undefined })
+      }
+    )
+
+    await discard(tab({ id: 50, url: "https://example.com/" }))
+
+    expect(
+      consoleSpy.mock.calls.some((c) =>
+        c.some((a) => String(a).includes("Cannot update tab."))
+      )
+    ).toBe(true)
+
+    consoleSpy.mockRestore()
+    prefs.log = false
   })
 
   it("never calls chrome.tabs.remove across any path", async () => {

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -7,8 +7,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "./discard"
 import { prefs } from "./prefs"
 
-type UpdateCb = (tab?: chrome.tabs.Tab) => void
-
 const flush = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -38,38 +36,60 @@ beforeEach(() => {
   vi.mocked(chrome.storage.local.get).mockImplementation(
     (_keys: unknown, cb: (items: Record<string, unknown>) => void) => cb({})
   )
-  // tabs.update resolves its callback immediately by default.
-   
-  vi.mocked(chrome.tabs.update).mockImplementation(((
-    _id: number,
-    _props: chrome.tabs.UpdateProperties,
-    cb: UpdateCb
-  ) => cb(undefined)))
+  // scripting.executeScript for title injection resolves immediately
+  vi.mocked(chrome.scripting.executeScript).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    () => Promise.resolve([])
+  )
+  // tabs.discard succeeds by default (native discard happy path)
+  vi.mocked(chrome.tabs.discard).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    () => Promise.resolve()
+  )
 })
 
 describe("discard", () => {
-  it("suspends an eligible tab by navigating to the suspend page", async () => {
+  it("suspends an eligible tab via native discard", async () => {
     await discard(tab({ id: 1, url: "https://example.com/", title: "Example" }))
+
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(1)
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.remove).not.toHaveBeenCalled()
+  })
+
+  it("injects the prepends marker into the tab title before discarding", async () => {
+    prefs.prepends = "💤"
+    await discard(tab({ id: 1, url: "https://example.com/", title: "My Tab" }))
+
+    expect(chrome.scripting.executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { tabId: 1 } })
+    )
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(1)
+  })
+
+  it("falls back to the suspend page when native discard is rejected", async () => {
+    vi.mocked(chrome.tabs.discard).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      () => Promise.reject(new Error("Cannot discard tab."))
+    )
+
+    await discard(
+      tab({ id: 1, url: "https://example.com/article", title: "A" })
+    )
 
     expect(chrome.tabs.update).toHaveBeenCalledWith(
       1,
-      expect.objectContaining({ url: expect.stringContaining("suspend.html") }),
-      expect.any(Function)
+      expect.objectContaining({ url: expect.stringContaining("suspend.html") })
     )
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
-  it("includes the prepends marker in the suspend URL title", async () => {
-    prefs.prepends = "💤"
-    await discard(tab({ id: 1, url: "https://example.com/", title: "My Tab" }))
+  it("includes the original URL in the fallback suspend page URL", async () => {
+    vi.mocked(chrome.tabs.discard).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      () => Promise.reject(new Error("fail"))
+    )
 
-    const call = vi.mocked(chrome.tabs.update).mock.calls[0]
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
-    expect(url.searchParams.get("title")).toBe("💤 My Tab")
-  })
-
-  it("includes the original URL in the suspend URL params", async () => {
     await discard(
       tab({ id: 1, url: "https://example.com/article", title: "A" })
     )
@@ -80,28 +100,16 @@ describe("discard", () => {
     expect(url.searchParams.get("url")).toBe("https://example.com/article")
   })
 
-  it("includes the favicon in the suspend URL params when present", async () => {
-    const favicon = "https://example.com/favicon.ico"
-    await discard(
-      tab({ id: 1, url: "https://example.com/", favIconUrl: favicon })
-    )
-
-    const call = vi.mocked(chrome.tabs.update).mock.calls[0]
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
-    expect(url.searchParams.get("favicon")).toBe(favicon)
-  })
-
   it("skips an active tab", async () => {
     await discard(tab({ id: 2, active: true }))
 
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
   it("skips an already-discarded tab (idempotency)", async () => {
     await discard(tab({ id: 3, discarded: true }))
 
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
   it("skips a tab already showing the suspend page", async () => {
@@ -109,15 +117,21 @@ describe("discard", () => {
       "moz-extension://testid/suspend.html?url=https%3A%2F%2Fexample.com%2F"
     await discard(tab({ id: 4, url: suspendUrl }))
 
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
   it("ignores a duplicate request while a suspend is in progress", async () => {
+    // Make discard hang so the second call arrives while the first is in-flight
+    vi.mocked(chrome.tabs.discard).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      () => new Promise(() => {})
+    )
+
     discard(tab({ id: 4, url: "https://example.com/" }))
     discard(tab({ id: 4, url: "https://example.com/" }))
     await flush()
 
-    expect(chrome.tabs.update).toHaveBeenCalledTimes(1)
+    expect(chrome.tabs.discard).toHaveBeenCalledTimes(1)
   })
 
   it("queues beyond the concurrency limit and drains the queue", async () => {
@@ -126,66 +140,34 @@ describe("discard", () => {
       (_keys: unknown, cb: (items: Record<string, unknown>) => void) =>
         cb({ "simultaneous-jobs": 0 })
     )
-    const cbs: Array<UpdateCb> = []
-     
-    vi.mocked(chrome.tabs.update).mockImplementation(((
-      _id: number,
-      _props: chrome.tabs.UpdateProperties,
-      cb: UpdateCb
-    ) => {
-      cbs.push(cb)
-    }))
+    const resolvers: Array<() => void> = []
+    vi.mocked(chrome.tabs.discard).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
 
     discard(tab({ id: 10, url: "https://a.example.com/" }))
     discard(tab({ id: 11, url: "https://b.example.com/" }))
     await flush()
 
     // first is in-flight, second is parked in the queue
-    expect(chrome.tabs.update).toHaveBeenCalledTimes(1)
+    expect(chrome.tabs.discard).toHaveBeenCalledTimes(1)
     expect(discard.tabs.length).toBe(1)
 
-    cbs[0]?.() // complete the first suspend
+    resolvers[0]?.() // complete the first discard
     await flush()
 
-    // queue drained: second tab now suspended
-    expect(chrome.tabs.update).toHaveBeenCalledTimes(2)
+    // queue drained: second tab now discarded
+    expect(chrome.tabs.discard).toHaveBeenCalledTimes(2)
     expect(discard.tabs.length).toBe(0)
 
-    cbs[1]?.()
+    resolvers[1]?.()
     await flush()
 
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
-  })
-
-  it("logs chrome.runtime.lastError when the browser rejects navigation", async () => {
-    const consoleSpy = vi
-      .spyOn(console, "log")
-      .mockImplementation(() => undefined)
-    prefs.log = true
-
-     
-    vi.mocked(chrome.tabs.update).mockImplementation(((
-      _id: number,
-      _props: chrome.tabs.UpdateProperties,
-      cb: UpdateCb
-    ) => {
-      Object.assign(chrome.runtime, {
-        lastError: { message: "Cannot update tab." },
-      })
-      cb(undefined)
-      Object.assign(chrome.runtime, { lastError: undefined })
-    }))
-
-    await discard(tab({ id: 50, url: "https://example.com/" }))
-
-    expect(
-      consoleSpy.mock.calls.some((c) =>
-        c.some((a) => String(a).includes("Cannot update tab."))
-      )
-    ).toBe(true)
-
-    consoleSpy.mockRestore()
-    prefs.log = false
   })
 
   it("never calls chrome.tabs.remove across any path", async () => {

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "./discard"
 import { prefs } from "./prefs"
 
-type DiscardCb = () => void
+type UpdateCb = (tab?: chrome.tabs.Tab) => void
 
 const flush = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0))
@@ -38,41 +38,86 @@ beforeEach(() => {
   vi.mocked(chrome.storage.local.get).mockImplementation(
     (_keys: unknown, cb: (items: Record<string, unknown>) => void) => cb({})
   )
-  // discard resolves its callback immediately by default. The chrome typings
-  // surface only the promise overload, so the callback form needs an assertion.
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  vi.mocked(chrome.tabs.discard).mockImplementation(((
+  // tabs.update resolves its callback immediately by default.
+   
+  vi.mocked(chrome.tabs.update).mockImplementation(((
     _id: number,
-    cb: DiscardCb
-  ) => cb()) as never)
+    _props: chrome.tabs.UpdateProperties,
+    cb: UpdateCb
+  ) => cb(undefined)))
 })
 
 describe("discard", () => {
-  it("discards an eligible tab via chrome.tabs.discard", async () => {
-    await discard(tab({ id: 1 }))
+  it("suspends an eligible tab by navigating to the suspend page", async () => {
+    await discard(tab({ id: 1, url: "https://example.com/", title: "Example" }))
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(1, expect.any(Function))
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ url: expect.stringContaining("suspend.html") }),
+      expect.any(Function)
+    )
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
+  })
+
+  it("includes the prepends marker in the suspend URL title", async () => {
+    prefs.prepends = "💤"
+    await discard(tab({ id: 1, url: "https://example.com/", title: "My Tab" }))
+
+    const call = vi.mocked(chrome.tabs.update).mock.calls[0]
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
+    expect(url.searchParams.get("title")).toBe("💤 My Tab")
+  })
+
+  it("includes the original URL in the suspend URL params", async () => {
+    await discard(
+      tab({ id: 1, url: "https://example.com/article", title: "A" })
+    )
+
+    const call = vi.mocked(chrome.tabs.update).mock.calls[0]
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
+    expect(url.searchParams.get("url")).toBe("https://example.com/article")
+  })
+
+  it("includes the favicon in the suspend URL params when present", async () => {
+    const favicon = "https://example.com/favicon.ico"
+    await discard(
+      tab({ id: 1, url: "https://example.com/", favIconUrl: favicon })
+    )
+
+    const call = vi.mocked(chrome.tabs.update).mock.calls[0]
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
+    expect(url.searchParams.get("favicon")).toBe(favicon)
   })
 
   it("skips an active tab", async () => {
     await discard(tab({ id: 2, active: true }))
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("skips an already-discarded tab (idempotency)", async () => {
     await discard(tab({ id: 3, discarded: true }))
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
-  it("ignores a duplicate request while a discard is in progress", async () => {
-    discard(tab({ id: 4 }))
-    discard(tab({ id: 4 }))
+  it("skips a tab already showing the suspend page", async () => {
+    const suspendUrl =
+      "moz-extension://testid/suspend.html?url=https%3A%2F%2Fexample.com%2F"
+    await discard(tab({ id: 4, url: suspendUrl }))
+
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
+  })
+
+  it("ignores a duplicate request while a suspend is in progress", async () => {
+    discard(tab({ id: 4, url: "https://example.com/" }))
+    discard(tab({ id: 4, url: "https://example.com/" }))
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledTimes(1)
+    expect(chrome.tabs.update).toHaveBeenCalledTimes(1)
   })
 
   it("queues beyond the concurrency limit and drains the queue", async () => {
@@ -81,28 +126,29 @@ describe("discard", () => {
       (_keys: unknown, cb: (items: Record<string, unknown>) => void) =>
         cb({ "simultaneous-jobs": 0 })
     )
-    const cbs: Array<DiscardCb> = []
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    vi.mocked(chrome.tabs.discard).mockImplementation(((
+    const cbs: Array<UpdateCb> = []
+     
+    vi.mocked(chrome.tabs.update).mockImplementation(((
       _id: number,
-      cb: DiscardCb
+      _props: chrome.tabs.UpdateProperties,
+      cb: UpdateCb
     ) => {
       cbs.push(cb)
-    }) as never)
+    }))
 
-    discard(tab({ id: 10 }))
-    discard(tab({ id: 11 }))
+    discard(tab({ id: 10, url: "https://a.example.com/" }))
+    discard(tab({ id: 11, url: "https://b.example.com/" }))
     await flush()
 
     // first is in-flight, second is parked in the queue
-    expect(chrome.tabs.discard).toHaveBeenCalledTimes(1)
+    expect(chrome.tabs.update).toHaveBeenCalledTimes(1)
     expect(discard.tabs.length).toBe(1)
 
-    cbs[0]?.() // complete the first discard
+    cbs[0]?.() // complete the first suspend
     await flush()
 
-    // queue drained: second tab now discarded
-    expect(chrome.tabs.discard).toHaveBeenCalledTimes(2)
+    // queue drained: second tab now suspended
+    expect(chrome.tabs.update).toHaveBeenCalledTimes(2)
     expect(discard.tabs.length).toBe(0)
 
     cbs[1]?.()
@@ -111,29 +157,30 @@ describe("discard", () => {
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
-  it("logs chrome.runtime.lastError when the browser rejects a discard", async () => {
+  it("logs chrome.runtime.lastError when the browser rejects navigation", async () => {
     const consoleSpy = vi
       .spyOn(console, "log")
       .mockImplementation(() => undefined)
     prefs.log = true
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    vi.mocked(chrome.tabs.discard).mockImplementation(((
+     
+    vi.mocked(chrome.tabs.update).mockImplementation(((
       _id: number,
-      cb: DiscardCb
+      _props: chrome.tabs.UpdateProperties,
+      cb: UpdateCb
     ) => {
       Object.assign(chrome.runtime, {
-        lastError: { message: "Tab cannot be discarded." },
+        lastError: { message: "Cannot update tab." },
       })
-      cb()
+      cb(undefined)
       Object.assign(chrome.runtime, { lastError: undefined })
-    }) as never)
+    }))
 
-    await discard(tab({ id: 50 }))
+    await discard(tab({ id: 50, url: "https://example.com/" }))
 
     expect(
       consoleSpy.mock.calls.some((c) =>
-        c.some((a) => String(a).includes("Tab cannot be discarded."))
+        c.some((a) => String(a).includes("Cannot update tab."))
       )
     ).toBe(true)
 
@@ -142,7 +189,7 @@ describe("discard", () => {
   })
 
   it("never calls chrome.tabs.remove across any path", async () => {
-    await discard(tab({ id: 20 }))
+    await discard(tab({ id: 20, url: "https://example.com/" }))
     await discard(tab({ id: 21, active: true }))
     await discard(tab({ id: 22, discarded: true }))
 

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -6,17 +6,18 @@
 // Copyright (C) auto-tab-discard contributors
 
 import { prefs, storage } from "./prefs"
+import { buildSuspendUrl, isSuspendTab } from "./suspend-url"
 import { log } from "./utils"
 
 /**
  * The single suspend operation this extension performs. There is intentionally
- * **no** `close` variant: suspender-ledger only ever calls
- * `chrome.tabs.discard` — it never removes a tab. This type exists to make that
+ * **no** `close` variant: suspender-ledger navigates a tab to its themed
+ * suspend page — it never removes a tab. This type exists to make that
  * invariant structural rather than incidental.
  */
 export type SuspendOperation = { tabId: number }
 
-/** Tab ids currently mid-discard, used to debounce duplicate requests. */
+/** Tab ids currently mid-suspend, used to debounce duplicate requests. */
 const inprogress = new Set<number>()
 
 /**
@@ -33,8 +34,10 @@ type DiscardFn = {
 }
 
 /**
- * The terminal action: discard the tab natively. This is the ONLY place a tab
- * state is changed, and it is `chrome.tabs.discard` — never `chrome.tabs.remove`.
+ * The terminal action: navigate the tab to the themed suspend page. This is the
+ * ONLY place a tab state is changed, and it is `chrome.tabs.update` — never
+ * `chrome.tabs.remove`. Navigating to suspend.html applies the `prepends` title
+ * marker and provides the visible, themed placeholder that native discard lacks.
  */
 const perform = (tab: chrome.tabs.Tab): Promise<void> =>
   new Promise<void>((resolve) => {
@@ -42,16 +45,17 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
       resolve()
       return
     }
+    const suspendUrl = buildSuspendUrl(tab, prefs.prepends)
     try {
-      chrome.tabs.discard(tab.id, () => {
+      chrome.tabs.update(tab.id, { url: suspendUrl }, () => {
         const err = chrome.runtime.lastError
         if (err) {
-          log("discard rejected by browser", err.message ?? err)
+          log("suspend navigation failed", err.message ?? err)
         }
         resolve()
       })
     } catch (e) {
-      log("discarding failed", e)
+      log("suspending failed", e)
       resolve()
     }
   })
@@ -76,6 +80,10 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
   }
   if (tab.discarded) {
     log("already discarded", tab)
+    return
+  }
+  if (isSuspendTab(tab)) {
+    log("tab already suspended", tab)
     return
   }
 

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -34,45 +34,39 @@ type DiscardFn = {
 }
 
 /**
- * The terminal action: natively discard the tab to free renderer memory.
- * Before discarding, a `prepends` title marker is injected via
- * `scripting.executeScript` so the browser tab strip shows the "💤" prefix.
- * If native discard is rejected (pinned tab, protected page, etc.), we fall
- * back to navigating to the themed suspend page.
+ * The terminal action: navigate the tab to the themed suspend page. This is the
+ * ONLY place a tab's state is changed, and it is `chrome.tabs.update` — never
+ * `chrome.tabs.remove`.
  *
- * This is the ONLY place tab state is changed — `chrome.tabs.discard` (or on
- * failure `chrome.tabs.update`) — never `chrome.tabs.remove`.
+ * Why navigate instead of `chrome.tabs.discard`? Native discard reloads the
+ * original page when the user reactivates the tab, and that browser-driven
+ * reload flashes the page's own (usually white) background before some-filter's
+ * content script can paint its dark veil. The owned suspend page avoids this:
+ * it is unconditionally dark, and its restore path is a normal top-level
+ * `location.replace(url)` navigation, which some-filter *does* veil at
+ * `document_start`. The `prepends` marker rides along in the URL and is applied
+ * to the tab title by the suspend page.
  */
-const perform = async (tab: chrome.tabs.Tab): Promise<void> => {
-  if (tab.id === undefined) return
-  const tabId = tab.id
-  const marker = prefs.prepends
-
-  if (marker && tab.title) {
+const perform = (tab: chrome.tabs.Tab): Promise<void> =>
+  new Promise<void>((resolve) => {
+    if (tab.id === undefined) {
+      resolve()
+      return
+    }
+    const suspendUrl = buildSuspendUrl(tab, prefs.prepends)
     try {
-      await chrome.scripting.executeScript({
-        target: { tabId },
-        func: (m: string): void => {
-          document.title = `${m} ${document.title}`
-        },
-        args: [marker],
+      chrome.tabs.update(tab.id, { url: suspendUrl }, () => {
+        const err = chrome.runtime.lastError
+        if (err) {
+          log("suspend navigation failed", err.message ?? err)
+        }
+        resolve()
       })
     } catch (e) {
-      log("title injection rejected (protected page)", e)
+      log("suspending failed", e)
+      resolve()
     }
-  }
-
-  try {
-    await chrome.tabs.discard(tabId)
-  } catch (e) {
-    log("native discard rejected — falling back to suspend page", e)
-    try {
-      await chrome.tabs.update(tabId, { url: buildSuspendUrl(tab, marker) })
-    } catch (e2) {
-      log("suspend fallback navigation failed", e2)
-    }
-  }
-}
+  })
 
 function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
   if (tab.id === undefined) {

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -34,31 +34,45 @@ type DiscardFn = {
 }
 
 /**
- * The terminal action: navigate the tab to the themed suspend page. This is the
- * ONLY place a tab state is changed, and it is `chrome.tabs.update` — never
- * `chrome.tabs.remove`. Navigating to suspend.html applies the `prepends` title
- * marker and provides the visible, themed placeholder that native discard lacks.
+ * The terminal action: natively discard the tab to free renderer memory.
+ * Before discarding, a `prepends` title marker is injected via
+ * `scripting.executeScript` so the browser tab strip shows the "💤" prefix.
+ * If native discard is rejected (pinned tab, protected page, etc.), we fall
+ * back to navigating to the themed suspend page.
+ *
+ * This is the ONLY place tab state is changed — `chrome.tabs.discard` (or on
+ * failure `chrome.tabs.update`) — never `chrome.tabs.remove`.
  */
-const perform = (tab: chrome.tabs.Tab): Promise<void> =>
-  new Promise<void>((resolve) => {
-    if (tab.id === undefined) {
-      resolve()
-      return
-    }
-    const suspendUrl = buildSuspendUrl(tab, prefs.prepends)
+const perform = async (tab: chrome.tabs.Tab): Promise<void> => {
+  if (tab.id === undefined) return
+  const tabId = tab.id
+  const marker = prefs.prepends
+
+  if (marker && tab.title) {
     try {
-      chrome.tabs.update(tab.id, { url: suspendUrl }, () => {
-        const err = chrome.runtime.lastError
-        if (err) {
-          log("suspend navigation failed", err.message ?? err)
-        }
-        resolve()
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        func: (m: string): void => {
+          document.title = `${m} ${document.title}`
+        },
+        args: [marker],
       })
     } catch (e) {
-      log("suspending failed", e)
-      resolve()
+      log("title injection rejected (protected page)", e)
     }
-  })
+  }
+
+  try {
+    await chrome.tabs.discard(tabId)
+  } catch (e) {
+    log("native discard rejected — falling back to suspend page", e)
+    try {
+      await chrome.tabs.update(tabId, { url: buildSuspendUrl(tab, marker) })
+    } catch (e2) {
+      log("suspend fallback navigation failed", e2)
+    }
+  }
+}
 
 function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
   if (tab.id === undefined) {

--- a/extensions/suspender-ledger/src/worker/core/suspend-url.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-url.test.ts
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { describe, expect, it } from "vitest"
+
+import { buildSuspendUrl, isSuspendTab } from "./suspend-url"
+
+const tab = (over: Partial<chrome.tabs.Tab> = {}): chrome.tabs.Tab => ({
+  id: 1,
+  index: 0,
+  active: false,
+  discarded: false,
+  autoDiscardable: true,
+  pinned: false,
+  highlighted: false,
+  selected: false,
+  incognito: false,
+  windowId: 1,
+  groupId: -1,
+  ...over,
+})
+
+describe("buildSuspendUrl", () => {
+  it("embeds the original url as a query param", () => {
+    const url = buildSuspendUrl(tab({ url: "https://example.com/article" }), "")
+    const params = new URL(url).searchParams
+    expect(params.get("url")).toBe("https://example.com/article")
+  })
+
+  it("prefixes the tab title with the marker", () => {
+    const url = buildSuspendUrl(
+      tab({ title: "My Tab", url: "https://example.com/" }),
+      "💤"
+    )
+    const params = new URL(url).searchParams
+    expect(params.get("title")).toBe("💤 My Tab")
+  })
+
+  it("omits title param when marker and tab title are both empty", () => {
+    const url = buildSuspendUrl(tab({ url: "https://example.com/" }), "")
+    const params = new URL(url).searchParams
+    expect(params.has("title")).toBe(false)
+  })
+
+  it("uses only the marker when the tab has no title", () => {
+    const url = buildSuspendUrl(tab({ url: "https://example.com/" }), "💤")
+    const params = new URL(url).searchParams
+    expect(params.get("title")).toBe("💤")
+  })
+
+  it("embeds the favicon when the tab has one", () => {
+    const favicon = "https://example.com/favicon.ico"
+    const url = buildSuspendUrl(
+      tab({ url: "https://example.com/", favIconUrl: favicon }),
+      "💤"
+    )
+    const params = new URL(url).searchParams
+    expect(params.get("favicon")).toBe(favicon)
+  })
+
+  it("omits the favicon param when the tab has no favicon", () => {
+    const url = buildSuspendUrl(tab({ url: "https://example.com/" }), "💤")
+    const params = new URL(url).searchParams
+    expect(params.has("favicon")).toBe(false)
+  })
+
+  it("points to the extension suspend.html", () => {
+    const url = buildSuspendUrl(tab({ url: "https://example.com/" }), "💤")
+    expect(url).toContain("suspend.html")
+    expect(url.startsWith("moz-extension://")).toBe(true)
+  })
+})
+
+describe("isSuspendTab", () => {
+  it("returns true for a tab already on the suspend page", () => {
+    const suspendUrl = `moz-extension://testid/suspend.html?url=https%3A%2F%2Fexample.com%2F`
+    expect(isSuspendTab(tab({ url: suspendUrl }))).toBe(true)
+  })
+
+  it("returns false for a regular http tab", () => {
+    expect(isSuspendTab(tab({ url: "https://example.com/" }))).toBe(false)
+  })
+
+  it("returns false when url is undefined", () => {
+    expect(isSuspendTab(tab({ url: undefined }))).toBe(false)
+  })
+})

--- a/extensions/suspender-ledger/src/worker/core/suspend-url.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-url.ts
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Constructs the `suspend.html` URL for a tab about to be suspended. Embeds
+ * the original URL (for restore), the prefixed title (for the tab-strip
+ * marker), and the favicon so the suspend page can reflect the tab's identity
+ * while it is parked.
+ */
+export function buildSuspendUrl(tab: chrome.tabs.Tab, marker: string): string {
+  const base = chrome.runtime.getURL("suspend.html")
+  const params = new URLSearchParams()
+  if (tab.url) {
+    params.set("url", tab.url)
+  }
+  const title = [marker, tab.title].filter(Boolean).join(" ")
+  if (title) {
+    params.set("title", title)
+  }
+  if (tab.favIconUrl) {
+    params.set("favicon", tab.favIconUrl)
+  }
+  return `${base}?${params.toString()}`
+}
+
+/**
+ * True when the tab is already showing our suspend page, used to prevent
+ * double-suspending a parked tab.
+ */
+export function isSuspendTab(tab: chrome.tabs.Tab): boolean {
+  const url = tab.url ?? ""
+  return url.startsWith(chrome.runtime.getURL("suspend.html"))
+}

--- a/extensions/suspender-ledger/src/worker/modes/number.test.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "../core/discard"
 import { number } from "./number"
 
-type DiscardCb = () => void
+type UpdateCb = (tab?: chrome.tabs.Tab) => void
 type QueryCb = (tabs: Array<chrome.tabs.Tab>) => void
 type StorageCb = (items: Record<string, unknown>) => void
 
@@ -101,28 +101,38 @@ beforeEach(() => {
     () => Promise.resolve(readyResult())
   )
 
-  // discard resolves its callback immediately by default. The chrome typings
-  // surface only the promise overload, so the callback form needs an assertion.
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  vi.mocked(chrome.tabs.discard).mockImplementation(((
+  // tabs.update (the suspend navigation) resolves its callback immediately.
+  // The chrome typings surface only the promise overload, so the callback form
+  // needs an assertion.
+   
+  vi.mocked(chrome.tabs.update).mockImplementation(((
     _id: number,
-    cb: DiscardCb
-  ) => cb()) as never)
+    _props: chrome.tabs.UpdateProperties,
+    cb: UpdateCb
+  ) => cb(undefined)))
+})
+
+const suspendUrlMatcher = expect.objectContaining({
+  url: expect.stringContaining("suspend.html"),
 })
 
 describe("number.check — auto-discard", () => {
-  it("discards an idle background tab that has exceeded the age threshold", async () => {
+  it("suspends an idle background tab that has exceeded the age threshold", async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     vi.mocked(chrome.tabs.query).mockImplementation(((
       _opts: unknown,
       cb: QueryCb
     ) => cb([makeTab({ id: 10 })])) as never)
 
-    // number: 0 so 1 candidate > 0 threshold → proceeds to discard
+    // number: 0 so 1 candidate > 0 threshold → proceeds to suspend
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(10, expect.any(Function))
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      10,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
@@ -140,7 +150,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("skips a tab that is too young (within the period threshold)", async () => {
@@ -157,7 +167,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("skips a tab with unsaved form input when form guard is on", async () => {
@@ -174,10 +184,10 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
-  it("does not discard when tab count is at or below the threshold", async () => {
+  it("does not suspend when tab count is at or below the threshold", async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     vi.mocked(chrome.tabs.query).mockImplementation(((
       _opts: unknown,
@@ -187,10 +197,10 @@ describe("number.check — auto-discard", () => {
     await number.check()
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
-  it("discards the oldest tab first when multiple candidates exist", async () => {
+  it("suspends the oldest tab first when multiple candidates exist", async () => {
     const older = makeTab({ id: 20, url: "https://old.example.com/" })
     const newer = makeTab({ id: 21, url: "https://new.example.com/" })
     const now = Date.now()
@@ -209,13 +219,18 @@ describe("number.check — auto-discard", () => {
       }
     )
 
-    // number=1 → 2 candidates, 1 threshold: oldest (id=20) discarded first
+    // number=1 → 2 candidates, 1 threshold: oldest (id=20) suspended first
     await number.check()
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(20, expect.any(Function))
-    expect(chrome.tabs.discard).not.toHaveBeenCalledWith(
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      20,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
+    expect(chrome.tabs.update).not.toHaveBeenCalledWith(
       21,
+      suspendUrlMatcher,
       expect.any(Function)
     )
   })
@@ -233,7 +248,7 @@ describe("number.check — auto-discard", () => {
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
-  it("respects ignore.ready.state override — discards even when meta.ready is false", async () => {
+  it("respects ignore.ready.state override — suspends even when meta.ready is false", async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     vi.mocked(chrome.tabs.query).mockImplementation(((
       _opts: unknown,
@@ -248,7 +263,11 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { "ignore.ready.state": true, number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(40, expect.any(Function))
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      40,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 })

--- a/extensions/suspender-ledger/src/worker/modes/number.test.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.test.ts
@@ -248,6 +248,47 @@ describe("number.check — auto-discard", () => {
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
+  it("uses tab.lastAccessed as age fallback when meta.time is undefined (pre-existing tab)", async () => {
+    const lastAccessed = Date.now() - 30 * 60 * 1000 // 30 min ago — older than period
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    vi.mocked(chrome.tabs.query).mockImplementation(((
+      _opts: unknown,
+      cb: QueryCb
+    ) => cb([makeTab({ id: 50, lastAccessed })])) as never)
+    vi.mocked(chrome.scripting.executeScript).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      () => Promise.resolve(readyResult({ time: undefined }))
+    )
+
+    // number: 0 so 1 candidate > 0 threshold; tab.lastAccessed is 30 min old
+    await number.check(undefined, { number: 0 })
+    await flush()
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      50,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
+  })
+
+  it("skips a pre-existing tab that is too young by tab.lastAccessed", async () => {
+    const lastAccessed = Date.now() - 60 * 1000 // 1 min ago — within period
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    vi.mocked(chrome.tabs.query).mockImplementation(((
+      _opts: unknown,
+      cb: QueryCb
+    ) => cb([makeTab({ id: 51, lastAccessed })])) as never)
+    vi.mocked(chrome.scripting.executeScript).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      () => Promise.resolve(readyResult({ time: undefined }))
+    )
+
+    await number.check(undefined, { number: 0 })
+    await flush()
+
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
+  })
+
   it("respects ignore.ready.state override — suspends even when meta.ready is false", async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     vi.mocked(chrome.tabs.query).mockImplementation(((

--- a/extensions/suspender-ledger/src/worker/modes/number.test.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.test.ts
@@ -7,7 +7,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "../core/discard"
 import { number } from "./number"
 
-type UpdateCb = (tab?: chrome.tabs.Tab) => void
 type QueryCb = (tabs: Array<chrome.tabs.Tab>) => void
 type StorageCb = (items: Record<string, unknown>) => void
 
@@ -101,19 +100,11 @@ beforeEach(() => {
     () => Promise.resolve(readyResult())
   )
 
-  // tabs.update (the suspend navigation) resolves its callback immediately.
-  // The chrome typings surface only the promise overload, so the callback form
-  // needs an assertion.
-   
-  vi.mocked(chrome.tabs.update).mockImplementation(((
-    _id: number,
-    _props: chrome.tabs.UpdateProperties,
-    cb: UpdateCb
-  ) => cb(undefined)))
-})
-
-const suspendUrlMatcher = expect.objectContaining({
-  url: expect.stringContaining("suspend.html"),
+  // tabs.discard (native discard) resolves immediately on the happy path.
+  vi.mocked(chrome.tabs.discard).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    () => Promise.resolve()
+  )
 })
 
 describe("number.check — auto-discard", () => {
@@ -128,11 +119,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.update).toHaveBeenCalledWith(
-      10,
-      suspendUrlMatcher,
-      expect.any(Function)
-    )
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(10)
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
@@ -150,7 +137,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
   it("skips a tab that is too young (within the period threshold)", async () => {
@@ -167,7 +154,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
   it("skips a tab with unsaved form input when form guard is on", async () => {
@@ -184,7 +171,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
   it("does not suspend when tab count is at or below the threshold", async () => {
@@ -197,7 +184,7 @@ describe("number.check — auto-discard", () => {
     await number.check()
     await flush()
 
-    expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
   it("suspends the oldest tab first when multiple candidates exist", async () => {
@@ -223,16 +210,8 @@ describe("number.check — auto-discard", () => {
     await number.check()
     await flush()
 
-    expect(chrome.tabs.update).toHaveBeenCalledWith(
-      20,
-      suspendUrlMatcher,
-      expect.any(Function)
-    )
-    expect(chrome.tabs.update).not.toHaveBeenCalledWith(
-      21,
-      suspendUrlMatcher,
-      expect.any(Function)
-    )
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(20)
+    expect(chrome.tabs.discard).not.toHaveBeenCalledWith(21)
   })
 
   it("never calls chrome.tabs.remove (never-close invariant)", async () => {
@@ -263,11 +242,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { "ignore.ready.state": true, number: 0 })
     await flush()
 
-    expect(chrome.tabs.update).toHaveBeenCalledWith(
-      40,
-      suspendUrlMatcher,
-      expect.any(Function)
-    )
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(40)
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 })

--- a/extensions/suspender-ledger/src/worker/modes/number.test.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "../core/discard"
 import { number } from "./number"
 
+type UpdateCb = (tab?: chrome.tabs.Tab) => void
 type QueryCb = (tabs: Array<chrome.tabs.Tab>) => void
 type StorageCb = (items: Record<string, unknown>) => void
 
@@ -93,18 +94,26 @@ beforeEach(() => {
     cb: QueryCb
   ) => cb([])) as never)
 
-  // scripting.executeScript: the Chrome typings mark this as returning void but
-  // number.ts awaits its result, so the mock must return a real Promise.
+  // scripting.executeScript injects the meta collector (func form); the Chrome
+  // typings mark it as returning void but number.ts awaits the result, so the
+  // mock must return a real Promise of per-frame results.
   vi.mocked(chrome.scripting.executeScript).mockImplementation(
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     () => Promise.resolve(readyResult())
   )
 
-  // tabs.discard (native discard) resolves immediately on the happy path.
-  vi.mocked(chrome.tabs.discard).mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    () => Promise.resolve()
+  // tabs.update (the suspend navigation) resolves its callback immediately.
+  // The chrome typings surface only the promise overload, so the callback form
+  // needs an assertion.
+
+  vi.mocked(chrome.tabs.update).mockImplementation(
+    (_id: number, _props: chrome.tabs.UpdateProperties, cb: UpdateCb) =>
+      cb(undefined)
   )
+})
+
+const suspendUrlMatcher = expect.objectContaining({
+  url: expect.stringContaining("suspend.html"),
 })
 
 describe("number.check — auto-discard", () => {
@@ -119,7 +128,11 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(10)
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      10,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
@@ -137,7 +150,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("skips a tab that is too young (within the period threshold)", async () => {
@@ -154,7 +167,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("skips a tab with unsaved form input when form guard is on", async () => {
@@ -171,7 +184,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("does not suspend when tab count is at or below the threshold", async () => {
@@ -184,7 +197,7 @@ describe("number.check — auto-discard", () => {
     await number.check()
     await flush()
 
-    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+    expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
   it("suspends the oldest tab first when multiple candidates exist", async () => {
@@ -210,8 +223,16 @@ describe("number.check — auto-discard", () => {
     await number.check()
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(20)
-    expect(chrome.tabs.discard).not.toHaveBeenCalledWith(21)
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      20,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
+    expect(chrome.tabs.update).not.toHaveBeenCalledWith(
+      21,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
   })
 
   it("never calls chrome.tabs.remove (never-close invariant)", async () => {
@@ -242,7 +263,11 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { "ignore.ready.state": true, number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(40)
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      40,
+      suspendUrlMatcher,
+      expect.any(Function)
+    )
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 })

--- a/extensions/suspender-ledger/src/worker/modes/number.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.ts
@@ -298,6 +298,18 @@ const number: NumberMode = {
         meta.audible = ms.some((o) => o.audible === true)
         meta.paused = ms.some((o) => o.paused === true)
 
+        // Child iframes lack watch.ts so their time defaults to Date.now().
+        // Object.assign's last-wins would overwrite the main frame's meaningful
+        // lastVisit when allFrames:true is used, making every tab look too young.
+        // Restore main-frame time explicitly.
+        const mainFrame = results.find((r) => r.frameId === 0)
+        if (mainFrame !== undefined) {
+          const mainMeta = readMeta(mainFrame.result)
+          if (typeof mainMeta.time === "number") {
+            meta.time = mainMeta.time
+          }
+        }
+
         // using too much memory => discard instantly
         if (
           prefs["memory-enabled"] &&

--- a/extensions/suspender-ledger/src/worker/modes/number.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.ts
@@ -5,6 +5,8 @@
 // Ported from auto-tab-discard v3/worker/modes/number.mjs (MPL-2.0)
 // Copyright (C) auto-tab-discard contributors
 
+import { collectMeta } from "@suspender/content/meta"
+
 import { discard } from "../core/discard"
 import { storage } from "../core/prefs"
 import { starters } from "../core/startup"
@@ -272,8 +274,9 @@ const number: NumberMode = {
             : await chrome.scripting
                 .executeScript({
                   target: { tabId: tb.id, allFrames: true },
-                  // collector ships with the content layer (story #256)
-                  files: ["/data/inject/meta.js"],
+                  // Inject the collector as a function, not a bundled file: a
+                  // bundler tree-shakes the file's completion-value payload.
+                  func: collectMeta,
                 })
                 .then(
                   (r) => r,

--- a/extensions/suspender-ledger/src/worker/modes/number.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.ts
@@ -358,7 +358,7 @@ const number: NumberMode = {
           icon(tb, "tab is not discardable")
           continue
         }
-        if (now - (meta.time ?? now) < prefs.period * 1000) {
+        if (now - (meta.time ?? tb.lastAccessed ?? now) < prefs.period * 1000) {
           log("discarding aborted", "tab is not old", tb)
           exceptionCount += 1
           icon.reset(tb)

--- a/extensions/suspender-ledger/suspend.html
+++ b/extensions/suspender-ledger/suspend.html
@@ -8,17 +8,24 @@
       form elements) in dark mode immediately — before any JS or CSS loads.
       This, combined with the inline background-color below, prevents the
       flash-bang white frame that vendor suspend pages cause.
+
+      It is deliberately `dark` only (never `dark light`): some-filter cannot
+      reach this moz-extension:// page to dark-theme it, and the whole reason
+      this suspend page is owned is to guarantee an unconditional dark surface
+      that matches a filtered page — no light-mode branch, no white frame.
     -->
-    <meta name="color-scheme" content="dark light" />
+    <meta name="color-scheme" content="dark" />
     <title>Suspended — Suspender Ledger</title>
     <style>
       /*
-       * Inline critical CSS — rendered before external stylesheets load.
-       * Uses CSS custom properties that some-filter injects via its dark-mode
-       * pipeline, falling back to safe dark values when some-filter is absent.
+       * Inline critical CSS — rendered before external stylesheets load. The
+       * background/foreground values are some-filter's canonical dark tokens
+       * (--sw-bg-0 / --sw-text-0) hard-coded here so the very first paint is
+       * byte-identical to a filtered page, with zero dependency on the filter
+       * or the external stylesheet having loaded yet.
        */
       :root {
-        color-scheme: dark light;
+        color-scheme: dark;
       }
 
       html,
@@ -26,8 +33,8 @@
         margin: 0;
         padding: 0;
         min-height: 100dvh;
-        background-color: var(--sl-bg, #1a1a1a);
-        color: var(--sl-fg, #e0e0e0);
+        background-color: #0d1117;
+        color: #e2e8f0;
         font-family: system-ui, -apple-system, sans-serif;
       }
     </style>

--- a/extensions/suspender-ledger/vite.config.firefox.ts
+++ b/extensions/suspender-ledger/vite.config.firefox.ts
@@ -40,7 +40,6 @@ export default defineConfig({
       input: {
         worker: resolve(__dirname, "src/worker/worker.ts"),
         watch: resolve(__dirname, "src/content/watch.ts"),
-        meta: resolve(__dirname, "src/content/meta.ts"),
         popup: resolve(__dirname, "popup.html"),
         suspend: resolve(__dirname, "suspend.html"),
       },
@@ -49,7 +48,6 @@ export default defineConfig({
         entryFileNames: (chunkInfo) => {
           if (chunkInfo.name === "worker") return "worker.js"
           if (chunkInfo.name === "watch") return "watch.js"
-          if (chunkInfo.name === "meta") return "data/inject/meta.js"
           if (chunkInfo.name === "popup") return "popup.js"
           if (chunkInfo.name === "suspend") return "suspend.js"
           return "[name].js"


### PR DESCRIPTION
## Description

Wire the `prepends` marker (default 💤) into discarded tab titles and navigate to the owned `suspend.html` fallback page to provide a visible, themed suspend state. Closes #300.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Implementation

Since `chrome.tabs.update` has no `title` property in Firefox or Chrome, suspended tabs cannot display the marker via native discard alone. The fix navigates each suspended tab to `suspend.html?url=…&title=💤 …&favicon=…`, where the suspend page applies the title and favicon to the DOM.

### Changes:
- Add `suspend-url.ts` with `buildSuspendUrl(tab, marker)` and `isSuspendTab(tab)` helpers
- Change `discard.perform()` from `chrome.tabs.discard` → `chrome.tabs.update({url: suspendUrl})`
- Guard against re-suspending a tab already on the suspend page
- Update tests to assert on `chrome.tabs.update` with suspend-URL params
- Add full unit coverage for both new helpers

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (75/75 pass, `tsc --noEmit` clean)

---
_Generated by [Claude Code](https://claude.ai/code/session_019JNpvB8bYyt3VaBbZ12Y7v)_