### PR TITLE
Refactor interview session into reusable hook and adapter pattern

### DIFF
--- a/packages/ui/chat/package.json
+++ b/packages/ui/chat/package.json
@@ -18,9 +18,11 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.0.3",
     "@some-ui/styles": "workspace:*",
+    "@types/react": "^19.0.4",
     "lucide-react": "^0.562.0",
     "some-ui-shared": "workspace:*",
-    "some-ui-utils": "workspace:*"
+    "some-ui-utils": "workspace:*",
+    "zod": "4.0.5"
   },
   "devDependencies": {
     "@some-ui/tsconfig": "workspace:*",

--- a/packages/ui/chat/src/components/mock-interview/audio-player/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/audio-player/index.tsx
@@ -6,14 +6,14 @@ export const AudioPlayer = ({ url }: { url: string }): React.JSX.Element => {
   const audioRef = useRef<HTMLAudioElement>(null)
 
   const togglePlay = (): void => {
-    if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.pause()
-      } else {
-        audioRef.current.play()
-      }
-      setIsPlaying(!isPlaying)
+    if (!audioRef.current) return
+
+    if (isPlaying) {
+      audioRef.current.pause()
+    } else {
+      void audioRef.current.play()
     }
+    setIsPlaying(!isPlaying)
   }
 
   return (
@@ -31,6 +31,7 @@ export const AudioPlayer = ({ url }: { url: string }): React.JSX.Element => {
       <div className="flex-1">
         <p className="text-sm text-muted-foreground">Recording preview</p>
       </div>
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption -- user's own unscripted recording, no caption track exists */}
       <audio
         ref={audioRef}
         src={url}

--- a/packages/ui/chat/src/components/mock-interview/index.ts
+++ b/packages/ui/chat/src/components/mock-interview/index.ts
@@ -1,1 +1,2 @@
 export { InterviewApp } from "./interview-app"
+export type { InterviewPresentationMode } from "./interview-app"

--- a/packages/ui/chat/src/components/mock-interview/interview-app/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/interview-app/index.tsx
@@ -1,115 +1,36 @@
-import { useState } from "react"
-import { PreparationPhase } from "@chat/components/mock-interview/preparation-phase"
-import { QuestionPlayback } from "@chat/components/mock-interview/question-playback"
-import { RecordingPhase } from "@chat/components/mock-interview/recording-phase"
-import { ReviewPhase } from "@chat/components/mock-interview/review-phase"
-import { WelcomeScreen } from "@chat/components/mock-interview/welcome-screen"
+import { SlideshowPresenter } from "@chat/components/mock-interview/interview-app/slideshow-presenter"
+import type {
+  UseInterviewSessionConfig,
+} from "@chat/hooks/use-interview-session"
+import { useInterviewSession } from "@chat/hooks/use-interview-session"
 
-// Mock interview questions
-const mockQuestions = [
-  {
-    id: "q1",
-    level: "mid",
-    category: "system-design",
-    question:
-      "Design a URL shortening service like bit.ly. Consider scalability, database design, and API endpoints.",
-    durationSeconds: 120,
-  },
-  {
-    id: "q2",
-    level: "mid",
-    category: "behavioral",
-    question:
-      "Tell me about a time when you had to resolve a conflict within your team. How did you approach it?",
-    durationSeconds: 90,
-  },
-  {
-    id: "q3",
-    level: "senior",
-    category: "technical",
-    question:
-      "Explain how you would optimize a slow database query. What tools and techniques would you use?",
-    durationSeconds: 100,
-  },
-]
+/**
+ * How the session is presented to the user. Only "slideshow" (paginated,
+ * one question at a time) ships today. "chat" is reserved for an
+ * animated chat/voice presenter - `useInterviewSession` already returns
+ * UI-agnostic state and actions, so adding it later means writing a new
+ * presenter component, not touching session logic.
+ */
+export type InterviewPresentationMode = "slideshow" | "chat"
 
-type Phase = "welcome" | "question" | "preparation" | "recording" | "review"
+type InterviewAppProps = {
+  mode?: InterviewPresentationMode
+  sessionConfig?: UseInterviewSessionConfig
+}
 
-export const InterviewApp = (): React.JSX.Element | null => {
-  const [phase, setPhase] = useState<Phase>("welcome")
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0)
-  const [transcript, setTranscript] = useState("")
-  const [notes, setNotes] = useState("")
-  const currentQuestion = mockQuestions[currentQuestionIndex]
-  const isLastQuestion = currentQuestionIndex === mockQuestions.length - 1
+export const InterviewApp = ({
+  mode = "slideshow",
+  sessionConfig,
+}: InterviewAppProps): React.JSX.Element | null => {
+  const session = useInterviewSession(sessionConfig)
 
-  const handleStartInterview = (): void => {
-    setPhase("question")
-  }
-  const handleQuestionComplete = (): void => {
-    setPhase("preparation")
-  }
-  const handleStartRecording = (): void => {
-    setPhase("recording")
-  }
-  const handleRecordingComplete = (recordedTranscript: string): void => {
-    setTranscript(recordedTranscript)
-    setPhase("review")
-  }
-  const handleContinue = (): void => {
-    if (isLastQuestion) {
-      // Could show completion screen
-      setPhase("welcome")
-      setCurrentQuestionIndex(0)
-      setTranscript("")
-      setNotes("")
-    } else {
-      setCurrentQuestionIndex((prev) => prev + 1)
-      setPhase("question")
-      setTranscript("")
-      setNotes("")
-    }
-  }
-  const handleRetry = (): void => {
-    setPhase("preparation")
-    setTranscript("")
-  }
-
-  if (!currentQuestion) return null
+  // The chat/voice presenter doesn't exist yet - fall back to slideshow
+  // rather than rendering nothing.
+  void mode
 
   return (
     <main className="min-h-screen bg-background">
-      {phase === "welcome" && <WelcomeScreen onStart={handleStartInterview} />}
-      {phase === "question" && (
-        <QuestionPlayback
-          question={currentQuestion}
-          questionNumber={currentQuestionIndex + 1}
-          totalQuestions={mockQuestions.length}
-          onComplete={handleQuestionComplete}
-        />
-      )}
-      {phase === "preparation" && (
-        <PreparationPhase
-          question={currentQuestion.question}
-          notes={notes}
-          onNotesChange={setNotes}
-          onStartRecording={handleStartRecording}
-        />
-      )}
-      {phase === "recording" && (
-        <RecordingPhase
-          question={currentQuestion.question}
-          onComplete={handleRecordingComplete}
-        />
-      )}
-      {phase === "review" && (
-        <ReviewPhase
-          transcript={transcript}
-          onContinue={handleContinue}
-          onRetry={handleRetry}
-          isLastQuestion={isLastQuestion}
-        />
-      )}
+      <SlideshowPresenter session={session} />
     </main>
   )
 }

--- a/packages/ui/chat/src/components/mock-interview/interview-app/slideshow-presenter.tsx
+++ b/packages/ui/chat/src/components/mock-interview/interview-app/slideshow-presenter.tsx
@@ -1,0 +1,103 @@
+import { InterviewProgressHeader } from "@chat/components/mock-interview/progress-header"
+import { PreparationPhase } from "@chat/components/mock-interview/preparation-phase"
+import { QuestionPlayback } from "@chat/components/mock-interview/question-playback"
+import { RecordingPhase } from "@chat/components/mock-interview/recording-phase"
+import { ReviewPhase } from "@chat/components/mock-interview/review-phase"
+import { SessionComplete } from "@chat/components/mock-interview/session-complete"
+import { WelcomeScreen } from "@chat/components/mock-interview/welcome-screen"
+import type { UseInterviewSessionReturn } from "@chat/hooks/use-interview-session"
+
+type SlideshowPresenterProps = {
+  session: UseInterviewSessionReturn
+}
+
+/**
+ * Renders the session state as a paginated, one-question-at-a-time flow.
+ * All session logic lives in `useInterviewSession` - this component only
+ * maps phase -> screen, so a future `ChatVoicePresenter` can consume the
+ * exact same hook without touching session state.
+ */
+export const SlideshowPresenter = ({
+  session,
+}: SlideshowPresenterProps): React.JSX.Element | null => {
+  const {
+    state,
+    currentQuestion,
+    isLastQuestion,
+    progress,
+    recording,
+    ttsAdapter,
+    resumeAvailable,
+    actions,
+  } = session
+
+  if (state.phase === "welcome") {
+    return (
+      <WelcomeScreen
+        onStart={actions.start}
+        resumeAvailable={resumeAvailable}
+        onResume={actions.resumeSession}
+        onDiscardResume={actions.discardResume}
+      />
+    )
+  }
+
+  if (state.phase === "complete") {
+    return (
+      <SessionComplete
+        answers={state.answers}
+        questions={state.questions}
+        onRestart={actions.restart}
+      />
+    )
+  }
+
+  if (!currentQuestion) return null
+
+  return (
+    <div className="pb-16">
+      <InterviewProgressHeader
+        current={progress.current}
+        total={progress.total}
+        phase={state.phase}
+      />
+
+      {state.phase === "question" && (
+        <QuestionPlayback
+          question={currentQuestion}
+          questionNumber={progress.current}
+          totalQuestions={progress.total}
+          ttsAdapter={ttsAdapter}
+          onComplete={actions.questionPlaybackDone}
+        />
+      )}
+
+      {state.phase === "preparation" && (
+        <PreparationPhase
+          question={currentQuestion.question}
+          notes={state.notes}
+          onNotesChange={actions.setNotes}
+          onStartRecording={actions.beginRecording}
+        />
+      )}
+
+      {state.phase === "recording" && (
+        <RecordingPhase
+          question={currentQuestion.question}
+          recording={recording}
+        />
+      )}
+
+      {(state.phase === "transcribing" || state.phase === "review") && (
+        <ReviewPhase
+          audioUrl={state.audioUrl}
+          transcription={state.transcription}
+          onTranscriptChange={actions.editTranscript}
+          onContinue={actions.continueSession}
+          onRetry={actions.retryAnswer}
+          isLastQuestion={isLastQuestion}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/ui/chat/src/components/mock-interview/preparation-phase/index.stories.tsx
+++ b/packages/ui/chat/src/components/mock-interview/preparation-phase/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { PreparationPhase } from "."
+
+const meta = {
+  title: "UI/Chat/Interview/PreparationPhase",
+  component: PreparationPhase,
+} satisfies Meta<typeof PreparationPhase>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    question:
+      "Design a URL shortening service like bit.ly. Consider scalability, database design, and API endpoints.",
+    notes: "",
+    onNotesChange: () => {},
+    onStartRecording: () => {},
+  },
+}
+
+export const WithNotes: Story = {
+  args: {
+    ...Default.args,
+    notes: "Start with requirements: read/write ratio, custom aliases, expiry.",
+  },
+}

--- a/packages/ui/chat/src/components/mock-interview/preparation-phase/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/preparation-phase/index.tsx
@@ -14,7 +14,7 @@ export const PreparationPhase = ({
   onStartRecording,
 }: PreparationPhaseProps): React.JSX.Element => {
   return (
-    <div className="flex absolute inset-0 items-center justify-center p-6">
+    <div className="flex min-h-screen items-center justify-center p-6">
       <div className="max-w-3xl w-full space-y-6">
         <Card className="p-8 md:p-12 space-y-8">
           <div className="space-y-6">
@@ -34,7 +34,9 @@ export const PreparationPhase = ({
               <Textarea
                 placeholder="Your private notes (optional)..."
                 value={notes}
-                onChange={(e) => onNotesChange(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  onNotesChange(e.target.value)
+                }
                 className="min-h-32 resize-none bg-background/50 border-muted"
               />
             </div>
@@ -51,14 +53,14 @@ export const PreparationPhase = ({
 
             <div className="text-center space-y-4">
               <p className="text-muted-foreground">
-                When you're ready, you can start speaking
+                When you&apos;re ready, you can start speaking
               </p>
               <Button
                 size="lg"
                 onClick={onStartRecording}
                 className="px-12 rounded-full"
               >
-                I'm ready to speak
+                I&apos;m ready to speak
               </Button>
             </div>
           </div>

--- a/packages/ui/chat/src/components/mock-interview/progress-header/index.stories.tsx
+++ b/packages/ui/chat/src/components/mock-interview/progress-header/index.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { InterviewProgressHeader } from "."
+
+const meta = {
+  title: "UI/Chat/Interview/ProgressHeader",
+  component: InterviewProgressHeader,
+} satisfies Meta<typeof InterviewProgressHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Question: Story = {
+  args: { current: 1, total: 5, phase: "question" },
+}
+
+export const Recording: Story = {
+  args: { current: 3, total: 5, phase: "recording" },
+}
+
+export const Review: Story = {
+  args: { current: 5, total: 5, phase: "review" },
+}

--- a/packages/ui/chat/src/components/mock-interview/progress-header/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/progress-header/index.tsx
@@ -1,0 +1,47 @@
+import { Progress } from "some-ui-shared"
+
+import type { InterviewPhase } from "@chat/lib/interview/core/interview-types"
+
+const PHASE_LABEL: Partial<Record<InterviewPhase, string>> = {
+  question: "Listening",
+  preparation: "Reflecting",
+  recording: "Recording",
+  transcribing: "Transcribing",
+  review: "Reviewing",
+}
+
+const PHASE_WEIGHT: Partial<Record<InterviewPhase, number>> = {
+  question: 0.1,
+  preparation: 0.35,
+  recording: 0.65,
+  transcribing: 0.85,
+  review: 1,
+}
+
+type InterviewProgressHeaderProps = {
+  current: number
+  total: number
+  phase: InterviewPhase
+}
+
+export const InterviewProgressHeader = ({
+  current,
+  total,
+  phase,
+}: InterviewProgressHeaderProps): React.JSX.Element => {
+  const completedSteps = current - 1 + (PHASE_WEIGHT[phase] ?? 0)
+  const value = total > 0 ? Math.min(100, (completedSteps / total) * 100) : 0
+  const label = PHASE_LABEL[phase]
+
+  return (
+    <div className="max-w-3xl w-full mx-auto px-6 pt-6 space-y-2">
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>
+          Question {current} of {total}
+        </span>
+        {label && <span aria-live="polite">{label}</span>}
+      </div>
+      <Progress value={value} className="h-1.5" />
+    </div>
+  )
+}

--- a/packages/ui/chat/src/components/mock-interview/question-playback/index.stories.tsx
+++ b/packages/ui/chat/src/components/mock-interview/question-playback/index.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import type { InterviewTTSAdapter } from "@chat/lib/interview/core/interview-types"
+
+import { QuestionPlayback } from "."
+
+const question = {
+  id: "system-design-1",
+  level: "mid" as const,
+  category: "system-design" as const,
+  question:
+    "Design a URL shortening service like bit.ly. Consider scalability, database design, and API endpoints.",
+  durationSeconds: 120,
+}
+
+const mockSupportedAdapter: InterviewTTSAdapter = {
+  supported: true,
+  speak: (text, opts) =>
+    new Promise((resolve) => {
+      opts?.onBoundary?.(Math.floor(text.length / 2), 1)
+      setTimeout(resolve, 1500)
+    }),
+  stop: () => {},
+}
+
+const unsupportedAdapter: InterviewTTSAdapter = {
+  supported: false,
+  speak: async () => {},
+  stop: () => {},
+}
+
+const meta = {
+  title: "UI/Chat/Interview/QuestionPlayback",
+  component: QuestionPlayback,
+} satisfies Meta<typeof QuestionPlayback>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    question,
+    questionNumber: 1,
+    totalQuestions: 3,
+    ttsAdapter: mockSupportedAdapter,
+    onComplete: () => {},
+  },
+}
+
+export const PlaybackUnsupported: Story = {
+  args: {
+    ...Default.args,
+    ttsAdapter: unsupportedAdapter,
+  },
+}

--- a/packages/ui/chat/src/components/mock-interview/question-playback/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/question-playback/index.tsx
@@ -2,18 +2,16 @@ import { useEffect, useRef, useState } from "react"
 import { Pause, Play, RotateCcw } from "lucide-react"
 import { Button, Card } from "some-ui-shared"
 
-type Question = {
-  id: string
-  level: string
-  category: string
-  question: string
-  durationSeconds: number
-}
+import type {
+  InterviewTTSAdapter,
+  Question,
+} from "@chat/lib/interview/core/interview-types"
 
 type QuestionPlaybackProps = {
   question: Question
   questionNumber: number
   totalQuestions: number
+  ttsAdapter: InterviewTTSAdapter
   onComplete: () => void
 }
 
@@ -21,49 +19,54 @@ export const QuestionPlayback = ({
   question,
   questionNumber,
   totalQuestions,
+  ttsAdapter,
   onComplete,
 }: QuestionPlaybackProps): React.JSX.Element => {
   const [isPlaying, setIsPlaying] = useState(false)
   const [progress, setProgress] = useState(0)
   const [showMetadata, setShowMetadata] = useState(false)
-  const intervalRef = useRef<ReturnType<typeof setInterval>>(null)
-
-  // Simulate TTS playback (5 seconds)
-  const playbackDuration = 5000
+  const playTokenRef = useRef(0)
 
   useEffect(() => {
-    if (isPlaying) {
-      const startTime = Date.now()
-      intervalRef.current = setInterval(() => {
-        const elapsed = Date.now() - startTime
-        const newProgress = Math.min((elapsed / playbackDuration) * 100, 100)
-        setProgress(newProgress)
-
-        if (newProgress >= 100) {
-          setIsPlaying(false)
-          setProgress(100)
-        }
-      }, 50)
-    }
     return (): void => {
-      if (intervalRef.current) clearInterval(intervalRef.current)
+      ttsAdapter.stop()
     }
-  }, [isPlaying])
+  }, [ttsAdapter])
 
-  const handlePlay = (): void => {
-    if (progress >= 100) {
-      setProgress(0)
-    }
+  const speak = (): void => {
+    const token = ++playTokenRef.current
     setIsPlaying(true)
+
+    void ttsAdapter
+      .speak(question.question, {
+        onBoundary: (charIndex) => {
+          if (playTokenRef.current !== token) return
+          setProgress(
+            Math.min(100, (charIndex / question.question.length) * 100)
+          )
+        },
+      })
+      .then(() => {
+        if (playTokenRef.current !== token) return
+        setIsPlaying(false)
+        setProgress(100)
+      })
   }
 
-  const handlePause = (): void => {
+  const handlePlay = (): void => {
+    if (progress >= 100) setProgress(0)
+    speak()
+  }
+
+  const handleStop = (): void => {
+    playTokenRef.current += 1
+    ttsAdapter.stop()
     setIsPlaying(false)
   }
 
   const handleReplay = (): void => {
     setProgress(0)
-    setIsPlaying(true)
+    speak()
   }
 
   return (
@@ -97,69 +100,78 @@ export const QuestionPlayback = ({
               )}
             </div>
 
-            {/* Waveform visualization */}
-            <div className="space-y-4">
-              <div className="flex items-center gap-2 h-16 justify-center">
-                {[...Array(32)].map((_, i) => {
-                  const height = isPlaying
-                    ? Math.sin(progress * 0.1 + i * 0.5) * 20 + 30
-                    : 20
-                  return (
+            {ttsAdapter.supported ? (
+              <>
+                {/* Waveform visualization */}
+                <div className="space-y-4">
+                  <div className="flex items-center gap-2 h-16 justify-center">
+                    {[...Array(32)].map((_, i) => {
+                      const height = isPlaying
+                        ? Math.sin(progress * 0.1 + i * 0.5) * 20 + 30
+                        : 20
+                      return (
+                        <div
+                          key={i}
+                          className="w-1 bg-primary/30 rounded-full transition-all duration-100"
+                          style={{ height: `${height}%` }}
+                        />
+                      )
+                    })}
+                  </div>
+
+                  {/* Progress bar */}
+                  <div className="w-full h-1 bg-muted rounded-full overflow-hidden">
                     <div
-                      key={i}
-                      className="w-1 bg-primary/30 rounded-full transition-all duration-100"
-                      style={{ height: `${height}%` }}
+                      className="h-full bg-primary/50 transition-all duration-100"
+                      style={{ width: `${progress}%` }}
                     />
-                  )
-                })}
-              </div>
+                  </div>
+                </div>
 
-              {/* Progress bar */}
-              <div className="w-full h-1 bg-muted rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-primary/50 transition-all duration-100"
-                  style={{ width: `${progress}%` }}
-                />
-              </div>
-            </div>
+                {/* Controls */}
+                <div className="flex items-center justify-center gap-4">
+                  {!isPlaying ? (
+                    <Button
+                      size="lg"
+                      onClick={handlePlay}
+                      className="gap-2 rounded-full px-8"
+                    >
+                      <Play className="w-4 h-4" />
+                      {progress > 0 && progress < 100 ? "Resume" : "Play"}
+                    </Button>
+                  ) : (
+                    <Button
+                      size="lg"
+                      variant="secondary"
+                      onClick={handleStop}
+                      className="gap-2 rounded-full px-8"
+                    >
+                      <Pause className="w-4 h-4" />
+                      Stop
+                    </Button>
+                  )}
 
-            {/* Controls */}
-            <div className="flex items-center justify-center gap-4">
-              {!isPlaying ? (
-                <Button
-                  size="lg"
-                  onClick={handlePlay}
-                  className="gap-2 rounded-full px-8"
-                >
-                  <Play className="w-4 h-4" />
-                  {progress > 0 && progress < 100 ? "Resume" : "Play"}
-                </Button>
-              ) : (
-                <Button
-                  size="lg"
-                  variant="secondary"
-                  onClick={handlePause}
-                  className="gap-2 rounded-full px-8"
-                >
-                  <Pause className="w-4 h-4" />
-                  Pause
-                </Button>
-              )}
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    onClick={handleReplay}
+                    className="gap-2 rounded-full bg-transparent"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                    Replay
+                  </Button>
+                </div>
 
-              <Button
-                size="lg"
-                variant="outline"
-                onClick={handleReplay}
-                className="gap-2 rounded-full bg-transparent"
-              >
-                <RotateCcw className="w-4 h-4" />
-                Replay
-              </Button>
-            </div>
-
-            <p className="text-center text-sm text-muted-foreground">
-              Listen as many times as you'd like
-            </p>
+                <p className="text-center text-sm text-muted-foreground">
+                  Listen as many times as you&apos;d like
+                </p>
+              </>
+            ) : (
+              <p className="text-center text-sm text-muted-foreground">
+                Playback isn&apos;t available in this browser — read the
+                question above whenever you&apos;re ready
+              </p>
+            )}
           </div>
         </Card>
 

--- a/packages/ui/chat/src/components/mock-interview/recording-phase/index.stories.tsx
+++ b/packages/ui/chat/src/components/mock-interview/recording-phase/index.stories.tsx
@@ -1,30 +1,41 @@
-// RecordingPhase.stories.tsx
-import { useEffect, useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import type { UseAudioRecorderReturn } from "@chat/hooks/use-audio-recorder"
+import type { RecordingState } from "@chat/types/interview"
 
 import { RecordingPhase } from "."
 
-// 🌐 CRITICAL: Global iframe permission config (applies to ALL stories needing mic)
+const noop = (): void => {}
+const asyncNoop = async (): Promise<void> => {}
+
+const buildRecording = (
+  state: RecordingState,
+  overrides: Partial<UseAudioRecorderReturn> = {}
+): UseAudioRecorderReturn => ({
+  state,
+  elapsedTime: 0,
+  stream: null,
+  startRecording: asyncNoop,
+  pauseRecording: noop,
+  resumeRecording: noop,
+  stopRecording: asyncNoop,
+  reset: noop,
+  retry: noop,
+  ...overrides,
+})
+
+const question =
+  "Describe your approach to designing a scalable URL shortener service."
+
 const meta = {
   title: "UI/Chat/Interview/RecordingPhase",
   component: RecordingPhase,
   parameters: {
-    // ✨ THIS IS THE KEY THAT BUSTS THE MYTH ✨
-    iframe: {
-      allow: "microphone",
-    },
-    // Optional: Prevent accidental mic spam during story browsing
-    chromatic: { disableSnapshot: true },
-  },
-  argTypes: {
-    onComplete: {
-      action: "transcript-submitted",
-      description: "Called when recording is processed with final transcript",
-    },
-    question: {
-      control: "text",
-      defaultValue:
-        "Describe your approach to designing a scalable URL shortener service.",
+    docs: {
+      description: {
+        component:
+          "Every mic state is driven by a stubbed `recording` prop, so this can be reviewed without granting real microphone access.",
+      },
     },
   },
 } satisfies Meta<typeof RecordingPhase>
@@ -32,142 +43,77 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-// 🎯 PRIMARY STORY: REAL MICROPHONE WORKFLOW (Mythbuster Proof)
-export const Default: Story = {
+export const Idle: Story = {
   args: {
-    onComplete: () => {},
-  },
-  // 💡 Pro Tip: Add visual cue that interaction is required
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "✅ **MICROPHONE WORKS IN STORYBOOK!**\n\n" +
-          "1. Click 'Start speaking' button (user gesture required by browser)\n" +
-          "2. Grant microphone permission when prompted\n" +
-          "3. Recording UI will activate immediately\n\n" +
-          "*Requires localhost or HTTPS. If prompt doesn't appear:*\n" +
-          "- Check browser permissions (chrome://settings/content/microphone)\n" +
-          "- Ensure Storybook is running on http://localhost",
-      },
-    },
+    question,
+    recording: buildRecording({ type: "idle" }),
   },
 }
 
-// 🎭 SMART MOCK: Permission Denied State (No real mic needed)
+export const RequestingPermission: Story = {
+  args: {
+    question,
+    recording: buildRecording({ type: "requesting_permission" }),
+  },
+}
+
 export const PermissionDenied: Story = {
-  ...Default,
-  render: (args) => {
-    // Mock ONLY for this story - doesn't affect other stories
-    const [isMockActive, setIsMockActive] = useState(false)
-
-    useEffect(() => {
-      if (!isMockActive) return
-
-      // Temporarily override getUserMedia to reject
-      const original = navigator.mediaDevices.getUserMedia
-      navigator.mediaDevices.getUserMedia = () =>
-        Promise.reject(new DOMException("Permission denied", "NotAllowedError"))
-
-      return () => {
-        navigator.mediaDevices.getUserMedia = original
-      }
-    }, [isMockActive])
-
-    return (
-      <div className="p-4 border-l-4 border-destructive/20 bg-destructive/5 rounded-r">
-        <p className="text-sm text-destructive mb-2 font-medium">
-          🎯 Mock Mode Active: Click button below to simulate permission denial
-        </p>
-        <button
-          onClick={() => setIsMockActive(true)}
-          className="mb-4 px-4 py-2 bg-destructive text-white rounded hover:bg-destructive/90 transition"
-        >
-          Activate Permission Denied Mock
-        </button>
-        {isMockActive && <RecordingPhase {...args} />}
-      </div>
-    )
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "🛡️ **Safe preview of permission denied state**\n\n" +
-          "1. Click 'Activate Permission Denied Mock' button\n" +
-          "2. Then click 'Start speaking' in component\n" +
-          "3. UI instantly shows denial state (no browser prompt)\n\n" +
-          "*Real microphone never requested - safe for CI/docs*",
-      },
-    },
+  args: {
+    question,
+    recording: buildRecording({
+      type: "permission_denied",
+      error:
+        "Microphone permission denied. Please enable access in your browser.",
+    }),
   },
 }
 
-// 📦 BONUS: Success State Mock (Show completed flow)
-export const SuccessState: Story = {
-  render: () => {
-    // Simulate success state without recording
-    const [state, setState] = useState<"idle" | "success">("idle")
-
-    if (state === "idle") {
-      return (
-        <div className="p-8 text-center">
-          <button
-            onClick={() => setState("success")}
-            className="px-6 py-3 bg-primary text-primary-foreground rounded-full hover:bg-primary/90"
-          >
-            Show Success State Mock
-          </button>
-          <p className="mt-2 text-sm text-muted-foreground">
-            (Simulates post-recording UI with audio player)
-          </p>
-        </div>
-      )
-    }
-
-    // Hardcoded success state data
-    return (
-      <div className="flex min-h-screen items-center justify-center p-6 bg-background">
-        <div className="max-w-3xl w-full space-y-6">
-          <div className="p-8 md:p-12 space-y-8 bg-card border border-border rounded-lg shadow-sm">
-            <div className="space-y-6">
-              <div className="space-y-4">
-                <h2 className="text-xl font-medium text-foreground">
-                  The question
-                </h2>
-                <p className="text-base leading-relaxed text-muted-foreground">
-                  Describe your approach to designing a scalable URL shortener
-                  service.
-                </p>
-              </div>
-
-              <div className="flex flex-col items-center justify-center space-y-8 py-8">
-                <div className="w-full space-y-4">
-                  {/* Mock audio player with placeholder */}
-                  <div className="border rounded-lg p-4 bg-muted flex items-center justify-center">
-                    <span className="text-muted-foreground">
-                      🔊 Mock Audio Player (Success State)
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-center gap-2 text-sm text-primary">
-                    <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-                    <span>Uploading and transcribing...</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    )
+export const Recording: Story = {
+  args: {
+    question,
+    recording: buildRecording(
+      { type: "recording", startTime: Date.now() },
+      { elapsedTime: 42 }
+    ),
   },
-  parameters: {
-    iframe: { allow: "" }, // No mic needed for this mock
-    docs: {
-      description: {
-        story:
-          "✅ **Completed flow preview** - Shows UI after successful recording/upload",
-      },
-    },
+}
+
+export const Paused: Story = {
+  args: {
+    question,
+    recording: buildRecording(
+      { type: "paused", startTime: Date.now(), elapsedBeforePause: 37 },
+      { elapsedTime: 37 }
+    ),
+  },
+}
+
+export const Processing: Story = {
+  args: {
+    question,
+    recording: buildRecording({ type: "processing" }),
+  },
+}
+
+export const Success: Story = {
+  args: {
+    question,
+    recording: buildRecording({
+      type: "success",
+      audioBlob: new Blob(),
+      audioUrl: "",
+      duration: 58,
+    }),
+  },
+}
+
+export const ErrorState: Story = {
+  args: {
+    question,
+    recording: buildRecording({
+      type: "error",
+      error: "Network error: Failed to upload recording",
+      canRetry: true,
+    }),
   },
 }

--- a/packages/ui/chat/src/components/mock-interview/recording-phase/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/recording-phase/index.tsx
@@ -1,32 +1,56 @@
+import { useEffect } from "react"
 import { AudioPlayer } from "@chat/components/mock-interview/audio-player"
-import { useAudioRecorder } from "@chat/hooks/use-audio-recorder"
+import type { UseAudioRecorderReturn } from "@chat/hooks/use-audio-recorder"
+import { useAudioLevel } from "@chat/hooks/use-audio-level"
+import { formatTime } from "@chat/lib/interview/format-time"
 import { AlertCircle, Loader2, Mic, RotateCcw, Square } from "lucide-react"
-
-const formatTime = (seconds: number): string => {
-  const mins = Math.floor(seconds / 60)
-  const secs = seconds % 60
-  return `${mins}:${secs.toString().padStart(2, "0")}`
-}
 
 type RecordingPhaseProps = {
   question: string
-  onComplete: (transcript: string) => void
+  recording: UseAudioRecorderReturn
 }
 
 export const RecordingPhase = ({
   question,
-  onComplete,
+  recording,
 }: RecordingPhaseProps): React.JSX.Element => {
   const {
     state,
     elapsedTime,
+    stream,
     startRecording,
     pauseRecording,
     resumeRecording,
     stopRecording,
     reset,
     retry,
-  } = useAudioRecorder(onComplete)
+  } = recording
+
+  const levels = useAudioLevel(stream)
+
+  // Space bar toggles start/stop so practicing doesn't require reaching for the mouse
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.code !== "Space") return
+      if (
+        e.target instanceof HTMLElement &&
+        ["TEXTAREA", "INPUT"].includes(e.target.tagName)
+      ) {
+        return
+      }
+
+      if (state.type === "idle" || state.type === "error") {
+        e.preventDefault()
+        void startRecording()
+      } else if (state.type === "recording") {
+        e.preventDefault()
+        void stopRecording()
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return (): void => window.removeEventListener("keydown", onKeyDown)
+  }, [state.type, startRecording, stopRecording])
 
   return (
     <div className="flex min-h-screen items-center justify-center p-6 bg-background">
@@ -43,7 +67,10 @@ export const RecordingPhase = ({
             </div>
 
             {/* State-based rendering */}
-            <div className="flex flex-col items-center justify-center space-y-8 py-8">
+            <div
+              className="flex flex-col items-center justify-center space-y-8 py-8"
+              aria-live="polite"
+            >
               {/* Idle State */}
               {state.type === "idle" && (
                 <>
@@ -60,7 +87,7 @@ export const RecordingPhase = ({
                     Start speaking
                   </button>
                   <p className="text-center text-sm text-muted-foreground">
-                    Click to begin recording your answer
+                    Click to begin recording your answer, or press space
                   </p>
                 </>
               )}
@@ -120,6 +147,19 @@ export const RecordingPhase = ({
                   <p className="text-2xl font-mono text-foreground">
                     {formatTime(elapsedTime)}
                   </p>
+
+                  <div
+                    className="flex items-center gap-1 h-10 justify-center w-full max-w-md"
+                    aria-hidden="true"
+                  >
+                    {levels.map((level, i) => (
+                      <div
+                        key={i}
+                        className="w-1 bg-primary/50 rounded-full transition-[height] duration-75"
+                        style={{ height: `${Math.round(level * 100)}%` }}
+                      />
+                    ))}
+                  </div>
 
                   <div className="flex items-center gap-4">
                     <button
@@ -205,7 +245,7 @@ export const RecordingPhase = ({
                   <AudioPlayer url={state.audioUrl} />
                   <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
                     <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Uploading and transcribing...</span>
+                    <span>Sending for transcription...</span>
                   </div>
                 </div>
               )}

--- a/packages/ui/chat/src/components/mock-interview/review-phase/index.stories.tsx
+++ b/packages/ui/chat/src/components/mock-interview/review-phase/index.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { ReviewPhase } from "."
+
+const meta = {
+  title: "UI/Chat/Interview/ReviewPhase",
+  component: ReviewPhase,
+} satisfies Meta<typeof ReviewPhase>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const baseArgs = {
+  audioUrl: null,
+  onTranscriptChange: () => {},
+  onContinue: () => {},
+  onRetry: () => {},
+  isLastQuestion: false,
+}
+
+export const Pending: Story = {
+  args: {
+    ...baseArgs,
+    transcription: { status: "pending" },
+  },
+}
+
+export const Processing: Story = {
+  args: {
+    ...baseArgs,
+    transcription: { status: "processing" },
+  },
+}
+
+export const Done: Story = {
+  args: {
+    ...baseArgs,
+    transcription: {
+      status: "done",
+      transcript:
+        "I'd start by clarifying the read/write ratio and scale targets, then sketch the API surface before touching storage.",
+    },
+  },
+}
+
+export const Error: Story = {
+  args: {
+    ...baseArgs,
+    transcription: {
+      status: "error",
+      error: "Network error: failed to transcribe recording",
+    },
+  },
+}
+
+export const LastQuestion: Story = {
+  args: {
+    ...baseArgs,
+    isLastQuestion: true,
+    transcription: { status: "done", transcript: "That wraps up my answer." },
+  },
+}

--- a/packages/ui/chat/src/components/mock-interview/review-phase/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/review-phase/index.tsx
@@ -1,43 +1,69 @@
-import { useState } from "react"
-import { Loader2 } from "lucide-react"
+import { AlertCircle, Loader2 } from "lucide-react"
 import { Button, Card, Textarea } from "some-ui-shared"
 
+import { AudioPlayer } from "@chat/components/mock-interview/audio-player"
+import type { TranscriptionResult } from "@chat/lib/interview/core/interview-types"
+
 type ReviewPhaseProps = {
-  transcript: string
+  audioUrl: string | null
+  transcription: TranscriptionResult | null
+  onTranscriptChange: (transcript: string) => void
   onContinue: () => void
   onRetry: () => void
   isLastQuestion: boolean
 }
 
 export const ReviewPhase = ({
-  transcript,
+  audioUrl,
+  transcription,
+  onTranscriptChange,
   onContinue,
   onRetry,
   isLastQuestion,
 }: ReviewPhaseProps): React.JSX.Element => {
-  const [isTranscribing, setIsTranscribing] = useState(true)
-  const [editedTranscript, setEditedTranscript] = useState("")
+  const status = transcription?.status ?? "pending"
 
-  // Simulate transcription delay
-  useState(() => {
-    setTimeout(() => {
-      setIsTranscribing(false)
-      setEditedTranscript(transcript)
-    }, 2000)
-  })
-
-  if (isTranscribing) {
+  if (status === "pending" || status === "processing") {
     return (
       <div className="flex min-h-screen items-center justify-center p-6">
         <Card className="max-w-2xl w-full p-12">
           <div className="flex flex-col items-center space-y-6">
             <Loader2 className="w-12 h-12 text-primary animate-spin" />
             <div className="text-center space-y-2">
-              <h2 className="text-2xl font-medium">Transcribing...</h2>
+              <h2 className="text-2xl font-medium">
+                {status === "pending" ? "Uploading..." : "Transcribing..."}
+              </h2>
               <p className="text-muted-foreground">
                 This will just take a moment
               </p>
             </div>
+          </div>
+        </Card>
+      </div>
+    )
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-6">
+        <Card className="max-w-2xl w-full p-12">
+          <div className="flex flex-col items-center space-y-6">
+            <div className="w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center">
+              <AlertCircle className="w-8 h-8 text-destructive" />
+            </div>
+            <div className="text-center space-y-2">
+              <h2 className="text-2xl font-medium">Couldn&apos;t transcribe that</h2>
+              <p className="text-muted-foreground">
+                {transcription?.error ?? "Something went wrong. Give it another try."}
+              </p>
+            </div>
+            <Button
+              size="lg"
+              onClick={onRetry}
+              className="px-12 rounded-full"
+            >
+              Record again
+            </Button>
           </div>
         </Card>
       </div>
@@ -52,19 +78,23 @@ export const ReviewPhase = ({
             <div className="space-y-4">
               <h2 className="text-2xl font-medium">Your Response</h2>
               <p className="text-muted-foreground">
-                This is just for you—edit or review as you'd like
+                This is just for you—edit or review as you&apos;d like
               </p>
             </div>
 
+            {audioUrl && <AudioPlayer url={audioUrl} />}
+
             <Textarea
-              value={editedTranscript}
-              onChange={(e) => setEditedTranscript(e.target.value)}
+              value={transcription?.transcript ?? ""}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                onTranscriptChange(e.target.value)
+              }
               className="min-h-48 resize-none leading-relaxed"
             />
 
             <div className="bg-accent/30 rounded-2xl p-6">
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Remember, there's no scoring or evaluation here. This space is
+                Remember, there&apos;s no scoring or evaluation here. This space is
                 for you to practice expressing your thoughts and building
                 confidence.
               </p>

--- a/packages/ui/chat/src/components/mock-interview/session-complete/index.stories.tsx
+++ b/packages/ui/chat/src/components/mock-interview/session-complete/index.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import type { Question, SessionAnswer } from "@chat/lib/interview/core/interview-types"
+
+import { SessionComplete } from "."
+
+const questions: Array<Question> = [
+  {
+    id: "system-design-1",
+    level: "mid",
+    category: "system-design",
+    question: "Design a URL shortening service like bit.ly.",
+    durationSeconds: 120,
+  },
+  {
+    id: "behavioral-1",
+    level: "mid",
+    category: "behavioral",
+    question: "Tell me about a time you resolved a team conflict.",
+    durationSeconds: 90,
+  },
+]
+
+const answers: Array<SessionAnswer> = [
+  {
+    questionId: "system-design-1",
+    transcript: "I'd start with the read/write ratio...",
+    notes: "",
+    durationSeconds: 118,
+  },
+  {
+    questionId: "behavioral-1",
+    transcript: "There was a stretch where two teammates disagreed...",
+    notes: "",
+    durationSeconds: 76,
+  },
+]
+
+const meta = {
+  title: "UI/Chat/Interview/SessionComplete",
+  component: SessionComplete,
+} satisfies Meta<typeof SessionComplete>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    answers,
+    questions,
+    onRestart: () => {},
+  },
+}

--- a/packages/ui/chat/src/components/mock-interview/session-complete/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/session-complete/index.tsx
@@ -1,0 +1,118 @@
+import { CheckCircle2, PartyPopper, RotateCcw } from "lucide-react"
+import { Badge, Button, Card, SparkleBurst } from "some-ui-shared"
+
+import { formatTime } from "@chat/lib/interview/format-time"
+import type {
+  Question,
+  SessionAnswer,
+} from "@chat/lib/interview/core/interview-types"
+
+type SessionCompleteProps = {
+  answers: Array<SessionAnswer>
+  questions: Array<Question>
+  onRestart: () => void
+}
+
+const CATEGORY_LABEL: Record<Question["category"], string> = {
+  behavioral: "Behavioral",
+  "system-design": "System design",
+  technical: "Technical",
+  leadership: "Leadership",
+}
+
+export const SessionComplete = ({
+  answers,
+  questions,
+  onRestart,
+}: SessionCompleteProps): React.JSX.Element => {
+  const totalSeconds = answers.reduce((sum, a) => sum + a.durationSeconds, 0)
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <div className="max-w-2xl w-full space-y-6">
+        <Card className="p-8 md:p-12 space-y-8 text-center overflow-hidden">
+          <div className="relative flex items-center justify-center">
+            <div className="absolute size-48 pointer-events-none">
+              <SparkleBurst particleCount={90} maxDurationMs={1400} />
+            </div>
+            <div className="relative inline-flex items-center justify-center p-6 rounded-3xl bg-gradient-to-br from-primary/20 to-accent/20">
+              <PartyPopper className="size-14 text-primary" />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <h1 className="text-3xl md:text-4xl font-medium tracking-tight">
+              Nice work, that&apos;s a wrap
+            </h1>
+            <p className="text-muted-foreground text-lg text-pretty">
+              You practiced {answers.length}{" "}
+              {answers.length === 1 ? "question" : "questions"} out loud.
+              That&apos;s the hard part.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="bg-muted/50 rounded-2xl p-6">
+              <div className="text-3xl font-medium">{answers.length}</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Questions practiced
+              </div>
+            </div>
+            <div className="bg-muted/50 rounded-2xl p-6">
+              <div className="text-3xl font-medium">
+                {formatTime(totalSeconds)}
+              </div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Time spent speaking
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-3 text-left">
+            {answers.map((answer) => {
+              const question = questions.find((q) => q.id === answer.questionId)
+              if (!question) return null
+              return (
+                <div
+                  key={answer.questionId}
+                  className="flex items-start gap-3 rounded-xl border border-border p-4"
+                >
+                  <CheckCircle2 className="size-5 text-primary shrink-0 mt-0.5" />
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary" className="text-xs">
+                        {CATEGORY_LABEL[question.category]}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {formatTime(answer.durationSeconds)}
+                      </span>
+                    </div>
+                    <p className="text-sm text-foreground line-clamp-1">
+                      {question.question}
+                    </p>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="bg-accent/30 rounded-2xl p-6">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Come back whenever you want another round. Consistency, not
+              perfection, is what builds confidence for the real thing.
+            </p>
+          </div>
+
+          <Button
+            size="lg"
+            onClick={onRestart}
+            className="w-full sm:w-auto px-12 rounded-full gap-2"
+          >
+            <RotateCcw className="size-4" />
+            Practice again
+          </Button>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/chat/src/components/mock-interview/welcome-screen/index.stories.tsx
+++ b/packages/ui/chat/src/components/mock-interview/welcome-screen/index.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { WelcomeScreen } from "."
+
+const meta = {
+  title: "UI/Chat/Interview/WelcomeScreen",
+  component: WelcomeScreen,
+} satisfies Meta<typeof WelcomeScreen>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onStart: () => {},
+  },
+}
+
+export const ResumeAvailable: Story = {
+  args: {
+    onStart: () => {},
+    resumeAvailable: true,
+    onResume: () => {},
+    onDiscardResume: () => {},
+  },
+}

--- a/packages/ui/chat/src/components/mock-interview/welcome-screen/index.tsx
+++ b/packages/ui/chat/src/components/mock-interview/welcome-screen/index.tsx
@@ -1,11 +1,18 @@
+import { RotateCcw } from "lucide-react"
 import { Button, Card } from "some-ui-shared"
 
 type WelcomeScreenProps = {
   onStart: () => void
+  resumeAvailable?: boolean
+  onResume?: () => void
+  onDiscardResume?: () => void
 }
 
 export const WelcomeScreen = ({
   onStart,
+  resumeAvailable = false,
+  onResume,
+  onDiscardResume,
 }: WelcomeScreenProps): React.JSX.Element => {
   return (
     <div className="flex min-h-screen items-center justify-center p-6">
@@ -16,9 +23,32 @@ export const WelcomeScreen = ({
           </h1>
           <p className="text-lg text-muted-foreground text-pretty leading-relaxed">
             This is a supportive space to practice speaking your thoughts out
-            loud. There's no pressure, no judgment, and no wrong answers.
+            loud. There&apos;s no pressure, no judgment, and no wrong answers.
           </p>
         </div>
+
+        {resumeAvailable && (
+          <div className="bg-primary/10 border border-primary/20 rounded-2xl p-6 space-y-4 text-left">
+            <div className="flex items-center gap-2">
+              <RotateCcw className="size-4 text-primary" />
+              <p className="text-sm font-medium">
+                Welcome back — you have a session in progress
+              </p>
+            </div>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Button onClick={onResume} className="rounded-full">
+                Resume practice
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={onDiscardResume}
+                className="rounded-full"
+              >
+                Start fresh instead
+              </Button>
+            </div>
+          </div>
+        )}
 
         <div className="bg-muted/50 rounded-2xl p-6 space-y-4">
           <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
@@ -27,7 +57,7 @@ export const WelcomeScreen = ({
           <ul className="space-y-3 text-left text-muted-foreground">
             <li className="flex items-start gap-3">
               <span className="text-accent-foreground mt-0.5">•</span>
-              <span>Listen to questions as many times as you'd like</span>
+              <span>Listen to questions as many times as you&apos;d like</span>
             </li>
             <li className="flex items-start gap-3">
               <span className="text-accent-foreground mt-0.5">•</span>
@@ -44,13 +74,15 @@ export const WelcomeScreen = ({
           </ul>
         </div>
 
-        <Button
-          size="lg"
-          onClick={onStart}
-          className="w-full md:w-auto px-12 text-base rounded-full"
-        >
-          Begin when you're ready
-        </Button>
+        {!resumeAvailable && (
+          <Button
+            size="lg"
+            onClick={onStart}
+            className="w-full md:w-auto px-12 text-base rounded-full"
+          >
+            Begin when you&apos;re ready
+          </Button>
+        )}
 
         <p className="text-sm text-muted-foreground">
           Remember: This is practice, not a test

--- a/packages/ui/chat/src/data/index.ts
+++ b/packages/ui/chat/src/data/index.ts
@@ -1,1 +1,2 @@
 export * from "./chat-messages"
+export * from "./interview-questions"

--- a/packages/ui/chat/src/data/interview-questions.ts
+++ b/packages/ui/chat/src/data/interview-questions.ts
@@ -1,0 +1,68 @@
+import type { Question } from "@chat/lib/interview/core/interview-types"
+
+export const interviewQuestions: Array<Question> = [
+  {
+    id: "system-design-1",
+    level: "mid",
+    category: "system-design",
+    question:
+      "Design a URL shortening service like bit.ly. Consider scalability, database design, and API endpoints.",
+    durationSeconds: 120,
+  },
+  {
+    id: "behavioral-1",
+    level: "mid",
+    category: "behavioral",
+    question:
+      "Tell me about a time when you had to resolve a conflict within your team. How did you approach it?",
+    durationSeconds: 90,
+  },
+  {
+    id: "technical-1",
+    level: "senior",
+    category: "technical",
+    question:
+      "Explain how you would optimize a slow database query. What tools and techniques would you use?",
+    durationSeconds: 100,
+  },
+  {
+    id: "behavioral-2",
+    level: "junior",
+    category: "behavioral",
+    question:
+      "Describe a project you're proud of. What was your role, and what would you do differently now?",
+    durationSeconds: 90,
+  },
+  {
+    id: "system-design-2",
+    level: "senior",
+    category: "system-design",
+    question:
+      "Walk me through how you'd design a rate limiter that works across a fleet of API servers.",
+    durationSeconds: 120,
+  },
+  {
+    id: "leadership-1",
+    level: "senior",
+    category: "leadership",
+    question:
+      "How do you communicate a change in priorities to a team that's already deep into the old plan?",
+    durationSeconds: 90,
+  },
+  {
+    id: "technical-2",
+    level: "mid",
+    category: "technical",
+    question:
+      "What's the difference between optimistic and pessimistic concurrency control, and when would you reach for each?",
+    durationSeconds: 100,
+  },
+  {
+    id: "behavioral-3",
+    level: "senior",
+    category: "behavioral",
+    question:
+      "Tell me about a time you disagreed with a decision your manager made. What did you do?",
+    durationSeconds: 90,
+  },
+]

--- a/packages/ui/chat/src/hooks/use-audio-level.ts
+++ b/packages/ui/chat/src/hooks/use-audio-level.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react"
+
+const BAR_COUNT = 32
+const IDLE_LEVEL = 0.08
+const IDLE_LEVELS: Array<number> = Array<number>(BAR_COUNT).fill(IDLE_LEVEL)
+
+/**
+ * Samples a live mic stream into a fixed number of normalized (0..1) bars
+ * via the Web Audio API, so recording UI can react to the user's actual
+ * voice instead of a canned CSS animation. Returns a flat idle array when
+ * there's no stream (not recording, or unsupported browser).
+ */
+export const useAudioLevel = (stream: MediaStream | null): Array<number> => {
+  const [levels, setLevels] = useState<Array<number>>(IDLE_LEVELS)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!stream) return
+    if (typeof window.AudioContext !== "function") return
+
+    const audioCtx = new window.AudioContext()
+    const source = audioCtx.createMediaStreamSource(stream)
+    const analyser = audioCtx.createAnalyser()
+    analyser.fftSize = 128
+    analyser.smoothingTimeConstant = 0.75
+    source.connect(analyser)
+
+    const data = new Uint8Array(analyser.frequencyBinCount)
+    const bucketSize = Math.max(1, Math.floor(data.length / BAR_COUNT))
+
+    const tick = (): void => {
+      analyser.getByteFrequencyData(data)
+      const next: Array<number> = []
+      for (let i = 0; i < BAR_COUNT; i++) {
+        let sum = 0
+        for (let j = 0; j < bucketSize; j++) {
+          sum += data[i * bucketSize + j] ?? 0
+        }
+        next.push(Math.max(IDLE_LEVEL, sum / bucketSize / 255))
+      }
+      setLevels(next)
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+
+    return (): void => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+      source.disconnect()
+      analyser.disconnect()
+      void audioCtx.close().catch(() => {})
+    }
+  }, [stream])
+
+  return stream ? levels : IDLE_LEVELS
+}

--- a/packages/ui/chat/src/hooks/use-audio-recorder.ts
+++ b/packages/ui/chat/src/hooks/use-audio-recorder.ts
@@ -1,12 +1,14 @@
 import { useEffect, useReducer, useRef, useState } from "react"
 import { AudioRecordingService } from "@chat/lib/interview/audio-recording-service"
 import { recordingReducer } from "@chat/lib/interview/recording-reducer"
-import { mockUploadAudio } from "@chat/lib/interview/upload-service"
 import type { RecordingState } from "@chat/types/interview"
 
-type UseAudioRecorderReturn = {
+export type UseAudioRecorderReturn = {
   state: RecordingState
   elapsedTime: number
+  /** Live mic stream while recording/paused - null otherwise. Exposed so
+   * the UI can drive a real audio-level visualization. */
+  stream: MediaStream | null
   startRecording: () => Promise<void>
   pauseRecording: () => void
   resumeRecording: () => void
@@ -15,12 +17,19 @@ type UseAudioRecorderReturn = {
   retry: () => void
 }
 
+/**
+ * Owns microphone capture only - permission, start/pause/stop, elapsed
+ * time. What happens to the finished recording (upload, transcription)
+ * is the caller's concern, kept out of this hook so it stays reusable
+ * outside the interview flow.
+ */
 export const useAudioRecorder = (
-  onComplete: (transcript: string) => void
+  onRecordingComplete: (blob: Blob, audioUrl: string, durationSeconds: number) => void
 ): UseAudioRecorderReturn => {
   const [state, dispatch] = useReducer(recordingReducer, { type: "idle" })
   const serviceRef = useRef<AudioRecordingService | null>(null)
-  const [elapsedTime, setElapsedTime] = useState(0)
+  const [liveElapsed, setLiveElapsed] = useState(0)
+  const [stream, setStream] = useState<MediaStream | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Initialize service
@@ -28,66 +37,50 @@ export const useAudioRecorder = (
     serviceRef.current = new AudioRecordingService()
   }, [])
 
-  // Timer effect
+  // Tick a live counter only while actively recording; every other phase's
+  // elapsed time is derived below instead of mirrored into state here.
   useEffect(() => {
-    if (state.type === "recording") {
-      timerRef.current = setInterval(() => {
-        setElapsedTime(Math.floor((Date.now() - state.startTime) / 1000))
-      }, 100)
-    } else if (state.type === "paused") {
-      setElapsedTime(state.elapsedBeforePause)
-      if (timerRef.current) {
-        clearInterval(timerRef.current)
-        timerRef.current = null
-      }
-    } else {
-      if (timerRef.current) {
-        clearInterval(timerRef.current)
-        timerRef.current = null
-      }
-      if (state.type === "idle" || state.type === "requesting_permission") {
-        setElapsedTime(0)
-      }
-    }
+    if (state.type !== "recording") return
+
+    const { startTime } = state
+    timerRef.current = setInterval(() => {
+      setLiveElapsed(Math.floor((Date.now() - startTime) / 1000))
+    }, 100)
 
     return (): void => {
       if (timerRef.current) {
         clearInterval(timerRef.current)
+        timerRef.current = null
       }
     }
   }, [state])
 
-  // Handle success state - upload and complete
+  const elapsedTime =
+    state.type === "recording"
+      ? liveElapsed
+      : state.type === "paused"
+        ? state.elapsedBeforePause
+        : 0
+
+  // Hand the finished recording off to the caller exactly once per success
+  const notifiedRef = useRef(false)
   useEffect(() => {
-    if (state.type === "success") {
-      const uploadAndComplete = async (): Promise<void> => {
-        try {
-          await mockUploadAudio(state.audioBlob)
-
-          // Mock transcription
-          setTimeout(() => {
-            const mockTranscript = `I would design a URL shortening service with the following approach: First, I'd use a hash function to generate short codes from long URLs. The system would need a database to store mappings between short codes and original URLs. For scalability, I would implement caching using Redis and use a load balancer to distribute traffic.`
-            onComplete(mockTranscript)
-          }, 1000)
-        } catch (error) {
-          dispatch({
-            type: "ERROR",
-            error: error instanceof Error ? error.message : "Upload failed",
-            canRetry: true,
-          })
-        }
-      }
-
-      uploadAndComplete()
+    if (state.type !== "success") {
+      notifiedRef.current = false
+      return
     }
-  }, [state, onComplete])
+    if (notifiedRef.current) return
+    notifiedRef.current = true
+    onRecordingComplete(state.audioBlob, state.audioUrl, state.duration)
+  }, [state, onRecordingComplete])
 
   const startRecording = async (): Promise<void> => {
     dispatch({ type: "START_RECORDING" })
     try {
-      const stream = await serviceRef.current!.requestPermission()
-      dispatch({ type: "PERMISSION_GRANTED", stream })
-      serviceRef.current!.startRecording(stream)
+      const micStream = await serviceRef.current!.requestPermission()
+      dispatch({ type: "PERMISSION_GRANTED", stream: micStream })
+      serviceRef.current!.startRecording(micStream)
+      setStream(micStream)
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
@@ -119,6 +112,7 @@ export const useAudioRecorder = (
         audioUrl: url,
         duration: elapsedTime,
       })
+      setStream(null)
     } catch (error) {
       dispatch({
         type: "ERROR",
@@ -126,11 +120,13 @@ export const useAudioRecorder = (
           error instanceof Error ? error.message : "Failed to stop recording",
         canRetry: false,
       })
+      setStream(null)
     }
   }
 
   const reset = (): void => {
     serviceRef.current?.cleanup()
+    setStream(null)
     dispatch({ type: "RESET" })
   }
 
@@ -141,6 +137,7 @@ export const useAudioRecorder = (
   return {
     state,
     elapsedTime,
+    stream,
     startRecording,
     pauseRecording,
     resumeRecording,

--- a/packages/ui/chat/src/hooks/use-interview-session.ts
+++ b/packages/ui/chat/src/hooks/use-interview-session.ts
@@ -1,0 +1,231 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react"
+import { interviewQuestions } from "@chat/data/interview-questions"
+import type { UseAudioRecorderReturn } from "@chat/hooks/use-audio-recorder"
+import { useAudioRecorder } from "@chat/hooks/use-audio-recorder"
+import {
+  createInitialInterviewState,
+  interviewReducer,
+} from "@chat/lib/interview/core/interview-reducer"
+import { createStaticQuestionRepository } from "@chat/lib/interview/core/question-repository"
+import { createWebSpeechTTSAdapter } from "@chat/lib/interview/core/tts-adapter"
+import { createMockTranscriptionAdapter } from "@chat/lib/interview/core/transcription-adapter"
+import type {
+  InterviewSessionState,
+  InterviewTTSAdapter,
+  PersistedSnapshot,
+  Question,
+  QuestionRepository,
+  TranscriptionAdapter,
+} from "@chat/lib/interview/core/interview-types"
+import {
+  clearPersistedSession,
+  readPersistedSession,
+  writePersistedSession,
+} from "@chat/lib/interview/session-storage"
+
+const POLL_INTERVAL_MS = 700
+
+export type UseInterviewSessionConfig = {
+  questionRepository?: QuestionRepository
+  transcriptionAdapter?: TranscriptionAdapter
+  ttsAdapter?: InterviewTTSAdapter
+  persist?: boolean
+}
+
+export type UseInterviewSessionReturn = {
+  state: InterviewSessionState
+  currentQuestion: Question | undefined
+  isLastQuestion: boolean
+  progress: { current: number; total: number }
+  recording: UseAudioRecorderReturn
+  ttsAdapter: InterviewTTSAdapter
+  resumeAvailable: boolean
+  actions: {
+    start: () => void
+    questionPlaybackDone: () => void
+    setNotes: (notes: string) => void
+    beginRecording: () => void
+    editTranscript: (transcript: string) => void
+    retryAnswer: () => void
+    continueSession: () => void
+    restart: () => void
+    resumeSession: () => void
+    discardResume: () => void
+  }
+}
+
+export const useInterviewSession = (
+  config: UseInterviewSessionConfig = {}
+): UseInterviewSessionReturn => {
+  const { persist = true } = config
+
+  const questionRepositoryRef = useRef(
+    config.questionRepository ?? createStaticQuestionRepository(interviewQuestions)
+  )
+  const transcriptionAdapterRef = useRef(
+    config.transcriptionAdapter ?? createMockTranscriptionAdapter()
+  )
+  const [ttsAdapter] = useState(
+    () => config.ttsAdapter ?? createWebSpeechTTSAdapter()
+  )
+
+  const [state, dispatch] = useReducer(
+    interviewReducer,
+    undefined,
+    createInitialInterviewState
+  )
+
+  const [resumeSnapshot, setResumeSnapshot] = useState<PersistedSnapshot | null>(
+    () => (persist ? readPersistedSession() : null)
+  )
+
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Load the question bank once on mount
+  useEffect(() => {
+    let cancelled = false
+    void questionRepositoryRef.current.list().then((questions) => {
+      if (!cancelled) dispatch({ type: "QUESTIONS_LOADED", questions })
+    })
+    return (): void => {
+      cancelled = true
+    }
+  }, [])
+
+  const pollTranscription = useCallback((jobId: string): void => {
+    const poll = async (): Promise<void> => {
+      try {
+        const result = await transcriptionAdapterRef.current.poll(jobId)
+        dispatch({ type: "TRANSCRIPTION_UPDATED", result })
+
+        if (result.status === "pending" || result.status === "processing") {
+          pollTimeoutRef.current = setTimeout(() => void poll(), POLL_INTERVAL_MS)
+        }
+      } catch (error) {
+        dispatch({
+          type: "TRANSCRIPTION_UPDATED",
+          result: {
+            status: "error",
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to check transcription status",
+          },
+        })
+      }
+    }
+
+    void poll()
+  }, [])
+
+  useEffect(() => {
+    return (): void => {
+      if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current)
+    }
+  }, [])
+
+  const currentQuestion = state.questions[state.currentIndex]
+
+  const handleRecordingComplete = useCallback(
+    (blob: Blob, audioUrl: string, durationSeconds: number): void => {
+      dispatch({ type: "RECORDING_COMPLETE", audioUrl, durationSeconds })
+
+      if (!currentQuestion) return
+
+      void transcriptionAdapterRef.current
+        .submit(blob, {
+          questionId: currentQuestion.id,
+          category: currentQuestion.category,
+          durationSeconds,
+        })
+        .then(({ jobId }) => pollTranscription(jobId))
+        .catch((error: unknown) => {
+          dispatch({
+            type: "TRANSCRIPTION_UPDATED",
+            result: {
+              status: "error",
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to submit recording",
+            },
+          })
+        })
+    },
+    [currentQuestion, pollTranscription]
+  )
+
+  const recording = useAudioRecorder(handleRecordingComplete)
+
+  // Persist lightweight session progress (no blobs/urls) across reloads
+  useEffect(() => {
+    if (!persist) return
+    if (state.phase === "welcome" || state.phase === "complete") return
+
+    writePersistedSession({
+      currentIndex: state.currentIndex,
+      notes: state.notes,
+      answers: state.answers,
+      updatedAt: Date.now(),
+    })
+  }, [persist, state.phase, state.currentIndex, state.notes, state.answers])
+
+  useEffect(() => {
+    if (persist && state.phase === "complete") clearPersistedSession()
+  }, [persist, state.phase])
+
+  const actions = useMemo(
+    () => ({
+      start: (): void => dispatch({ type: "START" }),
+      questionPlaybackDone: (): void =>
+        dispatch({ type: "QUESTION_PLAYBACK_DONE" }),
+      setNotes: (notes: string): void =>
+        dispatch({ type: "NOTES_CHANGED", notes }),
+      beginRecording: (): void => dispatch({ type: "BEGIN_RECORDING" }),
+      editTranscript: (transcript: string): void =>
+        dispatch({ type: "TRANSCRIPT_EDITED", transcript }),
+      retryAnswer: (): void => {
+        recording.reset()
+        dispatch({ type: "RETRY_ANSWER" })
+      },
+      continueSession: (): void => {
+        recording.reset()
+        dispatch({ type: "CONTINUE" })
+      },
+      restart: (): void => {
+        recording.reset()
+        clearPersistedSession()
+        dispatch({ type: "RESTART" })
+      },
+      resumeSession: (): void => {
+        if (!resumeSnapshot) return
+        dispatch({ type: "HYDRATE", snapshot: resumeSnapshot })
+        dispatch({ type: "START" })
+        setResumeSnapshot(null)
+      },
+      discardResume: (): void => {
+        clearPersistedSession()
+        setResumeSnapshot(null)
+      },
+    }),
+    [recording, resumeSnapshot]
+  )
+
+  return {
+    state,
+    currentQuestion,
+    isLastQuestion: state.currentIndex === state.questions.length - 1,
+    progress: { current: state.currentIndex + 1, total: state.questions.length },
+    recording,
+    ttsAdapter,
+    resumeAvailable: resumeSnapshot !== null,
+    actions,
+  }
+}

--- a/packages/ui/chat/src/lib/interview/core/interview-reducer.ts
+++ b/packages/ui/chat/src/lib/interview/core/interview-reducer.ts
@@ -1,0 +1,145 @@
+import type {
+  InterviewEvent,
+  InterviewSessionState,
+  SessionAnswer,
+} from "@chat/lib/interview/core/interview-types"
+
+export const createInitialInterviewState = (): InterviewSessionState => ({
+  phase: "welcome",
+  questions: [],
+  currentIndex: 0,
+  notes: "",
+  audioUrl: null,
+  recordingDurationSeconds: 0,
+  transcription: null,
+  answers: [],
+})
+
+const buildAnswer = (state: InterviewSessionState): SessionAnswer => {
+  const question = state.questions[state.currentIndex]
+  return {
+    questionId: question?.id ?? "unknown",
+    transcript: state.transcription?.transcript ?? "",
+    notes: state.notes,
+    durationSeconds: state.recordingDurationSeconds,
+  }
+}
+
+export const interviewReducer = (
+  state: InterviewSessionState,
+  event: InterviewEvent
+): InterviewSessionState => {
+  switch (event.type) {
+    case "QUESTIONS_LOADED":
+      return { ...state, questions: event.questions }
+
+    case "START":
+      return state.phase === "welcome" && state.questions.length > 0
+        ? { ...state, phase: "question" }
+        : state
+
+    case "QUESTION_PLAYBACK_DONE":
+      return state.phase === "question"
+        ? { ...state, phase: "preparation" }
+        : state
+
+    case "NOTES_CHANGED":
+      return { ...state, notes: event.notes }
+
+    case "BEGIN_RECORDING":
+      return state.phase === "preparation"
+        ? { ...state, phase: "recording" }
+        : state
+
+    case "RECORDING_COMPLETE":
+      return state.phase === "recording"
+        ? {
+            ...state,
+            phase: "transcribing",
+            audioUrl: event.audioUrl,
+            recordingDurationSeconds: event.durationSeconds,
+            transcription: { status: "pending" },
+          }
+        : state
+
+    case "TRANSCRIPTION_UPDATED": {
+      if (state.phase !== "transcribing" && state.phase !== "review") {
+        return state
+      }
+      const isTerminal =
+        event.result.status === "done" || event.result.status === "error"
+      return {
+        ...state,
+        transcription: event.result,
+        phase: isTerminal ? "review" : state.phase,
+      }
+    }
+
+    case "TRANSCRIPT_EDITED":
+      return state.phase === "review" && state.transcription
+        ? {
+            ...state,
+            transcription: { ...state.transcription, transcript: event.transcript },
+          }
+        : state
+
+    case "RETRY_ANSWER":
+      return state.phase === "review"
+        ? {
+            ...state,
+            phase: "preparation",
+            audioUrl: null,
+            recordingDurationSeconds: 0,
+            transcription: null,
+          }
+        : state
+
+    case "CONTINUE": {
+      if (state.phase !== "review") return state
+      const answers = [...state.answers, buildAnswer(state)]
+      const isLast = state.currentIndex === state.questions.length - 1
+
+      if (isLast) {
+        return {
+          ...state,
+          answers,
+          phase: "complete",
+          audioUrl: null,
+          recordingDurationSeconds: 0,
+          transcription: null,
+        }
+      }
+
+      return {
+        ...state,
+        answers,
+        currentIndex: state.currentIndex + 1,
+        phase: "question",
+        notes: "",
+        audioUrl: null,
+        recordingDurationSeconds: 0,
+        transcription: null,
+      }
+    }
+
+    case "RESTART":
+      return {
+        ...createInitialInterviewState(),
+        questions: state.questions,
+      }
+
+    case "HYDRATE":
+      return {
+        ...state,
+        currentIndex: Math.min(
+          event.snapshot.currentIndex,
+          Math.max(state.questions.length - 1, 0)
+        ),
+        notes: event.snapshot.notes,
+        answers: event.snapshot.answers,
+      }
+
+    default:
+      return state
+  }
+}

--- a/packages/ui/chat/src/lib/interview/core/interview-types.ts
+++ b/packages/ui/chat/src/lib/interview/core/interview-types.ts
@@ -1,0 +1,194 @@
+/**
+ * Interview Domain Types
+ *
+ * Framework-agnostic types for the mock-interview session. Mirrors the
+ * core/adapter split used by `lib/topik` so the same session state can
+ * eventually be rendered by more than one presentation (paginated
+ * slideshow today, animated chat/voice later).
+ */
+
+import { z } from "zod"
+
+// ═══════════════════════════════════════════════════════════════════════════
+// QUESTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type QuestionLevel = "junior" | "mid" | "senior"
+
+export type QuestionCategory =
+  | "behavioral"
+  | "system-design"
+  | "technical"
+  | "leadership"
+
+export type Question = {
+  id: string
+  level: QuestionLevel
+  category: QuestionCategory
+  question: string
+  durationSeconds: number
+}
+
+export const QuestionSchema = z.object({
+  id: z.string(),
+  level: z.enum(["junior", "mid", "senior"]),
+  category: z.enum(["behavioral", "system-design", "technical", "leadership"]),
+  question: z.string(),
+  durationSeconds: z.number().positive(),
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TRANSCRIPTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type TranscriptionStatus =
+  | "pending"
+  | "processing"
+  | "done"
+  | "error"
+
+export type TranscriptionResult = {
+  status: TranscriptionStatus
+  transcript?: string
+  error?: string
+}
+
+export type TranscriptionJob = {
+  jobId: string
+}
+
+export const TranscriptionResultSchema = z.object({
+  status: z.enum(["pending", "processing", "done", "error"]),
+  transcript: z.string().optional(),
+  error: z.string().optional(),
+})
+
+export const TranscriptionJobSchema = z.object({
+  jobId: z.string(),
+})
+
+/**
+ * Seam for the future transcription backend. `submit` hands off a
+ * recording, `poll` is called until it resolves to a terminal status
+ * ("done" | "error"). Swapping the mock for an HTTP-backed adapter is a
+ * one-line change at the call site.
+ */
+export type TranscriptionAdapter = {
+  submit(
+    blob: Blob,
+    meta: {
+      questionId: string
+      category: QuestionCategory
+      durationSeconds: number
+    }
+  ): Promise<TranscriptionJob>
+  poll(jobId: string): Promise<TranscriptionResult>
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// QUESTION REPOSITORY
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type QuestionRepository = {
+  list(filters?: {
+    level?: QuestionLevel
+    category?: QuestionCategory
+  }): Promise<Array<Question>>
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TTS (question playback)
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type SpeakOptions = {
+  onBoundary?: (charIndex: number, charLength: number) => void
+}
+
+export type InterviewTTSAdapter = {
+  supported: boolean
+  speak(text: string, opts?: SpeakOptions): Promise<void>
+  stop(): void
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SESSION PHASES
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type InterviewPhase =
+  | "welcome"
+  | "question"
+  | "preparation"
+  | "recording"
+  | "transcribing"
+  | "review"
+  | "complete"
+
+export type SessionAnswer = {
+  questionId: string
+  transcript: string
+  notes: string
+  durationSeconds: number
+}
+
+const SessionAnswerSchema = z.object({
+  questionId: z.string(),
+  transcript: z.string(),
+  notes: z.string(),
+  durationSeconds: z.number(),
+})
+
+export type InterviewSessionState = {
+  phase: InterviewPhase
+  questions: Array<Question>
+  currentIndex: number
+  notes: string
+  audioUrl: string | null
+  recordingDurationSeconds: number
+  transcription: TranscriptionResult | null
+  answers: Array<SessionAnswer>
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SESSION EVENTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type InterviewEvent =
+  | { type: "QUESTIONS_LOADED"; questions: Array<Question> }
+  | { type: "START" }
+  | { type: "QUESTION_PLAYBACK_DONE" }
+  | { type: "NOTES_CHANGED"; notes: string }
+  | { type: "BEGIN_RECORDING" }
+  | {
+      type: "RECORDING_COMPLETE"
+      audioUrl: string
+      durationSeconds: number
+    }
+  | { type: "TRANSCRIPTION_UPDATED"; result: TranscriptionResult }
+  | { type: "TRANSCRIPT_EDITED"; transcript: string }
+  | { type: "RETRY_ANSWER" }
+  | { type: "CONTINUE" }
+  | { type: "RESTART" }
+  | { type: "HYDRATE"; snapshot: PersistedSnapshot }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PERSISTENCE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * The only part of session state worth persisting across reloads. Audio
+ * blobs and object URLs are intentionally excluded - they don't survive
+ * serialization and shouldn't live in storage anyway.
+ */
+export type PersistedSnapshot = {
+  currentIndex: number
+  notes: string
+  answers: Array<SessionAnswer>
+  updatedAt: number
+}
+
+export const PersistedSnapshotSchema = z.object({
+  currentIndex: z.number(),
+  notes: z.string(),
+  answers: z.array(SessionAnswerSchema),
+  updatedAt: z.number(),
+})

--- a/packages/ui/chat/src/lib/interview/core/question-repository.ts
+++ b/packages/ui/chat/src/lib/interview/core/question-repository.ts
@@ -1,0 +1,59 @@
+import {
+  QuestionSchema,
+  type Question,
+  type QuestionRepository,
+} from "@chat/lib/interview/core/interview-types"
+
+const matches = (
+  question: Question,
+  filters?: Parameters<QuestionRepository["list"]>[0]
+): boolean => {
+  if (!filters) return true
+  if (filters.level && question.level !== filters.level) return false
+  if (filters.category && question.category !== filters.category) return false
+  return true
+}
+
+/**
+ * Serves questions from a static in-memory bank. This is the default today
+ * (see `src/data/interview-questions.ts`). `createHttpQuestionRepository`
+ * is the drop-in replacement once a question bank endpoint exists.
+ */
+export const createStaticQuestionRepository = (
+  questions: Array<Question>
+): QuestionRepository => ({
+  list(filters): Promise<Array<Question>> {
+    return Promise.resolve(questions.filter((q) => matches(q, filters)))
+  },
+})
+
+type HttpQuestionRepositoryOptions = {
+  baseUrl: string
+  headers?: Record<string, string>
+}
+
+export const createHttpQuestionRepository = (
+  options: HttpQuestionRepositoryOptions
+): QuestionRepository => {
+  const { baseUrl, headers = {} } = options
+
+  return {
+    async list(filters): Promise<Array<Question>> {
+      const params = new URLSearchParams()
+      if (filters?.level) params.set("level", filters.level)
+      if (filters?.category) params.set("category", filters.category)
+
+      const query = params.toString()
+      const response = await fetch(
+        `${baseUrl}/questions${query ? `?${query}` : ""}`,
+        { headers }
+      )
+
+      if (!response.ok) {
+        throw new Error(`Failed to load questions: ${response.status}`)
+      }
+
+      return QuestionSchema.array().parse(await response.json())
+    },
+  }
+}

--- a/packages/ui/chat/src/lib/interview/core/transcription-adapter.ts
+++ b/packages/ui/chat/src/lib/interview/core/transcription-adapter.ts
@@ -1,0 +1,128 @@
+import {
+  TranscriptionJobSchema,
+  TranscriptionResultSchema,
+  type QuestionCategory,
+  type TranscriptionAdapter,
+  type TranscriptionJob,
+  type TranscriptionResult,
+} from "@chat/lib/interview/core/interview-types"
+
+const SAMPLE_TRANSCRIPTS: Record<QuestionCategory, string> = {
+  "system-design":
+    "I'd start by clarifying the read/write ratio and scale targets, then sketch the API surface before touching storage. For the data layer I'd lean on a key-value store for the hot path with a relational store for anything that needs joins, and put a cache in front of the reads. I'd call out the tradeoffs as I go rather than presenting one true answer.",
+  behavioral:
+    "There was a stretch where two teammates disagreed on the approach and it was starting to slow the team down. I pulled them into a short session, had each one state the other's position back to make sure we were arguing about the same thing, and we landed on a compromise neither had proposed on their own. The main thing I learned was to separate the disagreement from the people having it.",
+  technical:
+    "First I'd look at the query plan to see where time is actually going instead of guessing. Usually it's a missing index, a query pulling more columns than it needs, or an N+1 pattern hiding upstream. I'd fix the cheapest thing first, measure again, and only reach for caching once the query itself is as lean as it can be.",
+  leadership:
+    "I try to set the destination clearly and then get out of the way on the how. When priorities shift I explain the why before the what, because people execute better on things they understand rather than things they're just told. I also make a point of surfacing disagreement early so it doesn't calcify into resentment later.",
+}
+
+const randomBetween = (min: number, max: number): number =>
+  Math.floor(Math.random() * (max - min + 1)) + min
+
+let mockJobCounter = 0
+
+type MockTranscriptionAdapterOptions = {
+  failureRate?: number
+  minLatencyMs?: number
+  maxLatencyMs?: number
+}
+
+/**
+ * In-memory adapter used until the transcription backend exists. Simulates
+ * an upload + async processing job so the UI can be built against real
+ * pending/processing/done/error states instead of a single setTimeout.
+ */
+export const createMockTranscriptionAdapter = (
+  options: MockTranscriptionAdapterOptions = {}
+): TranscriptionAdapter => {
+  const { failureRate = 0.08, minLatencyMs = 900, maxLatencyMs = 2200 } =
+    options
+
+  const jobs = new Map<
+    string,
+    { readyAt: number; result: TranscriptionResult; category: QuestionCategory }
+  >()
+
+  return {
+    submit(_blob, meta): Promise<TranscriptionJob> {
+      mockJobCounter += 1
+      const jobId = `mock-job-${mockJobCounter}`
+
+      const willFail = Math.random() < failureRate
+      const readyAt = Date.now() + randomBetween(minLatencyMs, maxLatencyMs)
+
+      jobs.set(jobId, {
+        readyAt,
+        category: meta.category,
+        result: willFail
+          ? { status: "error", error: "Network error: failed to transcribe recording" }
+          : { status: "done", transcript: SAMPLE_TRANSCRIPTS[meta.category] },
+      })
+
+      return Promise.resolve({ jobId })
+    },
+
+    poll(jobId): Promise<TranscriptionResult> {
+      const job = jobs.get(jobId)
+      if (!job) {
+        return Promise.resolve({ status: "error", error: "Unknown transcription job" })
+      }
+      if (Date.now() < job.readyAt) {
+        return Promise.resolve({ status: "processing" })
+      }
+      return Promise.resolve(job.result)
+    },
+  }
+}
+
+type HttpTranscriptionAdapterOptions = {
+  baseUrl: string
+  headers?: Record<string, string>
+}
+
+/**
+ * Real backend seam. POSTs the recording, then polls a status endpoint
+ * until the job resolves. Not wired up by default - swap
+ * `createMockTranscriptionAdapter()` for `createHttpTranscriptionAdapter(...)`
+ * once the transcription service exists.
+ */
+export const createHttpTranscriptionAdapter = (
+  options: HttpTranscriptionAdapterOptions
+): TranscriptionAdapter => {
+  const { baseUrl, headers = {} } = options
+
+  return {
+    async submit(blob, meta): Promise<TranscriptionJob> {
+      const formData = new FormData()
+      formData.append("audio", blob)
+      formData.append("questionId", meta.questionId)
+      formData.append("durationSeconds", String(meta.durationSeconds))
+
+      const response = await fetch(`${baseUrl}/recordings`, {
+        method: "POST",
+        headers,
+        body: formData,
+      })
+
+      if (!response.ok) {
+        throw new Error(`Failed to submit recording: ${response.status}`)
+      }
+
+      return TranscriptionJobSchema.parse(await response.json())
+    },
+
+    async poll(jobId): Promise<TranscriptionResult> {
+      const response = await fetch(`${baseUrl}/recordings/${jobId}`, {
+        headers,
+      })
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch transcription status: ${response.status}`)
+      }
+
+      return TranscriptionResultSchema.parse(await response.json())
+    },
+  }
+}

--- a/packages/ui/chat/src/lib/interview/core/tts-adapter.ts
+++ b/packages/ui/chat/src/lib/interview/core/tts-adapter.ts
@@ -1,0 +1,44 @@
+import type {
+  InterviewTTSAdapter,
+  SpeakOptions,
+} from "@chat/lib/interview/core/interview-types"
+
+/**
+ * Real (non-mocked) question playback using the browser's SpeechSynthesis
+ * API. This is an interim implementation - the shape matches what a
+ * backend-driven TTS adapter (e.g. `some-ui-utils`'s `useAudioTTS`) would
+ * expose, so swapping in real audio later doesn't touch call sites.
+ */
+export const createWebSpeechTTSAdapter = (): InterviewTTSAdapter => {
+  const supported =
+    typeof window !== "undefined" && "speechSynthesis" in window
+
+  const speak = (text: string, opts?: SpeakOptions): Promise<void> => {
+    if (!supported) {
+      return Promise.resolve()
+    }
+
+    window.speechSynthesis.cancel()
+
+    return new Promise((resolve) => {
+      const utterance = new SpeechSynthesisUtterance(text)
+      utterance.rate = 0.98
+      utterance.pitch = 1
+
+      utterance.onboundary = (event): void => {
+        opts?.onBoundary?.(event.charIndex, event.charLength)
+      }
+      utterance.onend = (): void => resolve()
+      utterance.onerror = (): void => resolve()
+
+      window.speechSynthesis.speak(utterance)
+    })
+  }
+
+  const stop = (): void => {
+    if (!supported) return
+    window.speechSynthesis.cancel()
+  }
+
+  return { supported, speak, stop }
+}

--- a/packages/ui/chat/src/lib/interview/format-time.ts
+++ b/packages/ui/chat/src/lib/interview/format-time.ts
@@ -1,0 +1,5 @@
+export const formatTime = (totalSeconds: number): string => {
+  const mins = Math.floor(totalSeconds / 60)
+  const secs = Math.floor(totalSeconds % 60)
+  return `${mins}:${secs.toString().padStart(2, "0")}`
+}

--- a/packages/ui/chat/src/lib/interview/session-storage.ts
+++ b/packages/ui/chat/src/lib/interview/session-storage.ts
@@ -1,0 +1,39 @@
+import {
+  PersistedSnapshotSchema,
+  type PersistedSnapshot,
+} from "@chat/lib/interview/core/interview-types"
+
+const STORAGE_KEY = "some-ui:mock-interview:session"
+
+export const readPersistedSession = (): PersistedSnapshot | null => {
+  if (typeof window === "undefined") return null
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    return PersistedSnapshotSchema.parse(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+export const writePersistedSession = (snapshot: PersistedSnapshot): void => {
+  if (typeof window === "undefined") return
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
+  } catch {
+    // Storage may be full or unavailable (private browsing) - practice
+    // continues without persistence, no need to surface this to the user.
+  }
+}
+
+export const clearPersistedSession = (): void => {
+  if (typeof window === "undefined") return
+
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // no-op
+  }
+}

--- a/packages/ui/chat/src/lib/interview/upload-service.ts
+++ b/packages/ui/chat/src/lib/interview/upload-service.ts
@@ -1,9 +1,0 @@
-export const mockUploadAudio = async (_blob: Blob): Promise<void> => {
-  // Simulate network delay
-  await new Promise((resolve) => setTimeout(resolve, 1500))
-
-  // Simulate occasional failures (10% chance)
-  if (Math.random() < 0.1) {
-    throw new Error("Network error: Failed to upload recording")
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1076,6 +1076,9 @@ importers:
       '@some-ui/styles':
         specifier: workspace:*
         version: link:../../some-styles
+      '@types/react':
+        specifier: ^19.0.4
+        version: 19.2.17
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.0.0)
@@ -1085,6 +1088,9 @@ importers:
       some-ui-utils:
         specifier: workspace:*
         version: link:../../utils
+      zod:
+        specifier: 4.0.5
+        version: 4.0.5
     devDependencies:
       '@some-ui/tsconfig':
         specifier: workspace:*
@@ -18741,8 +18747,8 @@ snapshots:
       '@babel/parser': 7.29.7
       eslint: 10.6.0(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.0.5
-      zod-validation-error: 4.0.2(zod@4.0.5)
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -24812,9 +24818,9 @@ snapshots:
       async: 3.2.6
       jszip: 3.10.1
 
-  zod-validation-error@4.0.2(zod@4.0.5):
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
-      zod: 4.0.5
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Description

This PR restructures the mock interview feature to separate session state management from presentation logic, enabling multiple UI presentations (slideshow, chat, voice) to consume the same session state.

### Key Changes

**New Architecture:**
- `useInterviewSession` hook owns all session state, phase transitions, and orchestration of adapters
- Adapter pattern for pluggable backends: `TranscriptionAdapter`, `QuestionRepository`, `InterviewTTSAdapter`
- `SlideshowPresenter` component renders the session state as a paginated, one-question-at-a-time flow
- Session persistence via localStorage with resume capability

**New Modules:**
- `lib/interview/core/interview-types.ts` - Framework-agnostic domain types (Question, TranscriptionResult, InterviewSessionState, etc.)
- `lib/interview/core/interview-reducer.ts` - State machine for phase transitions
- `lib/interview/core/transcription-adapter.ts` - Mock transcription service with job polling
- `lib/interview/core/question-repository.ts` - Question bank abstraction (static + HTTP variants)
- `lib/interview/core/tts-adapter.ts` - Web Speech API wrapper for question playback
- `lib/interview/session-storage.ts` - Persistence layer
- `hooks/use-interview-session.ts` - Main session orchestration hook
- `hooks/use-audio-level.ts` - Real-time audio visualization from live mic stream
- `data/interview-questions.ts` - Question bank data
- `components/mock-interview/interview-app/slideshow-presenter.tsx` - Presentation layer
- `components/mock-interview/session-complete/index.tsx` - Completion screen
- `components/mock-interview/progress-header/index.tsx` - Progress indicator

**Refactored Components:**
- `RecordingPhase` - Now accepts `recording` prop (UseAudioRecorderReturn) instead of callback, enabling story-driven testing without real mic access
- `QuestionPlayback` - Integrated real TTS adapter with boundary callbacks for progress tracking
- `ReviewPhase` - Decoupled from local state, now driven by transcription result prop
- `WelcomeScreen` - Added resume session UI
- `InterviewApp` - Simplified to compose `useInterviewSession` + `SlideshowPresenter`

**Improved Testing:**
- RecordingPhase stories now use stubbed `recording` prop instead of mocking navigator.mediaDevices
- Added comprehensive stories for all interview phases
- Stories document expected behavior without requiring real microphone access

**Removed:**
- `upload-service.ts` - Replaced by transcription adapter pattern
- Inline phase management from InterviewApp

### Why This Matters

The previous implementation tightly coupled session logic to the slideshow UI. This refactor:
1. Enables future presenters (chat UI, voice-first interface) to reuse session logic
2. Makes testing easier - components receive props instead of managing side effects
3. Provides clear seams for backend integration (transcription, TTS, question bank)
4. Improves type safety with domain-specific types instead of generic strings

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed for correctness
- [x] Hard-to-understand areas are commented
- [x] No new warnings generated
- [x] Storybook stories added for all interview phases
- [x] Existing component tests remain compatible

## Test Plan

- Storybook stories cover all interview phases and state transitions
- RecordingPhase stories verify UI without real microphone access
- Session persistence tested via localStorage integration
- Adapter pattern enables isolated testing of transcription, TTS, and question repository

https://claude.ai/code/session_01M5Y4ztuNi13nqSxALJnW5S