### PR TITLE
Fix suspend URL fragility and deceptive-pattern mitigation

### DIFF
--- a/extensions/suspender-ledger/amo-notes.md
+++ b/extensions/suspender-ledger/amo-notes.md
@@ -11,3 +11,19 @@ No page content, tab data, or user activity is transmitted off-device; all
 processing is local. The content script (`watch.js`) only tracks whether the
 page has unsaved form input and the time of the last visibility change — both
 are used solely to decide whether a tab is safe to suspend.
+
+## Content Security Policy
+
+All extension HTML surfaces (popup, suspend) run under an explicit, restrictive
+CSP declared in the manifest: `script-src 'self'; object-src 'self'`. No inline
+or remote script is used — every page loads a single bundled module from the
+extension's own origin.
+
+## Suspended-tab presentation (deceptive-pattern mitigation)
+
+The suspend page (`suspend.html`) never reflects a suspended tab's original
+title or favicon verbatim. The tab-strip title always carries a marker prefix
+(e.g. `💤 …`, never the bare original), the favicon is the extension's own inline
+"sleep" badge rather than the parked site's icon, and the page body displays a
+visible "Tab suspended by Suspender Ledger" header. This makes the suspended
+state unambiguous and ensures the page never impersonates the origin it parked.

--- a/extensions/suspender-ledger/docs/design-notes.md
+++ b/extensions/suspender-ledger/docs/design-notes.md
@@ -149,12 +149,39 @@ top-level navigation, which fires `document_start` in content scripts and lets
 or in-place DOM swaps bypass `document_start` entirely — do not use them as
 an alternative restore mechanism.
 
-### Suspend URL embeds the `prepends` marker at suspend time
+### Suspend URL carries its params in the hash, address last and raw (#339)
 
-The `💤` prefix is baked into the `title` query parameter of the suspend URL
-(`?title=%F0%9F%92%A4+My+Tab`). Changing `prefs.prepends` after tabs are
-already suspended does not update their displayed titles — the marker only
-refreshes when a tab is next suspended.
+The suspend URL is `suspend.html#title=<encoded>&uri=<original address raw>`.
+The address lives in the **hash fragment**, not the query string, and is the
+verbatim tail after `uri=` — `parseSuspendParams` slices everything after `uri=`
+rather than splitting on `&`, so an embedded query string (`?a=1&b=2`) or `#`
+survives intact. This exists so Firefox's `%` awesome-bar (which restricts
+matching to open tabs, against title + URL) sees the real address instead of a
+wall of `%3A%2F%2F` percent-soup. The legacy `?url=…&title=…&favicon=…` query
+form is still parsed so tabs suspended by an older build survive an update.
+
+The writer (`buildSuspendUrl`, `src/worker/core/suspend-url.ts`) and the reader
+(`parseSuspendParams`, `src/suspend/params.ts`) are **deliberately split across
+the worker/page boundary.** If the page imported the writer's module, Rollup
+would emit it as a chunk shared with the classic background script, and
+`worker.js` would gain a top-level ESM `import` that Firefox cannot load. The
+`uri=` separator is duplicated in both files; `suspend-url.test.ts` round-trips
+build → parse to keep them in lockstep — do not merge them back into one module.
+
+### Suspended tabs never reflect the original title/favicon verbatim (#317)
+
+`buildSuspendUrl` guarantees a non-empty marker (an empty `prefs.prepends` falls
+back to a literal `[Suspended]` prefix), so the tab-strip title can never be the
+bare original — and the suspend page sets its **own** inline-SVG "sleep" badge as
+the favicon, never the original site's icon. A `moz-extension://…/suspend.html`
+page that served another origin's exact title + favicon reads as phishing
+scaffolding to AMO's classifier (it triggered the original block). The favicon is
+no longer embedded in the URL at all, which also removes the single largest
+contributor to the `%`-search string-soup above.
+
+The `💤` prefix is baked into the `title` field at suspend time. Changing
+`prefs.prepends` after tabs are already suspended does not update their displayed
+titles — the marker only refreshes when a tab is next suspended.
 
 ### "No tab to switch to" is not an audio/video bug
 

--- a/extensions/suspender-ledger/public/manifest.firefox.json
+++ b/extensions/suspender-ledger/public/manifest.firefox.json
@@ -13,6 +13,9 @@
     "tabs"
   ],
   "host_permissions": ["*://*/*"],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
   "background": {
     "scripts": ["worker.js"]
   },

--- a/extensions/suspender-ledger/src/suspend/components/suspend-card/index.test.ts
+++ b/extensions/suspender-ledger/src/suspend/components/suspend-card/index.test.ts
@@ -26,6 +26,13 @@ describe("SuspendCard", () => {
     document.body.innerHTML = ""
   })
 
+  it("identifies itself as the extension's suspend page", () => {
+    const { el } = mount()
+    expect(el.querySelector(".suspend-card__badge")?.textContent).toBe(
+      "Tab suspended by Suspender Ledger"
+    )
+  })
+
   it("renders the title, url, and a restore button", () => {
     const { el } = mount()
     expect(el.querySelector(".suspend-card__title")?.textContent).toBe(

--- a/extensions/suspender-ledger/src/suspend/components/suspend-card/index.ts
+++ b/extensions/suspender-ledger/src/suspend/components/suspend-card/index.ts
@@ -41,6 +41,13 @@ export function SuspendCard({
   card.className = "suspend-card"
   card.setAttribute("data-recovery", String(recovery))
 
+  // Unambiguously identify this as the extension's own page, not the original
+  // site (#317): the suspended tab must never masquerade as the page it parked.
+  const badge = document.createElement("p")
+  badge.className = "suspend-card__badge"
+  badge.textContent = "Tab suspended by Suspender Ledger"
+  card.appendChild(badge)
+
   const iconWrap = document.createElement("div")
   iconWrap.className = "suspend-card__icon"
   if (favIconUrl && !recovery && isSafeFaviconUrl(favIconUrl)) {

--- a/extensions/suspender-ledger/src/suspend/index.ts
+++ b/extensions/suspender-ledger/src/suspend/index.ts
@@ -10,50 +10,45 @@
 // the page enters a self-explanatory recovery state rather than stranding the
 // user on a dead tab.
 
-import { isRestorableUrl, isSafeFaviconUrl } from "@suspender/lib/safe-url"
+import { isRestorableUrl } from "@suspender/lib/safe-url"
 import { SuspendCard } from "@suspender/suspend/components/suspend-card"
+import {
+  parseSuspendParams,
+  type SuspendParams,
+} from "@suspender/suspend/params"
 
 import "./suspend.css"
 
-/** Decoded parameters describing the tab that was suspended. */
-type SuspendParams = {
-  url: string
-  title: string
-  favIconUrl: string
-}
+/**
+ * The suspended-state favicon. An inline SVG (no network, no file dependency)
+ * showing a "Z" sleep glyph on the filter's dark canvas. It deliberately
+ * replaces the original site's favicon: a moz-extension page that serves another
+ * origin's exact icon reads as phishing scaffolding to AMO's classifier (#317),
+ * and it stops the real tab and its suspended twin from looking identical in the
+ * tab strip.
+ */
+const SUSPENDED_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><rect width="24" height="24" rx="5" fill="#0d1117"/><g fill="none" stroke="#7aa2f7" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8h6l-6 8h6"/><path d="M14 5h5l-5 6h5" opacity="0.55"/></g></svg>`
+const SUSPENDED_FAVICON = `data:image/svg+xml,${encodeURIComponent(
+  SUSPENDED_FAVICON_SVG
+)}`
 
 /**
- * Read suspend parameters from the page address. Both the query string and the
- * hash are checked: the hash form lets the worker update the marker without the
- * browser treating it as a fresh navigation.
+ * Reflect the suspended state onto the tab strip. The title carries the marker
+ * prefix that `buildSuspendUrl` guarantees (never the verbatim original), and
+ * the favicon is our own suspended badge — never the original site's icon.
  */
-function readParams(): SuspendParams {
-  const fromSearch = new URLSearchParams(location.search)
-  const fromHash = new URLSearchParams(location.hash.replace(/^#/, ""))
-  const pick = (key: string): string =>
-    fromSearch.get(key) ?? fromHash.get(key) ?? ""
-  return {
-    url: pick("url"),
-    title: pick("title"),
-    favIconUrl: pick("favicon"),
-  }
-}
-
-/** Reflect the original title/favicon onto the tab strip while suspended. */
 function applyTabChrome(params: SuspendParams): void {
   const label = params.title || hostOf(params.url)
   if (label) {
     document.title = label
   }
-  if (params.favIconUrl && isSafeFaviconUrl(params.favIconUrl)) {
-    let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
-    if (!link) {
-      link = document.createElement("link")
-      link.rel = "icon"
-      document.head.appendChild(link)
-    }
-    link.href = params.favIconUrl
+  let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
+  if (!link) {
+    link = document.createElement("link")
+    link.rel = "icon"
+    document.head.appendChild(link)
   }
+  link.href = SUSPENDED_FAVICON
 }
 
 function hostOf(url: string): string {
@@ -68,7 +63,7 @@ function main(): void {
   const root = document.getElementById("app")
   if (!root) return
 
-  const params = readParams()
+  const params = parseSuspendParams(location.search, location.hash)
   const recovery = !isRestorableUrl(params.url)
 
   if (!recovery) {
@@ -86,7 +81,6 @@ function main(): void {
     SuspendCard({
       title: params.title,
       url: params.url,
-      favIconUrl: params.favIconUrl || undefined,
       recovery,
       onRestore: restore,
     })

--- a/extensions/suspender-ledger/src/suspend/params.ts
+++ b/extensions/suspender-ledger/src/suspend/params.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 paulgsc — MIT License
+//
+// Reader for the suspend-page address. The writer is `buildSuspendUrl` in
+// `src/worker/core/suspend-url.ts`; that file documents the URL shape and why
+// it lives in the hash (#339). The two are deliberately kept in separate
+// modules across the worker/page boundary so neither becomes a Rollup chunk
+// shared with the classic background script — `suspend-url.test.ts` round-trips
+// build → parse to guarantee they never drift. The `uri=` separator below must
+// match the writer.
+
+/** Decoded parameters describing the tab that was suspended. */
+export type SuspendParams = {
+  url: string
+  title: string
+}
+
+/** Field marker for the verbatim original address; keep in sync with the writer. */
+const URI_FIELD = "uri="
+
+/**
+ * Reads the suspend parameters back out of the page address. The current hash
+ * form is preferred; the legacy `?url=…&title=…&favicon=…` query form is still
+ * understood so tabs suspended by an earlier build survive an extension update.
+ */
+export function parseSuspendParams(
+  search: string,
+  hash: string
+): SuspendParams {
+  const h = hash.replace(/^#/, "")
+
+  // Current form: `title=…&uri=<raw address>` in the hash. The address is the
+  // tail after `uri=`, taken whole so an embedded `&`/`?`/`#` survives intact.
+  const uriAt = h.startsWith(URI_FIELD)
+    ? 0
+    : (() => {
+        const i = h.indexOf(`&${URI_FIELD}`)
+        return i === -1 ? -1 : i + 1
+      })()
+  if (uriAt !== -1) {
+    const url = h.slice(uriAt + URI_FIELD.length)
+    const before = h.slice(0, uriAt).replace(/&$/, "")
+    return { url, title: new URLSearchParams(before).get("title") ?? "" }
+  }
+
+  // Legacy form: url/title/favicon as query (or hash) params. This also covers
+  // a current-form hash that carries only `title=…` with no address.
+  const fromSearch = new URLSearchParams(search)
+  const fromHash = new URLSearchParams(h)
+  const pick = (key: string): string =>
+    fromSearch.get(key) ?? fromHash.get(key) ?? ""
+  return { url: pick("url"), title: pick("title") }
+}

--- a/extensions/suspender-ledger/src/suspend/suspend.css
+++ b/extensions/suspender-ledger/src/suspend/suspend.css
@@ -67,6 +67,14 @@ body {
   text-align: center;
 }
 
+.suspend-card__badge {
+  color: var(--sl-fg-faint);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .suspend-card__icon {
   color: var(--sl-fg-dim);
   display: grid;

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -65,21 +65,24 @@ describe("discard", () => {
     const call = vi.mocked(chrome.tabs.update).mock.calls[0]
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
-    expect(url.searchParams.get("title")).toBe("💤 My Tab")
+    // Title rides in the hash now (#339), not the query string.
+    const fields = new URLSearchParams(url.hash.slice(1).split("&uri=")[0])
+    expect(fields.get("title")).toBe("💤 My Tab")
   })
 
-  it("includes the original URL in the suspend URL params", async () => {
-    await discard(
-      tab({ id: 1, url: "https://example.com/article", title: "A" })
-    )
+  it("embeds the original URL as the readable hash tail", async () => {
+    const target = "https://example.com/article"
+    await discard(tab({ id: 1, url: target, title: "A" }))
 
     const call = vi.mocked(chrome.tabs.update).mock.calls[0]
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
-    expect(url.searchParams.get("url")).toBe("https://example.com/article")
+    const built = (call?.[1] as chrome.tabs.UpdateProperties).url ?? ""
+    // No query-string soup; the address is the verbatim tail after `uri=`.
+    expect(new URL(built).search).toBe("")
+    expect(built).toContain(`uri=${target}`)
   })
 
-  it("includes the favicon in the suspend URL params when present", async () => {
+  it("never embeds the favicon in the suspend URL", async () => {
     const favicon = "https://example.com/favicon.ico"
     await discard(
       tab({ id: 1, url: "https://example.com/", favIconUrl: favicon })
@@ -87,8 +90,8 @@ describe("discard", () => {
 
     const call = vi.mocked(chrome.tabs.update).mock.calls[0]
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const url = new URL((call?.[1] as chrome.tabs.UpdateProperties).url ?? "")
-    expect(url.searchParams.get("favicon")).toBe(favicon)
+    const built = (call?.[1] as chrome.tabs.UpdateProperties).url ?? ""
+    expect(built).not.toContain("favicon")
   })
 
   it("skips an active tab", async () => {

--- a/extensions/suspender-ledger/src/worker/core/suspend-url.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-url.test.ts
@@ -4,6 +4,10 @@
 
 import { describe, expect, it } from "vitest"
 
+// parseSuspendParams lives in the page module (src/suspend/params.ts), split
+// from the writer so the worker never shares a chunk with it. Importing both
+// here round-trips the format and keeps the two in lockstep.
+import { parseSuspendParams } from "../../suspend/params"
 import { buildSuspendUrl, isSuspendTab } from "./suspend-url"
 
 const tab = (over: Partial<chrome.tabs.Tab> = {}): chrome.tabs.Tab => ({
@@ -21,11 +25,31 @@ const tab = (over: Partial<chrome.tabs.Tab> = {}): chrome.tabs.Tab => ({
   ...over,
 })
 
+/** Split a built suspend URL into its `{ search, hash }` for the parser. */
+const split = (url: string): { search: string; hash: string } => {
+  const u = new URL(url)
+  return { search: u.search, hash: u.hash }
+}
+
 describe("buildSuspendUrl", () => {
-  it("embeds the original url as a query param", () => {
+  it("carries the address in the hash, never the query string", () => {
     const url = buildSuspendUrl(tab({ url: "https://example.com/article" }), "")
-    const params = new URL(url).searchParams
-    expect(params.get("url")).toBe("https://example.com/article")
+    expect(new URL(url).search).toBe("")
+    expect(url).toContain("#")
+  })
+
+  it("embeds the original address as the readable, unencoded hash tail", () => {
+    const target = "https://example.com/article"
+    const url = buildSuspendUrl(tab({ url: target }), "💤")
+    // The whole address shows through — no %3A%2F%2F soup (#339).
+    expect(url).toContain(`uri=${target}`)
+  })
+
+  it("keeps a query string in the original address intact after uri=", () => {
+    const target = "https://example.com/search?a=1&b=2&c=3"
+    const url = buildSuspendUrl(tab({ title: "Q", url: target }), "💤")
+    const { search, hash } = split(url)
+    expect(parseSuspendParams(search, hash).url).toBe(target)
   })
 
   it("prefixes the tab title with the marker", () => {
@@ -33,36 +57,33 @@ describe("buildSuspendUrl", () => {
       tab({ title: "My Tab", url: "https://example.com/" }),
       "💤"
     )
-    const params = new URL(url).searchParams
-    expect(params.get("title")).toBe("💤 My Tab")
+    const { search, hash } = split(url)
+    expect(parseSuspendParams(search, hash).title).toBe("💤 My Tab")
   })
 
-  it("omits title param when marker and tab title are both empty", () => {
-    const url = buildSuspendUrl(tab({ url: "https://example.com/" }), "")
-    const params = new URL(url).searchParams
-    expect(params.has("title")).toBe(false)
+  it("falls back to a literal marker so the title is never verbatim", () => {
+    // An empty user marker must not yield the bare original title (#317).
+    const url = buildSuspendUrl(
+      tab({ title: "My Tab", url: "https://example.com/" }),
+      ""
+    )
+    const { search, hash } = split(url)
+    expect(parseSuspendParams(search, hash).title).toBe("[Suspended] My Tab")
   })
 
   it("uses only the marker when the tab has no title", () => {
     const url = buildSuspendUrl(tab({ url: "https://example.com/" }), "💤")
-    const params = new URL(url).searchParams
-    expect(params.get("title")).toBe("💤")
+    const { search, hash } = split(url)
+    expect(parseSuspendParams(search, hash).title).toBe("💤")
   })
 
-  it("embeds the favicon when the tab has one", () => {
-    const favicon = "https://example.com/favicon.ico"
+  it("never embeds a favicon", () => {
     const url = buildSuspendUrl(
-      tab({ url: "https://example.com/", favIconUrl: favicon }),
+      tab({ url: "https://example.com/", favIconUrl: "https://e/favicon.ico" }),
       "💤"
     )
-    const params = new URL(url).searchParams
-    expect(params.get("favicon")).toBe(favicon)
-  })
-
-  it("omits the favicon param when the tab has no favicon", () => {
-    const url = buildSuspendUrl(tab({ url: "https://example.com/" }), "💤")
-    const params = new URL(url).searchParams
-    expect(params.has("favicon")).toBe(false)
+    expect(url).not.toContain("favicon")
+    expect(url).not.toContain("favIconUrl")
   })
 
   it("points to the extension suspend.html", () => {
@@ -72,8 +93,44 @@ describe("buildSuspendUrl", () => {
   })
 })
 
+describe("parseSuspendParams", () => {
+  it("round-trips a build through to the original url and title", () => {
+    const target = "https://example.com/a/b?x=1&y=2#frag"
+    const url = buildSuspendUrl(tab({ title: "Round", url: target }), "💤")
+    const { search, hash } = split(url)
+    expect(parseSuspendParams(search, hash)).toEqual({
+      url: target,
+      title: "💤 Round",
+    })
+  })
+
+  it("returns an empty url when there is no address (recovery)", () => {
+    expect(parseSuspendParams("", "#title=Orphan")).toEqual({
+      url: "",
+      title: "Orphan",
+    })
+  })
+
+  it("still reads the legacy query form for tabs from an older build", () => {
+    const search = "?url=https%3A%2F%2Fexample.com%2F&title=Old&favicon=x"
+    expect(parseSuspendParams(search, "")).toEqual({
+      url: "https://example.com/",
+      title: "Old",
+    })
+  })
+
+  it("returns empty params for a bare suspend.html", () => {
+    expect(parseSuspendParams("", "")).toEqual({ url: "", title: "" })
+  })
+})
+
 describe("isSuspendTab", () => {
-  it("returns true for a tab already on the suspend page", () => {
+  it("returns true for a tab on the new hash-form suspend page", () => {
+    const suspendUrl = `moz-extension://testid/suspend.html#uri=https://example.com/`
+    expect(isSuspendTab(tab({ url: suspendUrl }))).toBe(true)
+  })
+
+  it("returns true for a tab on the legacy query-form suspend page", () => {
     const suspendUrl = `moz-extension://testid/suspend.html?url=https%3A%2F%2Fexample.com%2F`
     expect(isSuspendTab(tab({ url: suspendUrl }))).toBe(true)
   })

--- a/extensions/suspender-ledger/src/worker/core/suspend-url.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-url.ts
@@ -3,30 +3,65 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * Constructs the `suspend.html` URL for a tab about to be suspended. Embeds
- * the original URL (for restore), the prefixed title (for the tab-strip
- * marker), and the favicon so the suspend page can reflect the tab's identity
- * while it is parked.
+ * Builds the `suspend.html` URL for a tab about to be suspended.
+ *
+ * The original address and the tab-strip marker are carried in the page's
+ * **hash fragment**, not the query string, and the original URL is the verbatim
+ * tail after `uri=`:
+ *
+ *   moz-extension://…/suspend.html#title=💤+Example&uri=https://example.com/a?b=c
+ *
+ * Why this shape (#339): Firefox's `%` awesome-bar restricts matching to open
+ * tabs and matches against tab title + URL. The previous `?url=<encoded>` form
+ * percent-encoded the whole address into a wall of `%3A%2F%2F` soup that the
+ * awesome bar could neither read nor usefully match, and a reflected favicon
+ * `data:` URI made it worse. Keeping the address as the readable, unencoded tail
+ * of the fragment means the real URL shows through; pairing it with the prefixed
+ * title (set by the suspend page) makes `%`-search land on the right tab.
+ *
+ * The address is the *last* field and is read by slicing everything after
+ * `uri=`, never by splitting on `&`, so a query string of its own (`?a=1&b=2`)
+ * survives intact. The favicon is deliberately not embedded at all — the suspend
+ * page shows its own suspended badge (see #317).
+ *
+ * The companion reader is `parseSuspendParams` in `src/suspend/params.ts`. The
+ * two are intentionally split across the worker/page boundary so this module
+ * never becomes a chunk shared with the classic background script (which cannot
+ * use ESM `import`); `suspend-url.test.ts` round-trips them to keep the format
+ * in lockstep. The `uri=` separator below must match that reader.
+ */
+
+/** Field marker for the verbatim original address; keep in sync with the reader. */
+const URI_FIELD = "uri="
+
+/**
+ * Constructs the `suspend.html` URL for a tab about to be suspended. The marker
+ * is guaranteed non-empty so the resulting tab title can never be the verbatim
+ * original (a deceptive-pattern trigger — see #317): an empty user marker falls
+ * back to a literal `[Suspended]` prefix.
  */
 export function buildSuspendUrl(tab: chrome.tabs.Tab, marker: string): string {
   const base = chrome.runtime.getURL("suspend.html")
-  const params = new URLSearchParams()
-  if (tab.url) {
-    params.set("url", tab.url)
-  }
-  const title = [marker, tab.title].filter(Boolean).join(" ")
+  const safeMarker = marker || "[Suspended]"
+  const title = [safeMarker, tab.title].filter(Boolean).join(" ")
+
+  const fields = new URLSearchParams()
   if (title) {
-    params.set("title", title)
+    fields.set("title", title)
   }
-  if (tab.favIconUrl) {
-    params.set("favicon", tab.favIconUrl)
+  let fragment = fields.toString()
+  if (tab.url) {
+    // Appended raw and last so the address stays human-readable; everything
+    // after `uri=` is the original URL, `&`-and-all.
+    fragment += `${fragment ? "&" : ""}${URI_FIELD}${tab.url}`
   }
-  return `${base}?${params.toString()}`
+  return fragment ? `${base}#${fragment}` : base
 }
 
 /**
  * True when the tab is already showing our suspend page, used to prevent
- * double-suspending a parked tab.
+ * double-suspending a parked tab. Matches both the current hash form and the
+ * legacy query form (they share the `suspend.html` prefix).
  */
 export function isSuspendTab(tab: chrome.tabs.Tab): boolean {
   const url = tab.url ?? ""

--- a/extensions/suspender-ledger/tests/e2e/specs/suspend-page.spec.ts
+++ b/extensions/suspender-ledger/tests/e2e/specs/suspend-page.spec.ts
@@ -9,37 +9,60 @@
 
 import { expect, test } from "@playwright/test"
 
-/** Build a suspend-page URL with the given params. */
-function suspendUrl(params: Record<string, string>): string {
-  const qs = new URLSearchParams(params).toString()
-  return `/suspend.html?${qs}`
+/**
+ * Build a suspend-page URL in the current hash form: `title` is encoded, the
+ * original address is the verbatim tail after `uri=` (mirrors buildSuspendUrl).
+ */
+function suspendUrl({ title, uri }: { title?: string; uri?: string }): string {
+  const fields = new URLSearchParams()
+  if (title) fields.set("title", title)
+  let fragment = fields.toString()
+  if (uri) fragment += `${fragment ? "&" : ""}uri=${uri}`
+  return fragment ? `/suspend.html#${fragment}` : "/suspend.html"
 }
 
 test.describe("suspend page", () => {
-  test("renders a restorable card from query params", async ({ page }) => {
+  test("renders a restorable card from hash params", async ({ page }) => {
     const target = "https://example.com/article"
-    const favicon = "https://example.com/favicon.ico"
-    await page.goto(suspendUrl({ url: target, title: "My Tab", favicon }))
+    await page.goto(suspendUrl({ title: "💤 My Tab", uri: target }))
 
     const card = page.locator("main.suspend-card")
     await expect(card).toBeVisible()
     await expect(card).toHaveAttribute("data-recovery", "false")
-    await expect(page.locator(".suspend-card__title")).toHaveText("My Tab")
+    await expect(page.locator(".suspend-card__badge")).toHaveText(
+      "Tab suspended by Suspender Ledger"
+    )
+    await expect(page.locator(".suspend-card__title")).toHaveText("💤 My Tab")
     await expect(page.locator(".suspend-card__url")).toHaveText(target)
     await expect(page.locator(".suspend-card__restore")).toBeVisible()
 
-    // Tab chrome is reflected onto the real document.
-    await expect(page).toHaveTitle("My Tab")
-    await expect(page.locator('link[rel="icon"]')).toHaveAttribute(
-      "href",
-      favicon
+    // The tab title carries the marker prefix — never the verbatim original.
+    await expect(page).toHaveTitle("💤 My Tab")
+  })
+
+  test("preserves a query string in the restored address", async ({ page }) => {
+    const target = "https://example.com/search?a=1&b=2&c=3"
+    await page.goto(suspendUrl({ title: "💤 Results", uri: target }))
+    await expect(page.locator(".suspend-card__url")).toHaveText(target)
+  })
+
+  test("shows its own suspended badge favicon, never the original site's", async ({
+    page,
+  }) => {
+    // Even a legacy URL that smuggles an origin favicon must be ignored: the
+    // suspend page always serves its own badge (deceptive-pattern fix, #317).
+    await page.goto(
+      "/suspend.html?url=https%3A%2F%2Fexample.com%2F&favicon=https%3A%2F%2Fexample.com%2Ffavicon.ico"
     )
+    const href = await page.locator('link[rel="icon"]').getAttribute("href")
+    expect(href).toContain("data:image/svg+xml")
+    expect(href).not.toContain("example.com")
   })
 
   test("falls back to the host name when no title is given", async ({
     page,
   }) => {
-    await page.goto(suspendUrl({ url: "https://news.example.org/path" }))
+    await page.goto(suspendUrl({ uri: "https://news.example.org/path" }))
     await expect(page.locator(".suspend-card__title")).toHaveText(
       "news.example.org"
     )
@@ -58,37 +81,38 @@ test.describe("suspend page", () => {
     await expect(page.locator(".suspend-card__restore")).toHaveCount(0)
   })
 
-  test("rejects an unsafe favicon scheme", async ({ page }) => {
-    await page.goto(
-      suspendUrl({
-        url: "https://example.com/",
-        favicon: "javascript:alert(1)",
-      })
-    )
-    // The guard keeps the payload out of both the <head> and the card <img>.
-    await expect(page.locator('link[rel="icon"]')).toHaveCount(0)
-    await expect(page.locator(".suspend-card__favicon")).toHaveCount(0)
-  })
-
   test("restores by navigating to the original url on click", async ({
     page,
     baseURL,
   }) => {
     // Restore to a real, served page so the navigation actually lands.
     const target = new URL("/popup.html", baseURL).href
-    await page.goto(suspendUrl({ url: target, title: "Restore me" }))
+    await page.goto(suspendUrl({ title: "💤 Restore me", uri: target }))
 
     await page.locator(".suspend-card__restore").click()
-    await page.waitForURL("**/popup.html")
+    await page.waitForURL(target)
     expect(page.url()).toBe(target)
   })
 
   test("restores on Enter as well as click", async ({ page, baseURL }) => {
     const target = new URL("/popup.html", baseURL).href
-    await page.goto(suspendUrl({ url: target, title: "Keyboard restore" }))
+    await page.goto(suspendUrl({ title: "💤 Keyboard restore", uri: target }))
 
     await page.keyboard.press("Enter")
-    await page.waitForURL("**/popup.html")
+    await page.waitForURL(target)
+    expect(page.url()).toBe(target)
+  })
+
+  test("still restores tabs suspended by an older build (legacy query form)", async ({
+    page,
+    baseURL,
+  }) => {
+    const target = new URL("/popup.html", baseURL).href
+    const legacy = `/suspend.html?url=${encodeURIComponent(target)}&title=Old`
+    await page.goto(legacy)
+
+    await page.locator(".suspend-card__restore").click()
+    await page.waitForURL(target)
     expect(page.url()).toBe(target)
   })
 })


### PR DESCRIPTION
## Description

Fixes #339 (suspend URL fragility in Firefox % awesome-bar) and advances #367 deceptive-pattern mitigation slices (#317, #318, #315) plus manifest hygiene (#312, #313, #321, #323, #324).

**#339 root cause:** Firefox % awesome-bar restricts tab matching to open tabs and matches against tab title + URL. Percent-encoding the address in the query string (`?url=%3A%2F%2F…`) produces unreadable URL strings in the bar, making it impossible to find tabs by their real address.

**Solution:** Moved address from query string to hash fragment, stored as readable raw tail after `uri=` field. Parser slices everything after `uri=` rather than splitting on `&`, so embedded query strings and `#` survive intact. Legacy query-form URLs still parse for backward compatibility.

## Changes

- **Suspend URL codec split** (`src/suspend/params.ts` + `src/worker/core/suspend-url.ts`):
  - New format: `suspend.html#title=<encoded>&uri=<raw address>`
  - Address is readable and fully parseable by Firefox's awesome-bar
  - Builder and parser are deliberately in separate modules to prevent Rollup from emitting a shared chunk that would inject an ESM import into the classic background script
  - `suspend-url.test.ts` round-trips build → parse to keep the `uri=` separator in sync across the boundary

- **Deceptive-pattern mitigation** (advances #317):
  - Suspend page always serves its own inline-SVG "sleep" badge favicon, never the original site's icon
  - Non-empty marker prefix guarantee: empty marker falls back to `[Suspended]` literal
  - Visible "Tab suspended by Suspender Ledger" badge header on the page body
  - These prevent suspended pages from being misclassified as phishing scaffolding by AMO's content classifier

- **Content Security Policy** (manifest hygiene, #312):
  - Added `content_security_policy.extension_pages` to `manifest.firefox.json`
  - Restricts scripts to extension origin only: `script-src 'self'; object-src 'self'`

- **Tests:** Comprehensive updates to unit and e2e coverage
  - New e2e helper `suspendUrl()` builds hash-form URLs for test fixtures
  - E2E tests verify badge favicon (data URI) and legacy query-form backward compatibility
  - Unit tests verify no favicon is embedded in the suspend URL
  - Suspend card unit test verifies badge presence

- **Documentation:**
  - Design notes detail the URL codec split, Firefox % awesome-bar collision, and why the boundary exists
  - AMO reviewer notes document deceptive-pattern mitigation and CSP

## Type of Change

- [x] Bug fix (fixes fragile suspend URL in Firefox awesome-bar)
- [x] New feature (deceptive-pattern mitigation: own favicon, marker prefix, badge header)
- [ ] Breaking change
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (lint 0, web-ext lint 0, typecheck clean)
- [x] I have added tests that prove my fix is effective (unit + e2e coverage complete)
- [x] New and existing unit tests pass locally with my changes (84 pass)
- [x] E2E smoke tests pass (10 pass)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSPPjHDBUANVgQ48h14h6H)_