### PR TITLE
docs(M8): Workspace documentation—landing page, architecture, ADRs

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -29,6 +29,11 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    options: {
+      storySort: {
+        order: ["Introduction", "Docs", "Content", "*"],
+      },
+    },
   },
 
   tags: ["autodocs"],

--- a/content/docs/Introduction.mdx
+++ b/content/docs/Introduction.mdx
@@ -1,0 +1,152 @@
+import { Meta } from "@storybook/addon-docs/blocks"
+
+<Meta title="Introduction" />
+
+# some-ui Monorepo — Documentation Home
+
+This is the canonical documentation home for all workspaces in the monorepo. It is rendered by Storybook and deployed to GitHub Pages on every push to `main`.
+
+---
+
+## Workspace Map
+
+### Browser Extensions (`extensions/`)
+
+| Workspace | Description |
+|---|---|
+| [`common`](./extensions/common/ARCHITECTURE.md) | Shared commons: keybinding typestate, coexistence primitives, MigrationLedger, Good-Citizen Charter |
+| [`some-filter`](./extensions/some-filter/ARCHITECTURE.md) | Dark-mode filter extension — layer-isolated theme injection with luminance classifier |
+| [`suspender-ledger`](./extensions/suspender-ledger/ARCHITECTURE.md) | Firefox MV3 tab suspender — schedules idle-tab discards; owns the suspend page |
+| [`some-censor`](./extensions/some-censor/ARCHITECTURE.md) | YouTube title-censor extension — pure FSM (Masked → Meta → Title → Revealed) with keybinding unlock |
+| [`some-mujik`](./extensions/some-mujik/ARCHITECTURE.md) | Ambient music visualizer overlay for YouTube/YT Music tabs |
+| [`some-conveyor`](./extensions/some-conveyor/ARCHITECTURE.md) | Polyhedron content conveyor — WASM-driven rotating-cube strip injected into pages |
+| [`some-drama`](./extensions/some-drama/ARCHITECTURE.md) | Drama sentiment tracker — timestamped emotional reactions during C-drama viewing |
+| [`some-schedule`](./extensions/some-schedule/ARCHITECTURE.md) | Ambient music scheduler — domain-classifier-driven background audio player |
+| [`tab-tracker`](./extensions/tab-tracker/ARCHITECTURE.md) | Temporal tab ledger — active-time tracking with HUD overlay and popup ledger |
+| `some-scrobbler` | Last.fm-style listening scrobbler (early-stage) |
+| `some-streak` | Habit streak tracker (early-stage) |
+| `some-cycle` | Cycle tracker (early-stage) |
+| `some-prompt` | Prompt management (early-stage) |
+| `some-tab-meta` | Tab metadata collector used by `suspender-ledger` number-mode |
+
+### UI Packages (`packages/ui/`)
+
+| Workspace | Description |
+|---|---|
+| `@some-ui/styles` | Shared design system — UnoCSS preset + shadcn tokens/themes |
+| `@some-ui/calendar` | Calendar component |
+| `@some-ui/honeycomb` | Honeycomb grid component |
+| `@some-ui/overlays` | Overlay/modal components |
+| `@some-ui/portfolio` | Portfolio chart components |
+| `@some-ui/resume` | Resume layout components |
+| `@some-ui/vidya` | Video/media components |
+| `@some-ui/makjang` | Makjang drama UI components |
+| `@some-ui/attributions` | Attribution/credit components |
+| `maishatu-fetch-kit` | Typed fetch utilities |
+| `umag` | Utilities for magnetic / physics animations |
+| `some-ui-nfl` | NFL data display components |
+| `some-ui-chat` | Chat UI components |
+| `some-ui-input` | Input components |
+| `some-ui-neon-sign` | Neon sign animation component |
+| `some-ui-slideshow` | Slideshow component |
+| `some-ui-stepper` | Stepper/wizard component |
+| `some-ui-searchbar` | Searchbar component |
+| `some-ui-emoji-animations` | Emoji animation components |
+
+### Shared Infrastructure (`packages/`)
+
+| Workspace | Description |
+|---|---|
+| `@some-ui/content` | Shared content components and registry |
+| `@some-ui/styles` | Design system (UnoCSS preset, shadcn tokens) |
+| `some-ui-utils` | Shared utilities |
+| `some-types-utils` | Shared TypeScript types |
+| `packages/eslint` | `maishatu-eslint-kit` — ESLint rules including Good-Citizen lint |
+| `packages/tsconfig` | Shared TypeScript configurations |
+| `packages/rollup-config` | Shared Rollup configurations |
+| `packages/some-vite-config` | Shared Vite configurations |
+
+---
+
+## Documentation Structure
+
+Each workspace follows this layout:
+
+```
+<workspace>/
+  ARCHITECTURE.md          # D1 — entry points, key abstractions, invariants
+  docs/
+    adr/                   # D2 — architecture decision records
+      0001-<decision>.md
+    development.md         # D3 — run / test / build / debug workflow
+    feature-status.md      # D4 — live / deprecated / pending / misaligned
+    posture.md             # D5 — reliability tier, known gaps, security
+```
+
+---
+
+## MDX Authoring Conventions
+
+All documentation MDX lives under `content/docs/` and is auto-picked up by the Storybook glob (`content/**/*.mdx`).
+
+### Front matter
+
+```mdx
+import { Meta } from "@storybook/addon-docs/blocks"
+
+<Meta title="Docs/WorkspaceName/TopicName" />
+```
+
+Use `title` hierarchy to control sidebar placement:
+- `Introduction` — top-level, appears first (via `storySort`)
+- `Docs/<workspace>/<topic>` — per-workspace documentation
+- `Content/<name>` — project specifications, proposals
+
+### Heading levels
+
+| Level | Use |
+|---|---|
+| `#` | Document title (one per file) |
+| `##` | Major section |
+| `###` | Subsection |
+| `####` | Detail item (use sparingly) |
+
+### ADR format
+
+Architecture Decision Records live in `docs/adr/` within each workspace:
+
+```markdown
+# ADR NNNN — <short decision title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-NNNN
+- **Date:** YYYY-MM-DD
+- **Refs:** #<issue>
+
+## Context
+
+<Why this decision was needed. What constraint or discovery drove it.>
+
+## Decision
+
+<What was decided.>
+
+## Trade-offs accepted
+
+<What you gave up. What risks you accepted. What you explicitly deferred.>
+
+## Alternatives rejected
+
+<What else was considered and why it lost.>
+```
+
+ADRs are never deleted. Superseded decisions are marked `status: superseded by ADR-NNNN`.
+
+---
+
+## Charter
+
+Browser extension workspaces are governed by the [Good-Citizen Charter](../extensions/common/GOOD_CITIZEN.md). Read it before touching any content script.
+
+The two mandates:
+1. **Disjointness** — a diff in workspace A must never produce a bug in workspace B.
+2. **No reinvention** — shared contracts live in `@some-extension/common`; shared lint rules in `maishatu-eslint-kit`.

--- a/extensions/common/ARCHITECTURE.md
+++ b/extensions/common/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Architecture — `@some-extension/common`
+
+**Artifact:** Shared TypeScript library imported by all extension workspaces.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+The shared commons that balances two mandates: **disjointness** (a diff in one workspace must never break another) and **no reinvention** (contracts, primitives, and idioms are defined once). It hoists contracts and typestate; keeps application logic per-workspace; enforces idioms via a shared linter.
+
+---
+
+## Entry points
+
+| Export | Path | Purpose |
+|---|---|---|
+| Keybindings | `src/lib/keybindings/index.ts` | `ModifierSet`, `KeyBinding`, `Command` registry |
+| Layers | `src/lib/layers.ts` | `getOverlayRoot`, `EXT_ATTR`, overlay/page-layer helpers |
+| MigrationLedger | `src/lib/migration-ledger.ts` | Per-workspace isolated storage migrations |
+
+All re-exported from `src/index.ts`.
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **Good-Citizen Charter** | `GOOD_CITIZEN.md` — the normative reference every workspace reads before touching content scripts. Covers shadow DOM, z-index policy, fullscreen, resource budgets, storage namespacing, logic/effects separation. |
+| **Keybinding typestate** | `ModifierSet` × `KeyboardEvent.code` → typed `KeyBinding`; platform-normalized matcher; `isInputContext` guard. Defined once; each workspace defines its own handler table. |
+| **MigrationLedger** | Per-workspace, isolated, idempotent schema migrations. Workspace `w` has its own counter independent of every other workspace. |
+| **Layers** | `getOverlayRoot()` / page-layer helpers that enforce structural isolation (extension UI is never a descendant of the filtered page content). |
+| **Coexistence primitives** | `ShadowHost`, `PageMonitor`/`AttentionMode`, `DisposableRegistry` — planned for extraction from `some-conveyor` (issues #280–#282). |
+| **Z-index policy** | Single constant `Z_INDEX_POLICY = 2147483640` with deliberate headroom below `MAX_INT`. Planned for extraction (#282). |
+| **Governance table** | Five classes: typestate / primitive / lint-rule / migration / copy-inline reference encyclopedia (CMN-UTILS, #357–#362). |
+
+---
+
+## Module map
+
+```
+src/
+  index.ts                      — re-exports everything
+  lib/
+    keybindings/
+      index.ts                  — ModifierSet, KeyBinding, Command, matcher, isInputContext
+    layers.ts                   — getOverlayRoot, EXT_ATTR, page-layer helpers
+    migration-ledger.ts         — MigrationLedger class
+GOOD_CITIZEN.md                 — normative charter (start here)
+README.md                       — overview + governance table
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| C1 | Every workspace that imports this package must import only the contract/typestate, never application logic. |
+| C2 | `MigrationLedger` migrations are namespaced per workspace; workspace `w`'s migration counter is never modified by workspace `u`. |
+| C3 | No commons export has side effects at import time — the package is a pure library. |
+| C4 | The z-index constant `2147483640` (not `2147483647`) is the only allowed overlay z-index; workspaces that use `MAX_INT` violate Charter §6. |
+
+---
+
+## See also
+
+- [Good-Citizen Charter](./GOOD_CITIZEN.md)
+- Epics: [CMN-KB #271](https://github.com/paulgsc/some-ui/issues/271) · [CMN-COEXIST #272](https://github.com/paulgsc/some-ui/issues/272) · [CMN-UTILS #357](https://github.com/paulgsc/some-ui/issues/357)

--- a/extensions/common/docs/adr/0001-two-mandate-split.md
+++ b/extensions/common/docs/adr/0001-two-mandate-split.md
@@ -1,0 +1,30 @@
+# ADR 0001 — Two-mandate split: hoist contract, keep application local
+
+- **Status:** Accepted
+- **Date:** 2026-06-23
+- **Refs:** [CMN-KB #271](https://github.com/paulgsc/some-ui/issues/271)
+
+## Context
+
+As the number of extension workspaces grows, two forces pull in opposite directions. Shared code reduces duplication but creates blast-radius coupling: a change to one workspace's shared module can break a different workspace's runtime. Completely isolated workspaces eliminate coupling but cause every workspace to reinvent keybinding matchers, storage migration patterns, shadow DOM isolation, and disposable registries independently — accumulating divergent slop.
+
+## Decision
+
+Hoist the **contract and typestate** (types, pure functions, invariants) into `@some-extension/common`. Keep the **application** (handlers, adapters, side effects) isolated per workspace. Enforce the shared idioms via `maishatu-eslint-kit` lint rules rather than shared runtime code where possible.
+
+Five governance classes are recognised:
+1. **Typestate** — shared types and pure transition functions; imported by path.
+2. **Primitive** — reference implementations (ShadowHost, PageMonitor, DisposableRegistry); imported by path.
+3. **Lint rule** — enforced at `maishatu-eslint-kit` level; workspaces must not install their own rule that contradicts it.
+4. **Migration** — `MigrationLedger` instances are per-workspace, isolated, and namespaced; the class itself is shared.
+5. **Copy-inline reference** — pure utility encyclopedia (CMN-UTILS); the value is the documented rationale, not the code; copy inline, do not path-import.
+
+## Trade-offs accepted
+
+- Workspaces must import from `@some-extension/common` instead of copy-pasting — introduces a build-time dependency.
+- Lint enforcement requires every workspace to configure `maishatu-eslint-kit`; new workspaces must opt in.
+
+## Alternatives rejected
+
+- **Full monolith (one shared runtime):** rejected because a bug in the shared runtime breaks every extension simultaneously.
+- **Full isolation (no commons):** rejected because we already observed the reinvention cost empirically (three independent keybinding matchers, two independent fullscreen watchers, etc.).

--- a/extensions/some-censor/ARCHITECTURE.md
+++ b/extensions/some-censor/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Architecture — `@some-extension/censor` (some-censor)
+
+**Artifact:** Firefox/Chrome browser extension — YouTube title censor.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+Censors YouTube video titles in the tab strip, thumbnails, and search results until the user deliberately unlocks a title via keyboard shortcut. Uses a pure typed FSM with zero side effects in the transition functions so the state machine contract can be tested independently of the browser.
+
+---
+
+## Entry points
+
+| Surface | Entry | Role |
+|---|---|---|
+| Content script | `src/content/` | Mounts the censor overlay, drives the FSM |
+| Background | `src/background/` | Storage access, cross-tab coordination |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **FSM** | `src/lib/content/fsm.ts` — pure transition functions. Four states: `Masked → Meta → Title → Revealed`. Each transition is an overloaded function; calling `applyClick(revealed, el)` is a compile error. |
+| **SessionId** | `src/lib/content/session.ts` — opaque branded type. Every state carries its own `SessionId`; cross-session transitions cannot be constructed. `applyReset()` requires a caller-supplied new `SessionId`. |
+| **Observer** | `src/lib/content/observer.ts` — MutationObserver that detects new YouTube title nodes and applies the initial `Masked` state. |
+| **Controller** | `src/lib/content/controller.ts` — wires observer, keybinding events, and DOM handle into the FSM; owns the `ViewState` reference. |
+| **DOM handle** | `src/lib/content/dom-handle.ts` — the DOM mutation interface (mask/reveal HTML elements). Pure renderer — no FSM state knowledge. |
+| **Keybindings** | Commons keybinding typestate (`@some-extension/common`) — adopted in the refactor landed via [#370](https://github.com/paulgsc/some-ui/pull/370). `some-censor` is the reference implementation. |
+| **Commands** | `src/lib/content/commands.ts` — command registry wired to the commons typestate. |
+| **Click gate** | `src/lib/content/click-gate.ts` — prevents accidental title unlock from mis-clicks; requires a deliberate gesture. |
+
+---
+
+## Module map
+
+```
+src/
+  background/                 — storage coordination
+  content/                    — content script entry
+  lib/
+    content/
+      fsm.ts                  — pure FSM + state variants
+      session.ts              — SessionId opaque type
+      observer.ts             — MutationObserver for new title nodes
+      controller.ts           — FSM wiring (observer + keybinding + DOM)
+      dom-handle.ts           — DOM mutation renderer
+      commands.ts             — command registry
+      click-gate.ts           — deliberate-gesture guard
+      events.ts               — event helpers
+      extract/                — YouTube DOM extractors (meta, title, duration)
+      debug.ts                — debug mode helpers
+    platform/                 — browser API shims
+  types/                      — shared types
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| C1 | FSM transition functions are pure — no browser API calls, no DOM mutations. Side effects live in `controller.ts` and `dom-handle.ts` only. |
+| C2 | Every FSM state carries a `SessionId`; cross-session transitions are a compile-time error. |
+| C3 | `applyReset()` is the only function that accepts a new `SessionId`; it always returns `Masked`, never the prior state variant. |
+| C4 | `project()` in `fsm.ts` has an exhaustive switch over `ViewState.kind`; a missing branch is a compile error (`noImplicitReturns` + strict null checks). |
+| C5 | The commons keybinding typestate is the sole definition of `ModifierSet` and `KeyBinding` for this workspace — no local copies. |
+
+---
+
+## ADRs
+
+- [ADR 0001 — Pure FSM with SessionId brand to prevent cross-session transitions](./docs/adr/0001-pure-fsm-session-brand.md)
+
+## See also
+
+- Issues: [#277 keybinding adoption](https://github.com/paulgsc/some-ui/issues/277) · [#370 refactor PR](https://github.com/paulgsc/some-ui/pull/370)
+- [Good-Citizen Charter](../common/GOOD_CITIZEN.md)

--- a/extensions/some-censor/docs/adr/0001-pure-fsm-session-brand.md
+++ b/extensions/some-censor/docs/adr/0001-pure-fsm-session-brand.md
@@ -1,0 +1,29 @@
+# ADR 0001 — Pure FSM with `SessionId` brand to prevent cross-session transitions
+
+- **Status:** Accepted
+- **Date:** 2026-06-28
+- **Refs:** [#370 refactor PR](https://github.com/paulgsc/some-ui/pull/370)
+
+## Context
+
+The censor extension tracks a per-element view state (Masked → Meta → Title → Revealed). After a page navigation or extension reset, old state objects must not be applicable to new session state — a stale `Revealed` state from session A should not be usable to reveal a title in session B.
+
+The naive solution is a runtime session-mismatch check, but this catches the error at runtime rather than at compile time.
+
+## Decision
+
+Introduce a branded `SessionId` opaque type. Every `ViewState` variant carries its `SessionId`. Transition functions are overloaded so the TypeScript compiler knows which source states are legal for each event — `applyClick(revealed, el)` is a compile error, not a silent no-op.
+
+`applyReset()` is the only function that accepts a new `SessionId` (obtained from `mkSession()`). It cannot reuse the old session — the return type is `Masked` (not `ViewState`), so the old session is structurally gone after a reset.
+
+`project()` has an exhaustive switch over `ViewState.kind`; adding a new state variant without updating `project()` is a compile error (`noImplicitReturns` + strict null checks).
+
+## Trade-offs accepted
+
+- More verbose type signatures (each transition function has multiple overloads).
+- The `SessionId` brand requires a factory function (`mkSession()`); callers cannot construct a `SessionId` directly.
+
+## Alternatives rejected
+
+- **Runtime session check:** catches the bug at runtime instead of compile time. Rejected — we prefer catching this class of error at the type level.
+- **Simple counter/timestamp session ID:** a `number` or `string` `SessionId` can be accidentally constructed; the brand prevents this. Rejected.

--- a/extensions/some-conveyor/ARCHITECTURE.md
+++ b/extensions/some-conveyor/ARCHITECTURE.md
@@ -1,0 +1,99 @@
+# Architecture — `@some-extension/conveyor` (some-conveyor)
+
+**Artifact:** Firefox/Chrome browser extension — WASM-driven polyhedron content conveyor.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+Injects a continuously scrolling strip of rotating cubes into the bottom of every page. Each cube is an independent projection surface driven by a Rust/WASM state machine. Acts as an always-on, ambient attention surface for scheduled content — treating browser attention as a schedulable resource without requiring a dedicated tab.
+
+This workspace is the **reference implementation** of the Good-Citizen Charter's coexistence primitives (§5–§8): `ShadowHost`, `PageMonitor`/`AttentionMode`, `DisposableRegistry`, and the z-index policy originated here before being hoisted into `@some-extension/common`.
+
+---
+
+## Entry points
+
+| Surface | Entry | Role |
+|---|---|---|
+| Content script | `src/content/` | Mounts the conveyor strip; hosts the WASM bridge |
+| Background | `src/background/` | Scheduling and content queue management |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **WASM bridge** | `src/lib/content/wasm-bridge.ts` — TypeScript ↔ Rust boundary. The Rust state machine drives cube geometry and rotation scheduling. |
+| **Cube geometry** | `src/lib/content/cube-geometry.ts` — vertex/face calculations for the rotating polyhedra. |
+| **Cube renderer** | `src/lib/content/cube-renderer.ts` — DOM/canvas rendering of individual cubes. |
+| **Conveyor engine** | `src/lib/content/conveyor-engine.ts` — orchestrates the strip: positioning, scrolling velocity, cube lifecycle. |
+| **Effect bus** | `src/lib/content/effect-bus.ts` — decoupled event bus for triggering visual effects on cubes. |
+| **Coexistence runtime** | `src/lib/content/coexistence.ts` — the original `CoexistenceRuntime` implementation; source for the commons extraction. |
+| **ShadowHost** | `src/lib/content/shadow-host.ts` — isolated shadow DOM mount point with z-index `2147483640`. |
+| **PageMonitor** | `src/lib/content/page-monitor.ts` — fullscreen/visibility/focus → `Active`/`Reduced`/`Suspended` attention modes. |
+| **DisposableRegistry** | `src/lib/content/disposable-registry.ts` — deterministic teardown of all content script resources. |
+| **Theme engine** | `src/lib/content/theme-engine.ts` — integrates with `some-filter`'s theme system for consistent cube styling. |
+| **Cycle rotation adapter** | `src/lib/content/cycle-rotation-adapter.ts` — maps scheduling events to cube rotation sequences. |
+
+---
+
+## Module map
+
+```
+src/
+  background/                 — content queue + scheduling
+  components/                 — overlay React/Preact components
+  content/                    — content script entry
+  lib/
+    content/
+      wasm-bridge.ts          — Rust/WASM boundary
+      cube-geometry.ts        — polyhedron geometry
+      cube-instance.ts        — per-cube state
+      cube-renderer.ts        — DOM/canvas rendering
+      conveyor-engine.ts      — strip orchestration
+      effect-bus.ts           — decoupled visual effects
+      coexistence.ts          — CoexistenceRuntime (reference impl for commons)
+      shadow-host.ts          — shadow DOM isolation
+      page-monitor.ts         — attention mode detection
+      disposable-registry.ts  — teardown registry
+      theme-engine.ts         — some-filter theme integration
+      face-contents.ts        — cube face content model
+      cycle-rotation-adapter.ts — scheduling → rotation mapping
+      streak-store.ts         — streak data integration
+    platform/                 — browser API shims
+  styles/                     — conveyor CSS
+README.md
+amo-notes.md                  — wasm-unsafe-eval CSP justification
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| V1 | The conveyor strip is shadow-DOM isolated — it cannot be styled by the host page. |
+| V2 | All content script resources must be registered with `DisposableRegistry` for deterministic teardown on `runtime.onSuspend`. |
+| V3 | The WASM module uses `wasm-unsafe-eval` CSP; this must be justified in `amo-notes.md` for AMO review. |
+| V4 | `coexistence.ts`, `shadow-host.ts`, `page-monitor.ts`, `disposable-registry.ts` are the **source of truth** for the commons coexistence primitives — they should be re-homed to `@some-extension/common` (#284) and this workspace should import from there. |
+
+---
+
+## Known gaps
+
+- Local copies of coexistence primitives (`coexistence.ts`, `shadow-host.ts`, `page-monitor.ts`, `disposable-registry.ts`) should be deleted once commons extraction (#280–#282) lands; this workspace should become a consumer, not an owner (#284).
+- `wasm-unsafe-eval` CSP justification must be documented per AMO B6 requirement (#320).
+
+## ADRs
+
+- [ADR 0001 — WASM state machine for cube rotation scheduling](./docs/adr/0001-wasm-rotation-state-machine.md)
+
+## See also
+
+- [README](./README.md) — full overview and cube geometry detail
+- [AMO notes](./amo-notes.md) — wasm-unsafe-eval justification
+- Issues: [#284 re-home onto commons](https://github.com/paulgsc/some-ui/issues/284) · [#320 wasm CSP justification](https://github.com/paulgsc/some-ui/issues/320)
+- [Good-Citizen Charter](../common/GOOD_CITIZEN.md) §5–§8 (this extension is the reference)

--- a/extensions/some-conveyor/docs/adr/0001-wasm-rotation-state-machine.md
+++ b/extensions/some-conveyor/docs/adr/0001-wasm-rotation-state-machine.md
@@ -1,0 +1,29 @@
+# ADR 0001 — Rust/WASM state machine for cube rotation scheduling
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+- **Refs:** [some-conveyor README](../README.md) · [AMO notes — wasm-unsafe-eval](../amo-notes.md)
+
+## Context
+
+The conveyor strip requires deterministic, high-frequency rotation scheduling for many independent cube instances simultaneously. The scheduling logic involves geometric state (rotation axis, face sequence, dwell time) that is complex enough that a pure-JS implementation accumulated bugs under rapid event sequences. We needed a model where the scheduling invariants could be formally verified.
+
+Additionally, the extension benefits from near-native performance for the geometry calculations (vertex transforms, face ordering) during the continuous scroll animation.
+
+## Decision
+
+Implement the cube rotation scheduler and geometry engine in Rust, compiled to WebAssembly. The Rust module owns the deterministic scheduling state; TypeScript calls into it via a typed WASM bridge (`wasm-bridge.ts`). All geometry calculations (vertex positions, face contents, rotation sequences) are computed on the Rust side.
+
+This requires the `wasm-unsafe-eval` CSP directive in `manifest.json`, which is justified in `amo-notes.md` for AMO review.
+
+## Trade-offs accepted
+
+- Requires the `wasm-unsafe-eval` CSP exception, which AMO reviewers scrutinise. Must be explicitly justified per B6 requirement (#320).
+- WASM adds ~50–200KB to the extension bundle depending on optimisation level.
+- The Rust/WASM boundary adds a serialisation overhead for each call; complex geometry state should be kept on the Rust side and only results passed back to TypeScript.
+- Debugging requires either Rust debugging tools or logging at the WASM boundary.
+
+## Alternatives rejected
+
+- **Pure TypeScript geometry engine:** prototyped but accumulated subtle rotation-sequence bugs under rapid cube lifecycle events. Rejected.
+- **Web Worker for geometry:** still requires JS, doesn't benefit from Rust's type system for invariant enforcement. Rejected.

--- a/extensions/some-drama/ARCHITECTURE.md
+++ b/extensions/some-drama/ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# Architecture — `@some-extension/drama` (some-drama)
+
+**Artifact:** Firefox/Chrome browser extension — C-drama sentiment tracker.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+Captures timestamped emotional reactions while watching C-dramas. Detects drama context (title, episode, video timestamp) from the page and records reactions via a floating overlay UI with zero-friction capture flow.
+
+---
+
+## Entry points
+
+| Surface | Entry | Role |
+|---|---|---|
+| Content script | `src/content/` | Mounts the floating reaction bar and quick-capture panel |
+| Background | `src/background/background.ts` | Storage access and cross-tab coordination |
+| Popup | `src/popup/` | Session ledger view |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **FSM** | Class-based FSM in `src/lib/content/` — currently couples transition methods with `browser.tabs.executeScript()` and `sendMsg()` calls directly (known Charter §2 violation; pure-FSM refactor tracked in [#343](https://github.com/paulgsc/some-ui/issues/343)). |
+| **Reaction capture** | Two-second capture flow: emoji selection → optional intensity + notes → stored reaction record. |
+| **Context detector** | `src/lib/content/` — extracts drama title, episode number, and video timestamp from the host page DOM. |
+| **Storage** | Reaction records keyed by `(drama, episode, timestamp)`. Uses `browser.storage.local`. |
+| **Domain classifier** | `src/lib/background/domain-classifier.ts` — identifies drama streaming pages where the extension should activate. |
+
+---
+
+## Module map
+
+```
+src/
+  background/
+    background.ts             — storage + cross-tab coordination
+    domain-classifier.ts      — streaming site detection
+    capture.ts                — reaction record persistence
+    id.ts                     — reaction record ID generation
+    types.ts                  — shared types
+  content/                    — reaction bar + context detection
+  lib/
+    content/                  — FSM, context extractor, DOM utilities
+    popup/                    — popup ledger view logic
+  components/                 — React/Preact overlay components
+  popup/                      — popup entry
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| D1 | Reaction records are timestamped to the video timestamp, not wall clock, so they survive page reload. |
+| D2 | The floating reaction bar must not obstruct video playback controls. |
+
+---
+
+## Known gaps
+
+- The FSM directly calls browser APIs from transition methods, violating Charter §2 (logic ≠ effects). Pure FSM refactor tracked in [#343](https://github.com/paulgsc/some-ui/issues/343).
+
+## ADRs
+
+- [ADR 0001 — Video-timestamp anchoring for reaction records](./docs/adr/0001-video-timestamp-anchoring.md)
+
+## See also
+
+- [README](./README.md)
+- [Good-Citizen Charter](../common/GOOD_CITIZEN.md) §2 (logic ≠ effects)

--- a/extensions/some-drama/docs/adr/0001-video-timestamp-anchoring.md
+++ b/extensions/some-drama/docs/adr/0001-video-timestamp-anchoring.md
@@ -1,0 +1,24 @@
+# ADR 0001 — Video-timestamp anchoring for reaction records
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+
+## Context
+
+The drama sentiment tracker records emotional reactions during video playback. The reaction must be meaningful when replayed later — "this made me gasp" is only useful if the user can find exactly where in the episode it happened.
+
+Two timestamp options: wall-clock time (when the user tapped the emoji) or video timestamp (the position in the video at the moment of capture).
+
+## Decision
+
+Anchor reaction records to the **video timestamp** (seconds into the video), not wall-clock time. The record schema is `(drama, episode, video_timestamp_seconds, emotion, intensity, notes)`.
+
+## Trade-offs accepted
+
+- Requires extracting the video timestamp from the host page DOM at capture time. This is page-structure-dependent and may break if the streaming platform changes its DOM.
+- If the user pauses and then taps, the video timestamp is the paused position — which is correct (the reaction was to the paused frame), but may feel counterintuitive.
+
+## Alternatives rejected
+
+- **Wall-clock timestamp:** useful for session analytics but useless for finding the moment in the video. A user cannot replay episode 12 and seek to 14:32:05 PM. Rejected.
+- **Both timestamps:** adds schema complexity for marginal benefit. If wall-clock analytics are needed later, they can be derived from the session start time + video timestamp. Deferred.

--- a/extensions/some-filter/ARCHITECTURE.md
+++ b/extensions/some-filter/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# Architecture — `@some-extension/filter` (some-filter)
+
+**Artifact:** Firefox/Chrome browser extension — dark-mode filter.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+Injects a structurally isolated dark theme into arbitrary web pages. Uses a luminance classifier to detect light pages and applies CSS token overrides scoped to a page-layer container, keeping extension UI in a sibling overlay root that is never filtered or themed.
+
+---
+
+## Entry points
+
+| Surface | Entry | Output |
+|---|---|---|
+| Content script | `src/content/content.ts` | Injected into every page |
+| Background | `src/background/background.ts` | Service worker / background page |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **Layer model** | `#__sw_page_layer` holds all vendor DOM; `#__sw_overlay_root` holds extension UI. These are siblings, never nested — the structural invariant that makes all theming safe. |
+| **Prepaint veil** | `src/lib/content/prepaint.ts` — injects a blocking dark background before first paint to eliminate flash-of-white during page load. |
+| **Theme applier** | `src/lib/content/theme-apply.ts` — applies CSS token overrides and drives the MutationObserver for dynamic pages. |
+| **Theme detector** | `src/lib/content/theme-detector.ts` — luminance classifier (`classifyPage()`) that samples `body`, `main`, `article`, `#app`, `#root`. Returns `{ isLight, skip, avgLuminance }`. |
+| **Legacy filter** | `html { filter: invert(1) hue-rotate(180deg) … }` — manual fallback mode scoped to `#__sw_page_layer`. Activated via popup or shortcut. |
+| **Tab state** | `src/lib/tab-state.ts` — three states: `auto` (classifier-driven), `legacy` (always-on invert), `off`. Persisted in `browser.storage.local`. |
+| **Modify-colors** | `src/lib/content/modify-colors.ts` — per-element background override that handles `rgba`, HSL, and computed colour values. |
+
+---
+
+## Module map
+
+```
+src/
+  background/
+    background.ts             — service worker: responds to tab state changes + commands
+  content/
+    content.ts                — entry: sets up layer model, runs classifier, mounts applier
+    filter.css                — legacy filter CSS rules
+  lib/
+    background/               — background utilities (tab queries, storage)
+    content/
+      prepaint.ts             — first-paint veil
+      theme-apply.ts          — CSS token injection + MutationObserver
+      theme-detector.ts       — luminance classifier
+      color.ts                — colour manipulation helpers
+      modify-colors.ts        — per-element colour overrides
+      guard.ts                — isInputContext and other guards
+      images.ts               — image handling (invert bypass)
+    platform/                 — browser API shims
+    tab-state.ts              — TabState type + storage helpers
+  popup/                      — popup UI (TypeScript + HTML)
+  types/                      — shared types
+public/
+  manifest.json               — extension manifest
+  prepaint.css                — injected CSS for first-paint veil
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| F1 | `#__sw_overlay_root` is **never** a descendant of `#__sw_page_layer`. |
+| F2 | Dark theme CSS selectors are scoped to `#__sw_page_layer` — never to `html` or `body`. |
+| F3 | The legacy `filter` targets `#__sw_page_layer` only, not `html`. |
+| F4 | `#__sw_overlay_root` has `pointer-events: none`; only its children opt in to pointer events. |
+| F5 | Prepaint veil must execute synchronously before `DOMContentLoaded`. |
+
+---
+
+## ADRs
+
+- [ADR 0001 — Dark-mode pipeline rework](./docs/adr/0001-dark-mode-pipeline-rework.md)
+
+## See also
+
+- [README](./README.md) — full architecture narrative and known issues
+- [AMO notes](./amo-notes.md) — Firefox Add-on Marketplace compliance
+- Epics: [CMN-KB #279](https://github.com/paulgsc/some-ui/issues/279) (filter half) · [FILTER-FLASH #371](https://github.com/paulgsc/some-ui/issues/371) (compositor canvas flash diagnosis)

--- a/extensions/some-mujik/ARCHITECTURE.md
+++ b/extensions/some-mujik/ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# Architecture — `@some-extension/mujik` (some-mujik)
+
+**Artifact:** Firefox/Chrome browser extension — ambient music visualizer overlay.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+Renders a persistent, ambient now-playing overlay on the active tab, sourcing music state from a background YouTube or YouTube Music tab. Decouples the audio source from the visual surface: music plays in one tab, the overlay lives in another.
+
+---
+
+## Entry points
+
+| Surface | Entry | Role |
+|---|---|---|
+| Content script | `src/content/` | Mounts the visualizer overlay into the active page |
+| Background | `src/background/` | Polls the music tab; manages overlay state |
+| Popup | `src/popup/` | On/off toggle and settings |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **Musical state** | Each song maps to inferred dimensions (valence, arousal, intensity, tempo) that drive the visual palette and animation parameters. |
+| **Overlay** | A shadow-DOM-isolated overlay mounted at `Z_INDEX_POLICY` z-index, attached as a sibling to the page content (never inside it). |
+| **Music source tab** | Background script detects an active YouTube/YT Music tab and reads its DOM via messaging to extract now-playing metadata. |
+| **Draggable** | `src/content/lib/draggable.ts` — makes the overlay repositionable. Currently writes to `localStorage` (Charter §4 violation — migration to `browser.storage` is tracked in [#283](https://github.com/paulgsc/some-ui/issues/283)). |
+| **Fullscreen watcher** | `src/content/lib/fullscreen.ts` — hides the overlay during fullscreen video. Planned replacement with commons `PageMonitor` (#283). |
+| **Components** | `src/components/` — overlay UI components (React or Preact). |
+
+---
+
+## Module map
+
+```
+src/
+  background/                 — music tab detection + metadata extraction
+  content/
+    lib/
+      draggable.ts            — drag-to-reposition (⚠ writes raw localStorage)
+      fullscreen.ts           — fullscreen hide/show (⚠ local watcher, pre-PageMonitor)
+  components/                 — overlay React/Preact components
+  popup/                      — popup UI
+  styles/                     — overlay CSS
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| M1 | The overlay is shadow-DOM isolated and must never inherit styles from the host page. |
+| M2 | The overlay's z-index must use the commons `Z_INDEX_POLICY` constant (2147483640), not `MAX_INT`. |
+| M3 | Storage writes must use `browser.storage` (namespaced), never raw `localStorage` — once #283 lands. |
+| M4 | The overlay must hide during fullscreen to not obstruct video. |
+
+---
+
+## Known gaps
+
+- `draggable.ts` writes raw, unnamespaced `localStorage` — Charter §4 violation. Fix tracked in [#283](https://github.com/paulgsc/some-ui/issues/283).
+- `fullscreen.ts` reinvents fullscreen detection; the commons `PageMonitor` should replace it (#283).
+
+## ADRs
+
+- [ADR 0001 — Overlay isolation via shadow DOM + Z_INDEX_POLICY](./docs/adr/0001-shadow-dom-overlay.md)
+
+## See also
+
+- Issues: [#283 coexistence adoption](https://github.com/paulgsc/some-ui/issues/283)
+- [Good-Citizen Charter](../common/GOOD_CITIZEN.md) §5 (shadow DOM), §6 (z-index), §4 (namespaced storage)

--- a/extensions/some-mujik/docs/adr/0001-shadow-dom-overlay.md
+++ b/extensions/some-mujik/docs/adr/0001-shadow-dom-overlay.md
@@ -1,0 +1,24 @@
+# ADR 0001 — Shadow DOM overlay isolation + Z_INDEX_POLICY for the visualizer
+
+- **Status:** Accepted
+- **Date:** 2026-06-23
+- **Refs:** [Good-Citizen Charter §5–§6](../../common/GOOD_CITIZEN.md)
+
+## Context
+
+The music visualizer overlay must be rendered on top of arbitrary host pages without inheriting their styles, being styled by them, or interfering with their z-index stacking contexts. Early prototypes used a plain `div` appended to `document.body`, which was frequently overridden by host-page styles and z-index wars.
+
+## Decision
+
+The overlay is mounted inside a closed shadow DOM (`attachShadow({ mode: 'closed' })`). All overlay styles are scoped inside the shadow root. The shadow host element is positioned at z-index `2147483640` (the commons `Z_INDEX_POLICY` constant — 7 below `MAX_INT` to leave headroom for browser chrome).
+
+## Trade-offs accepted
+
+- Shadow DOM means the host page's CSS variables and themes are not automatically inherited — the overlay must explicitly replicate or import any design tokens it needs from `some-filter`'s theme system.
+- `mode: 'closed'` prevents external scripts from accessing the shadow root, which is intentional but means debugging requires DevTools shadow DOM inspection.
+
+## Alternatives rejected
+
+- **Plain `div` with high z-index:** subject to host-page style inheritance and z-index wars. Rejected.
+- **`z-index: 2147483647` (MAX_INT):** violates Charter §6 which reserves headroom. Rejected.
+- **`mode: 'open'` shadow DOM:** allows host-page scripts to traverse into the shadow root, which violates the isolation contract. Rejected.

--- a/extensions/some-schedule/ARCHITECTURE.md
+++ b/extensions/some-schedule/ARCHITECTURE.md
@@ -1,0 +1,72 @@
+# Architecture — `@some-extensions/schedule` (some-schedule)
+
+**Artifact:** Firefox/Chrome browser extension — ambient music scheduler.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+An ambient music player driven by domain classification. Selects and schedules background audio based on the type of page the user is visiting. Features a well-designed 12-state pure FSM — currently with zero test coverage (highest-priority target for the Invariant Confidence Stack, [#341](https://github.com/paulgsc/some-ui/issues/341)).
+
+---
+
+## Entry points
+
+| Surface | Entry | Role |
+|---|---|---|
+| Background | `src/background/` | Scheduling engine, domain classifier integration |
+| Content script | `src/content/` | Page context detection |
+| Popup | `src/popup/` | Playback controls and schedule view |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **12-state FSM** | Pure state machine in `src/shared/` — the highest-priority FSM in the codebase for testing ([#341](https://github.com/paulgsc/some-ui/issues/341)) because it is well-designed and pure, yet has zero test coverage. |
+| **Domain classifier** | `src/background/` + `src/extractors/` — classifies the current page domain to select the appropriate ambient music track/category. |
+| **Extractors** | `src/extractors/` — page content extractors that inform the scheduler (activity type, focus level, etc.). |
+| **Shared state** | `src/shared/` — FSM types, transitions, and schedule data shared between background and popup. |
+
+---
+
+## Module map
+
+```
+src/
+  background/
+    background.ts             — scheduler entry, alarm management
+    capture.ts                — activity capture
+    domain-classifier.ts      — page type → music category
+    types.ts                  — shared types
+  content/                    — page context injection
+  extractors/                 — per-page content extractors
+  popup/                      — playback controls UI
+  shared/                     — FSM types + 12-state machine
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| SC1 | The 12-state FSM transitions are pure — no browser API calls. |
+| SC2 | Audio playback is always gated on user gesture or explicit activation (browser autoplay policy). |
+
+---
+
+## Known gaps
+
+- The 12-state FSM has zero test coverage. This is the highest-friction-to-reward testing target in the codebase; tests are tracked in [#344](https://github.com/paulgsc/some-ui/issues/344) and [#342](https://github.com/paulgsc/some-ui/issues/342).
+
+## ADRs
+
+- [ADR 0001 — 12-state FSM for music scheduling](./docs/adr/0001-12-state-music-fsm.md)
+
+## See also
+
+- Issues: [#341 Invariant Confidence Stack epic](https://github.com/paulgsc/some-ui/issues/341) · [#344 transition graph exhaustion tests](https://github.com/paulgsc/some-ui/issues/344)
+- [Good-Citizen Charter](../common/GOOD_CITIZEN.md)

--- a/extensions/some-schedule/docs/adr/0001-12-state-music-fsm.md
+++ b/extensions/some-schedule/docs/adr/0001-12-state-music-fsm.md
@@ -1,0 +1,24 @@
+# ADR 0001 — 12-state FSM for music scheduling
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+The ambient music scheduler needs to respond to many concurrent signals: page type changes, user focus, playback errors, network state, user preferences, and explicit overrides. An ad-hoc if/else implementation of this logic accumulated edge cases and silent no-ops when state combinations were missed.
+
+## Decision
+
+Model the scheduler as an explicit 12-state FSM with typed state variants and pure transition functions. The FSM lives in `src/shared/` and is shared between the background script and popup. All state is in the FSM; side effects (audio playback, API calls) are triggered by the controller in response to state transitions.
+
+The 12 states cover: `Idle`, `Detecting`, `Selected`, `Buffering`, `Playing`, `Paused`, `Error`, `Retrying`, `UserOverride`, `Suspended`, `FocusLost`, `NetworkLost`.
+
+## Trade-offs accepted
+
+- 12 states × N events = large transition table. Some transitions are intentionally `null` (no-ops for invalid combinations), which must be documented clearly.
+- The FSM is currently untested (zero test files). This is the highest-priority target for the Invariant Confidence Stack (#341–#346) because the FSM is already pure — tests can be written without a browser environment.
+
+## Alternatives rejected
+
+- **Ad-hoc if/else with boolean flags:** the original implementation; accumulated silent no-ops and edge cases on race conditions. Replaced by the FSM.
+- **XState or similar FSM library:** adds a runtime dependency; the FSM is simple enough that a hand-rolled implementation is more transparent. Deferred until complexity warrants it.

--- a/extensions/suspender-ledger/ARCHITECTURE.md
+++ b/extensions/suspender-ledger/ARCHITECTURE.md
@@ -1,0 +1,98 @@
+# Architecture — `@some-extension/suspender-ledger`
+
+**Artifact:** Firefox MV3 browser extension — tab suspender.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+Watches open tabs and discards (suspends) idle ones after a configurable period to reclaim RAM. Never closes tabs — suspension is always reversible. A suspended tab keeps its position in the strip; restoring it reloads the original URL transparently.
+
+---
+
+## Entry points
+
+| Surface | Entry | Output | Role |
+|---|---|---|---|
+| Service worker | `src/worker/worker.ts` | `worker.js` | Discard scheduling, prefs, context menu, keyboard commands |
+| Content script | `src/content/watch.ts` | `watch.js` | Per-page activity detection (input/scroll/visibility) |
+| Popup | `popup.html` → `src/popup/index.ts` | `popup.js` | Toolbar UI: per-tab actions, whitelist toggle, settings |
+| Suspend page | `suspend.html` → `src/suspend/index.ts` | `suspend.js` | Stand-in page shown for navigated suspends; restores on click/Enter |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **Discard engine** | `src/worker/core/discard.ts` — the core logic: queries all tabs, filters by guards (audio, pinned, whitelist, form-dirty), sorts by last-access, discards the oldest N. |
+| **Prefs** | `src/worker/core/prefs.ts` — typed preferences stored in `browser.storage.local`. Includes `period`, `number` (threshold), `whitelist`, `pinned`, `paused`. |
+| **Startup** | `src/worker/core/startup.ts` — alarm registration, context menu construction, tab listener wiring on worker init. |
+| **Suspend URL codec** | `src/worker/core/suspend-url.ts` (builder) + `src/suspend/params.ts` (parser) — hash-form URL: `suspend.html#title=…&uri=…`. Split deliberately to prevent Rollup from emitting a shared chunk that would inject ESM into the classic background script. |
+| **Number mode** | `src/worker/modes/number.ts` — alternative mode: always keep exactly N most-recent tabs loaded; discard all others. |
+| **Platform shim** | `src/lib/platform/firefox.ts` (aliased `@suspender/platform`) — isolates `browser.*` API differences so core logic is testable without a real browser. |
+| **Message protocol** | `src/types/messages.ts` — typed, validated message types for every popup ↔ worker ↔ content boundary. |
+| **Activity watcher** | `src/content/watch.ts` — listens for input events, scroll, and page visibility; reports `lastActive` timestamps to the worker via messaging. |
+
+---
+
+## Module map
+
+```
+src/
+  worker/
+    worker.ts                 — entry: wires all handlers, starts alarm
+    core/
+      discard.ts              — suspension engine
+      prefs.ts                — typed preferences + storage
+      startup.ts              — alarm + context menu init
+      navigate.ts             — tab navigation helpers
+      suspend-url.ts          — suspend URL builder (hash form)
+      utils.ts                — tab query helpers
+    menu.ts                   — context menu item construction
+    modes/
+      number.ts               — number-based keep-N mode
+  content/
+    watch.ts                  — activity detection content script
+  popup/                      — popup UI
+  suspend/
+    index.ts                  — suspend page entry
+    params.ts                 — suspend URL parser (hash form)
+  lib/
+    platform/
+      firefox.ts              — browser API shim
+    safe-url.ts               — URL validation (shared)
+  types/
+    messages.ts               — typed message protocol
+suspend.html                  — suspend page HTML
+popup.html                    — popup HTML
+docs/
+  design-notes.md             — known gaps, trade-offs, post-beta roadmap
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| S1 | The service worker is built as a **single flat bundle** (no code-splitting). Firefox MV3 background scripts cannot be ESM-imported. |
+| S2 | The suspend URL codec is intentionally split across two modules (`suspend-url.ts` in worker, `params.ts` in suspend page) to prevent a shared Rollup chunk that would violate S1. |
+| S3 | Suspension is always reversible — the extension never calls `browser.tabs.remove()`. |
+| S4 | The active tab is never auto-suspended regardless of idle time. |
+| S5 | Whitelist entries survive browser restart (stored via `browser.storage.local`); session-whitelist entries do not. |
+| S6 | The suspend page badge favicon is always the extension's own inline SVG — never the original site's icon (AMO deceptive-pattern requirement). |
+
+---
+
+## ADRs
+
+- [ADR 0001 — MV3 single-bundle constraint and Rollup chunk split](./docs/adr/0001-mv3-single-bundle-constraint.md)
+
+## See also
+
+- [README](./README.md) — full architecture table, MV3 constraints, build notes
+- [Design notes](./design-notes.md) — known gaps (queue durability, battery gate, memory pressure)
+- [AMO notes](./amo-notes.md)
+- Issues: [#317 deceptive-pattern mitigation](https://github.com/paulgsc/some-ui/issues/317) · [#339 suspend URL fragility](https://github.com/paulgsc/some-ui/issues/339)

--- a/extensions/suspender-ledger/docs/adr/0001-mv3-single-bundle-constraint.md
+++ b/extensions/suspender-ledger/docs/adr/0001-mv3-single-bundle-constraint.md
@@ -1,0 +1,27 @@
+# ADR 0001 — MV3 single-bundle constraint and Rollup/Vite chunk split
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+- **Refs:** [suspender-ledger build](../../README.build.md)
+
+## Context
+
+Firefox Manifest V3 background scripts must be a single self-contained file — they cannot use `import()` or `import` statements at the module level when loaded as a classic script. Rollup/Vite's default behaviour is to emit shared chunks when two entry points share dependencies, which would produce ESM `import` statements in the generated bundle — breaking the MV3 service worker.
+
+The suspend URL codec (`suspend-url.ts` in the worker, `params.ts` in the suspend page) is the most obvious shared boundary: both the worker and the suspend page need to build and parse the same URL format.
+
+## Decision
+
+- Configure Vite with `output.manualChunks: {}` (or equivalent) so the worker entry point is always a single flat bundle.
+- Deliberately split the suspend URL codec into two **separate** modules — `src/worker/core/suspend-url.ts` (builder) and `src/suspend/params.ts` (parser) — with no shared import between them. They share the URL format specification via documentation and a round-trip test, not shared code.
+- The round-trip test (`suspend-url.test.ts`) asserts that build → parse produces the original values, keeping the two modules in sync without a shared import.
+
+## Trade-offs accepted
+
+- The URL format is documented in two places (builder and parser comments) instead of one. This is the cost of avoiding the shared chunk.
+- A change to the URL format requires updating both modules and the test. The test enforces this — a change to one without the other will fail CI.
+
+## Alternatives rejected
+
+- **Shared URL codec module imported by both:** this would cause Rollup to emit a shared chunk, injecting an ESM `import` into the worker bundle and breaking the MV3 service worker. Rejected.
+- **Encode the URL format in a `.json` config file:** adds complexity without solving the fundamental issue; Rollup still emits a shared chunk for the `.json` import. Rejected.

--- a/extensions/tab-tracker/ARCHITECTURE.md
+++ b/extensions/tab-tracker/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# Architecture — TabLedger (`tab-tracker`)
+
+**Artifact:** Firefox/Chrome browser extension — temporal tab accountability ledger.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+Passively tracks active time per tab (pausing when the browser loses focus, window switches, or tab switches) and surfaces it via a live HUD chip injected into every page and a popup ledger sorted by time spent.
+
+---
+
+## Entry points
+
+| Surface | Entry | Role |
+|---|---|---|
+| Content script | injected into every page | HUD overlay with live clock + drift-correction flash |
+| Background | background service | Tab activity event aggregation + ledger updates |
+| Popup | popup | Sorted ledger: time bars, sparklines, session/all-time toggle, tags |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **Active-time model** | Only wall-clock time while the tab is the active, focused tab counts. Paused on blur, tab switch, or window switch. |
+| **HUD overlay** | Monospace chip in top-right corner. Color-coded green → amber → red → violet as time accumulates. Fades during active use; surfaces on idle. |
+| **Drift-correction flash** | On tab switch-to, briefly shows the session total before reverting to the live clock — corrects mental model mismatch. |
+| **Threshold toasts** | Non-blocking bottom-left toasts at 15m, 45m, 90m per tab. |
+| **Neglect alerts** | If the current tab has 45m+ and an "intentional" tab has <5m, a subtle nag appears. |
+| **Popup ledger** | Tabs sorted by time. Tags: RABBIT HOLE, DEEP WORK, NEGLECTED, COLD. Sparkline history per tab. Markdown export. |
+
+---
+
+## Module map
+
+```
+src/                          — (structure mirrors standard extension layout)
+  background/                 — event aggregation + ledger storage
+  content/                    — HUD overlay + drift-correction flash
+  popup/                      — popup ledger UI
+README.md                     — full feature description + setup
+AI.md                         — AI-assisted development notes
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| T1 | Active time only counts while the tab is the foreground tab in the focused window. |
+| T2 | The HUD must not obstruct page content interaction — it uses `pointer-events: none` except on explicit interaction zones. |
+| T3 | Time data survives browser restart (stored via `browser.storage.local`). |
+
+## ADRs
+
+- [ADR 0001 — Active-only time model (no idle or background time)](./docs/adr/0001-active-only-time-model.md)
+
+## See also
+
+- [README](./README.md)
+- [AI notes](./AI.md)

--- a/extensions/tab-tracker/docs/adr/0001-active-only-time-model.md
+++ b/extensions/tab-tracker/docs/adr/0001-active-only-time-model.md
@@ -1,0 +1,28 @@
+# ADR 0001 — Active-only time model (no idle or background time)
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+- **Refs:** [README — What it does](../README.md)
+
+## Context
+
+A tab time tracker can measure several different things: total time a tab has been open, time the tab was in the foreground, time the user was actively interacting with the tab, or some weighted combination. The choice determines what the data actually means and whether it is useful for accountability.
+
+## Decision
+
+Measure **active foreground time** only: the clock runs only when the tab is the active tab in the focused browser window. It pauses on:
+- Browser blur (user switched to another application)
+- Tab switch (user switched to another tab)
+- Window switch (user switched to another browser window)
+
+Background time (tab open but not in focus) is explicitly not counted.
+
+## Trade-offs accepted
+
+- "Active time" understates total engagement time — a video playing in a background tab adds zero time. This is a deliberate choice: the ledger measures *attention*, not presence.
+- Implementation requires listening to `visibilitychange`, `focus`/`blur`, and `tabs.onActivated` across both content script and background; these must be kept in sync.
+
+## Alternatives rejected
+
+- **Total open time:** measures "how long was this tab open", not "how long did I spend on this tab". A tab open for 8 hours while working in another app would record 8 hours. Misleading. Rejected.
+- **Interaction-gated time (active typing/scrolling only):** too aggressive — reading a long article with no input still counts as active attention. The tab being in the foreground in a focused window is the right proxy. Rejected.

--- a/packages/some-styles/ARCHITECTURE.md
+++ b/packages/some-styles/ARCHITECTURE.md
@@ -1,0 +1,62 @@
+# Architecture — `@some-ui/styles`
+
+**Artifact:** Shared TypeScript/CSS library — design system for the some-ui monorepo.
+**Docs home:** [Introduction](../../content/docs/Introduction.mdx)
+
+---
+
+## What it is
+
+The shared design system. Provides a UnoCSS preset with shadcn-compatible tokens and themes, plus a JS config API for consuming packages. Runtime output is plain static CSS; the JS layer is dev-time only.
+
+---
+
+## Entry points
+
+| Export | Path | Role |
+|---|---|---|
+| JS config API | `src/index.ts` | `defineSomeUiConfig`, `presetSomeUi`, theme data, component types |
+| Token CSS | `src/tokens.css` | CSS custom properties for colors, radius, font-family |
+| Theme CSS | `src/themes.css` | Light/dark theme overrides |
+| Tailwind compat | `src/tailwind.css` | Tailwind-compatible utility classes via UnoCSS |
+
+---
+
+## Key abstractions
+
+| Abstraction | Description |
+|---|---|
+| **`presetSomeUi`** | UnoCSS preset that adds some-ui's color palette, font-family, radius scale, and shortcut utilities. |
+| **`defineSomeUiConfig`** | Config factory for consuming packages — merges some-ui defaults with per-package overrides. |
+| **shadcn tokens** | CSS custom property schema compatible with shadcn/ui (`--background`, `--foreground`, `--primary`, etc.). |
+| **Theme switcher** | Light/dark theme switching via data attribute or class; exposes JS API for runtime toggles. |
+| **`someUiTheme`** | The canonical theme object shared with Tailwind/UnoCSS config. |
+
+---
+
+## Module map
+
+```
+src/
+  index.ts                    — re-exports all JS API
+  config.ts                   — defineSomeUiConfig + SomeUiConfigOptions
+  preset/                     — presetSomeUi, colors, fontFamily, radius, someUiTheme
+  components/                 — component-level style exports
+  data/                       — design token data (colors, scales)
+  types/                      — TypeScript types for design tokens
+  registry/                   — component registry for shadcn compatibility
+```
+
+---
+
+## Critical invariants
+
+| # | Invariant |
+|---|---|
+| ST1 | The JS API is dev-time only — no runtime JS is shipped to pages. |
+| ST2 | All color tokens are CSS custom properties, not hardcoded values. |
+| ST3 | The shadcn token names must not be renamed; downstream shadcn components depend on the exact custom property names. |
+
+## ADRs
+
+- [ADR 0001 — UnoCSS + shadcn token schema over Tailwind-only approach](./docs/adr/0001-unocss-shadcn-tokens.md)

--- a/packages/some-styles/docs/adr/0001-unocss-shadcn-tokens.md
+++ b/packages/some-styles/docs/adr/0001-unocss-shadcn-tokens.md
@@ -1,0 +1,28 @@
+# ADR 0001 — UnoCSS + shadcn token schema over pure Tailwind
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+
+## Context
+
+The some-ui monorepo needs a shared design system that covers: (1) utility classes for rapid UI development, (2) design tokens (colors, radius, spacing) shared across packages, and (3) component-level styles compatible with shadcn/ui components (which many packages adopt).
+
+Tailwind CSS alone handles (1) but not (2) and (3) — shadcn components expect specific CSS custom property names (`--background`, `--foreground`, `--primary`, etc.) and a dark-mode switcher that works at the CSS layer.
+
+## Decision
+
+Use **UnoCSS** as the utility class engine (it processes Tailwind-compatible class names and our custom shortcuts) and adopt the **shadcn token schema** (CSS custom properties) as the design token layer. UnoCSS's `presetSomeUi` preset wraps both together.
+
+Runtime output is plain static CSS (no JS shipped to browsers). The JS layer (`src/index.ts` exports) is dev-time only for config factories and TypeScript types.
+
+## Trade-offs accepted
+
+- UnoCSS is a less-common choice than Tailwind; new contributors must learn UnoCSS's config API.
+- The shadcn token names must never be renamed (shadcn components have hard-coded custom property expectations). Breaking this constraint breaks all shadcn components in the monorepo.
+- Some Tailwind-specific utilities (JIT arbitrary values) require UnoCSS equivalents which may differ.
+
+## Alternatives rejected
+
+- **Pure Tailwind with CSS variables:** Tailwind's JIT mode doesn't easily compose CSS custom properties as first-class design tokens. Rejected.
+- **CSS Modules per package:** no shared token system; each package would define its own color palette. Rejected.
+- **Full shadcn/ui with Tailwind CSS:** locks in Tailwind as the required build tool for all consumers. UnoCSS provides more flexibility. Rejected.


### PR DESCRIPTION
## Description

Lands issues #330, #331, #332 from the Workspace Documentation milestone (M8). Establishes the documentation infrastructure and initial architecture/ADR coverage for all key workspaces.

### #330 (D0) — Storybook MDX landing page + conventions
- `content/docs/Introduction.mdx`: canonical docs home pinned first in sidebar
- Workspace map covering all 15 extensions + packages
- MDX authoring conventions + lightweight ADR template format
- `.storybook/preview.tsx`: `storySort` pinning "Introduction" first

### #331 (D1) — Architecture snapshots per workspace
- `ARCHITECTURE.md` for 10 workspaces: common, some-filter, suspender-ledger, some-censor, some-mujik, some-conveyor, some-drama, some-schedule, tab-tracker, some-styles
- Covers: entry points, key abstractions, module map, critical invariants
- Satisfies D1 acceptance criteria: returning developers can orient without reading source

### #332 (D2) — ADR scaffolding + first decisions
- `docs/adr/` directories created in 9 workspaces
- Inaugural ADR (0001) for each, covering the most significant design decision:
  - common: two-mandate split (hoist contract, keep application local)
  - suspender-ledger: MV3 single-bundle constraint + Rollup/Vite chunk split
  - some-censor: pure FSM with SessionId brand
  - some-mujik: shadow DOM + Z_INDEX_POLICY
  - some-conveyor: Rust/WASM for rotation scheduling
  - some-drama: video-timestamp anchoring
  - some-schedule: 12-state FSM
  - tab-tracker: active-only time model
  - some-styles: UnoCSS + shadcn tokens

## Type of Change

- [x] New feature (documentation infrastructure + content)
- [x] This change requires a documentation update (it _is_ the documentation update)

## Checklist

- [x] Documentation follows repo conventions
- [x] All workspace architecture docs follow the D1 template
- [x] All workspace ADRs follow the lightweight template format
- [x] Storybook landing page is pinned first via `storySort`
- [x] No breaking changes
- [x] No new warnings introduced

## Next steps

Issues #333 (D3—dev workflow docs) and #335 (D5—security posture docs) remain open. #334 (D4—feature status matrix) will be addressed separately.


---
_Generated by [Claude Code](https://claude.ai/code/session_011wKNnbi1aoVMWypTrPZTNW)_