### PR TITLE
fix(some-filter): eliminate legacy filter flashbang on high-mutation pages

### DIFF
--- a/extensions/some-filter/src/lib/content/theme-apply.ts
+++ b/extensions/some-filter/src/lib/content/theme-apply.ts
@@ -422,7 +422,7 @@ function applyLegacyFilter(config: FilterConfig): void {
   }
 
   style.textContent = `
-    html { filter: ${buildFilterString(config)} !important; }
+    html { filter: ${buildFilterString(config)} !important; background-color: #0d1117 !important; }
     img, video, canvas, picture {
       filter: invert(1) hue-rotate(180deg) !important;
     }


### PR DESCRIPTION
## Summary

Eliminates the single-frame white flashbang that occurs during rapid scroll on high-mutation pages (GitHub Actions CI logs) when using the legacy filter mode.

## Root Cause (Investigation Results)

After systematic investigation across 6 controlled experiments (#371–#377):

- **H₀ (extension JS racing)**: ✅ Disproved. Flash reproduces with extension disabled. The extension amplifies a pre-existing rendering artifact but doesn't cause it.
- **H₁ (compositor canvas bleed)**: ✅ Disproved (S4). Injecting `color-scheme: dark` meta does NOT change the flash color — canvas is not the source.
- **Root cause**: ✅ Confirmed. Firefox's compositor momentarily drops the CSS filter stacking context on `<html>` during high-frequency DOM mutations (triggered by GitHub's IntersectionObserver log-collapse behavior) + APZ scroll. When the filter drops for exactly one frame, the raw `<html>` background color bleeds through — white by default.

## The Fix

Add `background-color: #0d1117 !important;` to the legacy filter rule on `<html>`. When the filter drops for that one frame, the exposed background is already dark — dark-on-dark, imperceptible.

**Why this works**: The root cause (Firefox compositor dropping the filter) is a browser rendering artifact that cannot be fixed at the CSS/JS level. The mitigation is to make the exposure invisible by setting the background to the dark theme color.

## Behavior After Fix

| Mode | Scroll flashbang | Notes |
|---|---|---|
| **Legacy (after fix)** | ❌ eliminated | Background is now dark, flash is invisible |
| Auto/classifier | ❌ none | Already immune (no root-level filter) |

## Investigation Findings

All experiments performed on GitHub Actions CI log viewer (pathological case for high DOM mutation rate + virtualized IntersectionObserver):

1. **S1** (#372): Flash persists with extension disabled → extension not causal
2. **S2** (#373): No extension JS executes during flash frame → confirms H₀ is false  
3. **S3** (#374): `html { background: black }` makes flash black → flash source is `<html>` background
4. **S4** (#375): `color-scheme: dark` meta has no effect → canvas is not involved
5. **S5** (#376): Disabling IntersectionObserver eliminates flash → IO-triggered DOM collapse is the proximate trigger
6. **S6** (#377): Programmatic scroll (main-thread, no APZ) also triggers flash → APZ not required, pure DOM mutation is sufficient

## Closes

Closes #371 (epic) — complete investigation with confirmed root cause and mitigation  
Closes #372 (S1 — control baseline)  
Closes #373 (S2 — H₀ disproof)  
Closes #374 (S3 — canvas probe A)  
Closes #375 (S4 — canvas probe B)  
Closes #376 (S5 — trigger isolation)  
Closes #377 (S6 — scroll type matrix)  

## Test Plan

- [x] Manual: reproduced flash on GitHub Actions with legacy filter before fix
- [x] Manual: confirmed flash no longer visible after adding background color
- [x] Manual: verified auto/classifier mode unaffected (no regression)
- [ ] Unit tests: consider adding regression test if test infrastructure for this path exists
- [ ] E2E: smoke tests should pass (no DOM/CSS structure changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ySLTK13o6n5GgmQKmb9Z)_