### PR TITLE
Fix marker stranding on audible/refused-discard tabs (#344, #345)

### DIFF
--- a/extensions/some-filter/src/background/background.ts
+++ b/extensions/some-filter/src/background/background.ts
@@ -6,6 +6,7 @@ import {
 } from "@filter/lib/legacy-presets"
 import { DEFAULT_TAB_STATE, nextTabState } from "@filter/lib/tab-state"
 import { ext } from "@filter/platform/background"
+import type { ExtensionMessage } from "@filter/types/message"
 import type { FilterConfig, LegacyStyle } from "@filter/types/popup"
 import type { TabState } from "@filter/types/tab"
 
@@ -61,10 +62,7 @@ async function setTabState(tabId: number, state: TabState): Promise<void> {
   })
 }
 
-async function sendToTab(
-  tabId: number,
-  msg: Record<string, unknown>
-): Promise<void> {
+async function sendToTab(tabId: number, msg: ExtensionMessage): Promise<void> {
   try {
     await ext.tabs.sendMessage(tabId, msg)
   } catch {

--- a/extensions/some-filter/src/content/content.ts
+++ b/extensions/some-filter/src/content/content.ts
@@ -158,8 +158,19 @@ function init(): void {
         filterConfig = response.config
 
         if (response.enabled) {
-          // Background confirms legacy — ensure we're there regardless of cache.
-          if (currentState !== "legacy") applyState("legacy")
+          // Background confirms legacy — ensure we're there regardless of
+          // cache, and repaint with the authoritative config even if the
+          // cache already guessed "legacy": the synchronous cached paint
+          // above ran before this response arrived, using whatever config
+          // was in scope at that time (the module default, or a stale value
+          // from a previous style). Skipping the repaint here left tabs
+          // stuck on that stale look whenever the legacy style had changed
+          // (e.g. dim <-> invert) since the last paint.
+          if (currentState !== "legacy") {
+            applyState("legacy")
+          } else {
+            applyTheme("legacy", filterConfig)
+          }
         } else if (currentState === "legacy") {
           // Cache said legacy but this tab is no longer in the filter list
           // (user removed it via popup). Re-classify with auto.
@@ -205,7 +216,12 @@ ext.runtime.onMessage.addListener((msg: unknown): void => {
     }
 
     case "TOGGLE_FILTER": {
-      applyState("legacy")
+      // The background pushes this whenever the legacy style changes (e.g.
+      // dim <-> invert) or this tab's filtered membership changes — the
+      // config it carries is authoritative and must replace whatever this
+      // tab last painted with, not just re-trigger a repaint of the old one.
+      filterConfig = msg.config
+      applyState(msg.enabled ? "legacy" : "auto")
       return
     }
 

--- a/extensions/some-filter/src/lib/background/guard.ts
+++ b/extensions/some-filter/src/lib/background/guard.ts
@@ -1,8 +1,21 @@
 import { isLegacyStyle } from "@filter/lib/legacy-presets"
+import type { FilterConfig } from "@filter/types/config"
 import type { ExtensionMessage } from "@filter/types/message"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
+}
+
+function isFilterConfig(value: unknown): value is FilterConfig {
+  if (!isRecord(value)) return false
+
+  return (
+    (value.invert === undefined || typeof value.invert === "number") &&
+    (value.hueRotate === undefined || typeof value.hueRotate === "number") &&
+    (value.sepia === undefined || typeof value.sepia === "number") &&
+    (value.brightness === undefined || typeof value.brightness === "number") &&
+    (value.contrast === undefined || typeof value.contrast === "number")
+  )
 }
 
 export function isExtensionMessage(msg: unknown): msg is ExtensionMessage {
@@ -17,9 +30,9 @@ export function isExtensionMessage(msg: unknown): msg is ExtensionMessage {
     return isLegacyStyle(msg.style)
   }
 
-  return (
-    msg.type === "GET_TAB_FILTER_STATE" ||
-    msg.type === "TOGGLE_FILTER" ||
-    msg.type === "CYCLE_TAB_STATE"
-  )
+  if (msg.type === "TOGGLE_FILTER") {
+    return typeof msg.enabled === "boolean" && isFilterConfig(msg.config)
+  }
+
+  return msg.type === "GET_TAB_FILTER_STATE" || msg.type === "CYCLE_TAB_STATE"
 }

--- a/extensions/some-filter/src/lib/content/__tests__/guard.test.ts
+++ b/extensions/some-filter/src/lib/content/__tests__/guard.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import { isExtensionMessage, isGetTabFilterStateResponse } from "../guard"
+
+describe("isExtensionMessage — TOGGLE_FILTER", () => {
+  it("accepts a well-formed TOGGLE_FILTER carrying enabled + config", () => {
+    expect(
+      isExtensionMessage({
+        type: "TOGGLE_FILTER",
+        enabled: true,
+        config: {
+          invert: 0,
+          hueRotate: 0,
+          sepia: 0,
+          brightness: 0.7,
+          contrast: 0.95,
+        },
+      })
+    ).toBe(true)
+  })
+
+  it("accepts enabled: false with a config (unfilter push)", () => {
+    expect(
+      isExtensionMessage({
+        type: "TOGGLE_FILTER",
+        enabled: false,
+        config: {},
+      })
+    ).toBe(true)
+  })
+
+  // This is the regression: a TOGGLE_FILTER with no payload used to be
+  // accepted by the guard (the type had no fields to validate), which is
+  // exactly how the background's config/enabled silently got dropped on
+  // the way to the content script.
+  it("rejects a bare TOGGLE_FILTER with no enabled/config payload", () => {
+    expect(isExtensionMessage({ type: "TOGGLE_FILTER" })).toBe(false)
+  })
+
+  it("rejects a TOGGLE_FILTER missing enabled", () => {
+    expect(isExtensionMessage({ type: "TOGGLE_FILTER", config: {} })).toBe(
+      false
+    )
+  })
+
+  it("rejects a TOGGLE_FILTER with a malformed config", () => {
+    expect(
+      isExtensionMessage({
+        type: "TOGGLE_FILTER",
+        enabled: true,
+        config: { invert: "yes" },
+      })
+    ).toBe(false)
+  })
+})
+
+describe("isGetTabFilterStateResponse", () => {
+  it("accepts a well-formed response", () => {
+    expect(
+      isGetTabFilterStateResponse({
+        enabled: true,
+        config: {
+          invert: 0,
+          hueRotate: 0,
+          sepia: 0,
+          brightness: 0.7,
+          contrast: 0.95,
+        },
+        tabState: "legacy",
+      })
+    ).toBe(true)
+  })
+
+  it("rejects a response missing config", () => {
+    expect(isGetTabFilterStateResponse({ enabled: true })).toBe(false)
+  })
+})

--- a/extensions/some-filter/src/lib/content/guard.ts
+++ b/extensions/some-filter/src/lib/content/guard.ts
@@ -19,11 +19,11 @@ export function isExtensionMessage(msg: unknown): msg is ExtensionMessage {
     return isLegacyStyle(msg.style)
   }
 
-  return (
-    msg.type === "GET_TAB_FILTER_STATE" ||
-    msg.type === "TOGGLE_FILTER" ||
-    msg.type === "CYCLE_TAB_STATE"
-  )
+  if (msg.type === "TOGGLE_FILTER") {
+    return typeof msg.enabled === "boolean" && isFilterConfig(msg.config)
+  }
+
+  return msg.type === "GET_TAB_FILTER_STATE" || msg.type === "CYCLE_TAB_STATE"
 }
 
 function isFilterConfig(value: unknown): value is FilterConfig {

--- a/extensions/some-filter/src/types/message.ts
+++ b/extensions/some-filter/src/types/message.ts
@@ -1,8 +1,9 @@
+import type { FilterConfig } from "./config"
 import type { LegacyStyle } from "./popup"
 
 export type ExtensionMessage =
   | { type: "GET_TAB_FILTER_STATE" }
   | { type: "SET_FILTERED_TABS"; ids: Array<number> }
-  | { type: "TOGGLE_FILTER" }
+  | { type: "TOGGLE_FILTER"; enabled: boolean; config: FilterConfig }
   | { type: "CYCLE_TAB_STATE" }
   | { type: "SET_LEGACY_STYLE"; style: LegacyStyle }

--- a/extensions/some-filter/src/types/tab.ts
+++ b/extensions/some-filter/src/types/tab.ts
@@ -7,13 +7,3 @@ export type GetTabFilterStateResponse = {
   config: FilterConfig
   tabState?: TabState
 }
-
-export type ContentCommand =
-  | {
-      type: "TOGGLE_FILTER"
-      enabled: boolean
-      config: FilterConfig
-    }
-  | {
-      type: "CYCLE_TAB_STATE"
-    }

--- a/extensions/some-filter/vitest.config.ts
+++ b/extensions/some-filter/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@filter": resolve(__dirname, "./extensions/some-filter/src"),
+      "@filter": resolve(__dirname, "./src"),
     },
   },
 })

--- a/extensions/suspender-ledger/package.json
+++ b/extensions/suspender-ledger/package.json
@@ -1,46 +1,47 @@
 {
-	"bugs": {
-		"url": "https://github.com/paulgsc/some-ui/issues"
-	},
-	"devDependencies": {
-		"@playwright/test": "1.60.0",
-		"@some-ui/tsconfig": "workspace:*",
-		"@types/chrome": "^0.0.293",
-		"@types/firefox-webext-browser": "^120.0.4",
-		"eslint": "^10.6.0",
-		"maishatu-eslint-kit": "workspace:*",
-		"web-ext": "^8.4.0"
-	},
-	"homepage": "https://pgdev.maishatu.com/?tab=github",
-	"keywords": [],
-	"license": "MPL-2.0 AND MIT",
-	"name": "@some-extension/suspender-ledger",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/paulgsc/some-ui"
-	},
-	"scripts": {
-		"build": "vite build --config vite.config.firefox.ts",
-		"build:firefox": "vite build --config vite.config.firefox.ts",
-		"check:headers": "node scripts/check-mpl-headers.js",
-		"clean": "rimraf .turbo && rimraf node_modules && rimraf .eslintcache && pnpm clean:build",
-		"clean:build": "rimraf ./dist && rimraf tsconfig.tsbuildinfo",
-		"lint": "pnpm lint:js && pnpm check:headers && pnpm typecheck",
-		"lint:ext": "web-ext lint --source-dir dist --self-hosted",
-		"lint:js": "cross-env NODE_OPTIONS='--max_old_space_size=4096' eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
-		"package:source": "bash ../scripts/package-source.sh",
-		"sign:firefox": "web-ext sign --source-dir dist --artifacts-dir artifacts --channel=unlisted --api-key=$WEB_EXT_API_KEY --api-secret=$WEB_EXT_API_SECRET",
-		"test": "vitest",
-		"test:e2e": "playwright test",
-		"test:e2e:headed": "playwright test --headed",
-		"test:e2e:ui": "playwright test --ui",
-		"typecheck": "tsc --noEmit"
-	},
-	"sideEffects": [
-		"./src/worker/**",
-		"./src/content/**",
-		"./src/lib/platform/**"
-	],
-	"type": "module",
-	"version": "0.1.0"
+  "bugs": {
+    "url": "https://github.com/paulgsc/some-ui/issues"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.60.0",
+    "@some-ui/tsconfig": "workspace:*",
+    "@types/chrome": "^0.0.293",
+    "@types/firefox-webext-browser": "^120.0.4",
+    "eslint": "^10.6.0",
+    "fast-check": "^3.23.1",
+    "maishatu-eslint-kit": "workspace:*",
+    "web-ext": "^8.4.0"
+  },
+  "homepage": "https://pgdev.maishatu.com/?tab=github",
+  "keywords": [],
+  "license": "MPL-2.0 AND MIT",
+  "name": "@some-extension/suspender-ledger",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paulgsc/some-ui"
+  },
+  "scripts": {
+    "build": "vite build --config vite.config.firefox.ts",
+    "build:firefox": "vite build --config vite.config.firefox.ts",
+    "check:headers": "node scripts/check-mpl-headers.js",
+    "clean": "rimraf .turbo && rimraf node_modules && rimraf .eslintcache && pnpm clean:build",
+    "clean:build": "rimraf ./dist && rimraf tsconfig.tsbuildinfo",
+    "lint": "pnpm lint:js && pnpm check:headers && pnpm typecheck",
+    "lint:ext": "web-ext lint --source-dir dist --self-hosted",
+    "lint:js": "cross-env NODE_OPTIONS='--max_old_space_size=4096' eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
+    "package:source": "bash ../scripts/package-source.sh",
+    "sign:firefox": "web-ext sign --source-dir dist --artifacts-dir artifacts --channel=unlisted --api-key=$WEB_EXT_API_KEY --api-secret=$WEB_EXT_API_SECRET",
+    "test": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "typecheck": "tsc --noEmit"
+  },
+  "sideEffects": [
+    "./src/worker/**",
+    "./src/content/**",
+    "./src/lib/platform/**"
+  ],
+  "type": "module",
+  "version": "0.1.0"
 }

--- a/extensions/suspender-ledger/src/content/resume-veil.ts
+++ b/extensions/suspender-ledger/src/content/resume-veil.ts
@@ -51,7 +51,20 @@ function liftVeil(): void {
   )
 }
 
-if (consumeResumeFlag()) {
+const resumeFlagged = consumeResumeFlag()
+
+// TEMP DIAGNOSTIC for the silent-background-reload bug (#409 follow-up).
+// This runs at document_start on EVERY navigation of a matching page,
+// discarded-tab-revival or not. If you see this fire (flag=true) for tab A
+// while focus is still on B, the resume flag really did survive into a fresh
+// document — i.e. a genuine navigation/reload happened, which is the browser
+// confirming the tab materialized. Delete alongside worker/core/trace.ts.
+// eslint-disable-next-line no-console -- temporary diagnostic instrumentation
+console.log(
+  `[SL:veil] init t=${performance.now().toFixed(1)}ms flag=${String(resumeFlagged)} readyState=${document.readyState} url=${location.href} title=${JSON.stringify(document.title)}`
+)
+
+if (resumeFlagged) {
   paintVeil()
   if (document.readyState === "complete") {
     liftVeil()

--- a/extensions/suspender-ledger/src/content/watch.ts
+++ b/extensions/suspender-ledger/src/content/watch.ts
@@ -48,6 +48,18 @@ function isPrintableKey(key: string): boolean {
   return key.length === 1 && /[0-9a-zA-Z]/.test(key)
 }
 
+// TEMP DIAGNOSTIC for the silent-background-reload bug (#409 follow-up).
+// If this fires more than once for what should be a single navigation (watch
+// for two log lines with the same URL but different timestamps, without an
+// intervening full page load in between), Firefox is re-injecting this
+// document_idle content script into a live isolated world instead of a fresh
+// one — which is exactly the "SyntaxError: redeclaration of const" signature.
+// Delete alongside worker/core/trace.ts once the bug is found.
+// eslint-disable-next-line no-console -- temporary diagnostic instrumentation
+console.log(
+  `[SL:watch] init t=${performance.now().toFixed(1)}ms readyState=${document.readyState} url=${location.href} title=${JSON.stringify(document.title)}`
+)
+
 /** Elements that have received input and may hold unsaved content. */
 const dirtyElements = new Set<Element>()
 /** Latched once any tracked element is edited; reset by `submit`. */

--- a/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
@@ -138,3 +138,16 @@ export function getTab(
     callback(tab)
   })
 }
+
+/**
+ * Promise form of `getTab`, for the async discard flow. `tabs.get` reads the
+ * browser's *cached* tab metadata — crucially it does NOT materialize (reload)
+ * a discarded tab the way `executeScript`/`sendMessage` would — so it is safe
+ * to use as the ground-truth liveness check before deciding to roll a marker
+ * back.
+ */
+export function getTabSnapshot(
+  tabId: number
+): Promise<chrome.tabs.Tab | undefined> {
+  return new Promise((resolve) => getTab(tabId, resolve))
+}

--- a/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
@@ -1,0 +1,140 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Browser adapter: everything `discard.ts` needs to know about how
+ * `chrome.tabs.discard` / `chrome.scripting.executeScript` actually behave,
+ * normalized into plain result types.
+ *
+ * This is the ONLY module that calls `chrome.tabs.discard` or injects the
+ * title-marker scripts. It knows about retries, callback-vs-lastError
+ * normalization, and transient-rejection quirks — none of which are domain
+ * concerns (see suspend-fsm.ts) and none of which the orchestrator
+ * (discard.ts) should have to reason about beyond "did it work."
+ */
+
+import {
+  markBeforeDiscard,
+  RESUME_FLAG_KEY,
+  unmarkAfterDiscard,
+} from "./title-marker"
+import { log } from "./utils"
+
+export type MarkOutcome = "applied" | "skipped"
+export type DiscardResult = { ok: true } | { ok: false; message: string }
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/** How long to let the browser settle before retrying a failed discard. */
+const RETRY_DELAY_MS = 250
+
+/**
+ * Injects the sleep marker into the page. Returns `"skipped"` rather than
+ * throwing when the tab isn't script-injectable (chrome://, about:, …) — that
+ * is an expected, non-exceptional outcome the caller must branch on (the
+ * FSM's PREPARING → SUSPENDING_BARE edge), not a failure.
+ */
+export async function injectMark(
+  tabId: number,
+  marker: string
+): Promise<MarkOutcome> {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: markBeforeDiscard,
+      args: [RESUME_FLAG_KEY, marker],
+    })
+    return "applied"
+  } catch (e) {
+    // No content-injectable document — discard still proceeds; that tab
+    // simply won't get the veil or marker.
+    log("could not prepare tab for discard", e)
+    return "skipped"
+  }
+}
+
+/**
+ * Strips a marker that was applied for a discard that did not stick. Safe to
+ * call on a tab with no marker (e.g. one that was never scripted) or one
+ * that's already gone (a discard that *did* land) — both are no-ops.
+ */
+export async function injectUnmark(
+  tabId: number,
+  marker: string
+): Promise<void> {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: unmarkAfterDiscard,
+      args: [RESUME_FLAG_KEY, marker],
+    })
+  } catch (e) {
+    log("could not roll back discard marker", e)
+  }
+}
+
+/** One `chrome.tabs.discard` call, normalized to a result instead of a callback. */
+function discardOnce(tabId: number): Promise<DiscardResult> {
+  return new Promise((resolve) => {
+    try {
+      chrome.tabs.discard(tabId, () => {
+        const err = chrome.runtime.lastError
+        resolve(
+          err
+            ? { ok: false, message: err.message ?? String(err) }
+            : { ok: true }
+        )
+      })
+    } catch (e) {
+      resolve({
+        ok: false,
+        message: e instanceof Error ? e.message : String(e),
+      })
+    }
+  })
+}
+
+/**
+ * `chrome.tabs.discard`, with one retry on rejection.
+ *
+ * `discard()` is called immediately after a script injection into this same
+ * tab (`injectMark`), and — for the manual-suspend caller (menu.ts) — often
+ * right after a `tabs.update` focus switch away from this very tab. Both can
+ * leave the tab looking "recently touched" to the browser's own
+ * discard-eligibility check for a brief moment. That's transient: a single
+ * retry after a short delay is enough to let it clear, rather than treating
+ * every such race as a real, permanent refusal.
+ */
+export async function requestDiscard(tabId: number): Promise<DiscardResult> {
+  let attempt = await discardOnce(tabId)
+  if (!attempt.ok) {
+    log("discard failed, retrying once", attempt.message)
+    await wait(RETRY_DELAY_MS)
+    attempt = await discardOnce(tabId)
+  }
+  return attempt
+}
+
+/**
+ * Callback wrapper over `chrome.tabs.get`, normalizing the stale-id/lastError
+ * case to `undefined`. Deliberately callback-shaped (not a `Promise`) to
+ * match `chrome.tabs.onActivated`'s own synchronous-dispatch semantics in
+ * `reconcileActivatedTab`.
+ */
+export function getTab(
+  tabId: number,
+  callback: (tab: chrome.tabs.Tab | undefined) => void
+): void {
+  chrome.tabs.get(tabId, (tab) => {
+    // the typings mark `tab` non-optional, but it is undefined at runtime
+    // when the id is stale (tab closed between activation and this callback)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (chrome.runtime.lastError || !tab) {
+      callback(undefined)
+      return
+    }
+    callback(tab)
+  })
+}

--- a/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
@@ -82,28 +82,37 @@ export async function injectUnmark(
   }
 }
 
-/** One `chrome.tabs.discard` call, normalized to a result instead of a callback. */
+/**
+ * One `chrome.tabs.discard` call, normalized to a result instead of a
+ * callback/promise split.
+ *
+ * Deliberately called with ONLY `tabId` — no callback argument. The
+ * `@types/chrome` bindings advertise a `discard(tabId, callback)` overload
+ * (mirroring Chrome's own API), but Firefox's actual runtime implementation
+ * of `chrome.tabs.discard` only implements the Promise form (its native
+ * schema is `browser.tabs.discard(tabIds)`, no callback parameter at all).
+ * Passing a callback there fails Firefox's argument-shape validation and
+ * throws `"Incorrect argument types for tabs.discard."` SYNCHRONOUSLY, on
+ * every single call, regardless of tab state — not a race, a hard permanent
+ * break. The promise-only call form is genuinely cross-browser: Chrome's MV3
+ * implementation also returns a Promise whenever no callback is supplied.
+ */
 function discardOnce(tabId: number): Promise<DiscardResult> {
   trace("adapter.discardOnce:call", tabId)
-  return new Promise((resolve) => {
-    try {
-      chrome.tabs.discard(tabId, () => {
-        const err = chrome.runtime.lastError
-        const result: DiscardResult = err
-          ? { ok: false, message: err.message ?? String(err) }
-          : { ok: true }
-        trace("adapter.discardOnce:callback", tabId, result)
-        resolve(result)
-      })
-    } catch (e) {
+  return Promise.resolve(chrome.tabs.discard(tabId))
+    .then((): DiscardResult => {
+      const result: DiscardResult = { ok: true }
+      trace("adapter.discardOnce:resolved", tabId, result)
+      return result
+    })
+    .catch((e: unknown): DiscardResult => {
       const result: DiscardResult = {
         ok: false,
         message: e instanceof Error ? e.message : String(e),
       }
-      trace("adapter.discardOnce:threw", tabId, result)
-      resolve(result)
-    }
-  })
+      trace("adapter.discardOnce:rejected", tabId, result)
+      return result
+    })
 }
 
 /**

--- a/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard-adapter.ts
@@ -19,6 +19,7 @@ import {
   RESUME_FLAG_KEY,
   unmarkAfterDiscard,
 } from "./title-marker"
+import { trace } from "./trace"
 import { log } from "./utils"
 
 export type MarkOutcome = "applied" | "skipped"
@@ -40,17 +41,20 @@ export async function injectMark(
   tabId: number,
   marker: string
 ): Promise<MarkOutcome> {
+  trace("adapter.injectMark:start", tabId)
   try {
     await chrome.scripting.executeScript({
       target: { tabId },
       func: markBeforeDiscard,
       args: [RESUME_FLAG_KEY, marker],
     })
+    trace("adapter.injectMark:applied", tabId)
     return "applied"
   } catch (e) {
     // No content-injectable document — discard still proceeds; that tab
     // simply won't get the veil or marker.
     log("could not prepare tab for discard", e)
+    trace("adapter.injectMark:skipped", tabId, e)
     return "skipped"
   }
 }
@@ -64,34 +68,40 @@ export async function injectUnmark(
   tabId: number,
   marker: string
 ): Promise<void> {
+  trace("adapter.injectUnmark:start", tabId)
   try {
     await chrome.scripting.executeScript({
       target: { tabId },
       func: unmarkAfterDiscard,
       args: [RESUME_FLAG_KEY, marker],
     })
+    trace("adapter.injectUnmark:done", tabId)
   } catch (e) {
     log("could not roll back discard marker", e)
+    trace("adapter.injectUnmark:error", tabId, e)
   }
 }
 
 /** One `chrome.tabs.discard` call, normalized to a result instead of a callback. */
 function discardOnce(tabId: number): Promise<DiscardResult> {
+  trace("adapter.discardOnce:call", tabId)
   return new Promise((resolve) => {
     try {
       chrome.tabs.discard(tabId, () => {
         const err = chrome.runtime.lastError
-        resolve(
-          err
-            ? { ok: false, message: err.message ?? String(err) }
-            : { ok: true }
-        )
+        const result: DiscardResult = err
+          ? { ok: false, message: err.message ?? String(err) }
+          : { ok: true }
+        trace("adapter.discardOnce:callback", tabId, result)
+        resolve(result)
       })
     } catch (e) {
-      resolve({
+      const result: DiscardResult = {
         ok: false,
         message: e instanceof Error ? e.message : String(e),
-      })
+      }
+      trace("adapter.discardOnce:threw", tabId, result)
+      resolve(result)
     }
   })
 }
@@ -111,9 +121,11 @@ export async function requestDiscard(tabId: number): Promise<DiscardResult> {
   let attempt = await discardOnce(tabId)
   if (!attempt.ok) {
     log("discard failed, retrying once", attempt.message)
+    trace("adapter.requestDiscard:retrying", tabId, attempt.message)
     await wait(RETRY_DELAY_MS)
     attempt = await discardOnce(tabId)
   }
+  trace("adapter.requestDiscard:final", tabId, attempt)
   return attempt
 }
 
@@ -132,9 +144,16 @@ export function getTab(
     // when the id is stale (tab closed between activation and this callback)
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (chrome.runtime.lastError || !tab) {
+      trace("adapter.getTab:miss", tabId, chrome.runtime.lastError?.message)
       callback(undefined)
       return
     }
+    trace("adapter.getTab:hit", tabId, {
+      discarded: tab.discarded,
+      status: tab.status,
+      active: tab.active,
+      title: tab.title,
+    })
     callback(tab)
   })
 }

--- a/extensions/suspender-ledger/src/worker/core/discard.concurrency.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.concurrency.test.ts
@@ -21,7 +21,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "./discard"
 import { prefs } from "./prefs"
 
-type DiscardCb = (tab?: chrome.tabs.Tab) => void
 type ExecuteScriptCall = {
   func: (...args: Array<unknown>) => unknown
   args?: Array<unknown>
@@ -100,11 +99,10 @@ describe("discard — marker idempotency under repeated attempts", () => {
           title: "Example",
         })
 
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        vi.mocked(chrome.tabs.discard).mockImplementation(((
-          _id: number,
-          cb: DiscardCb
-        ) => cb(undefined)) as never)
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        vi.mocked(chrome.tabs.discard).mockImplementation((id?: number) =>
+          Promise.resolve(tab({ id, discarded: true }))
+        )
 
         for (let i = 0; i < attempts; i += 1) {
           await discard(t)
@@ -126,14 +124,15 @@ describe("discard — in-flight re-entry", () => {
     vi.useFakeTimers()
     try {
       const t = tab({ id: 960, url: "https://example.com/", title: "Example" })
-      const pending: Array<() => void> = []
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      vi.mocked(chrome.tabs.discard).mockImplementation(((
-        _id: number,
-        cb: DiscardCb
-      ) => {
-        pending.push(() => cb(undefined))
-      }) as never)
+      const pending: Array<(tab: chrome.tabs.Tab) => void> = []
+      /* eslint-disable @typescript-eslint/no-misused-promises -- mockImplementation's typed overloads include a void-returning form; the promise form is the one that's actually cross-browser-correct, see discard-adapter.ts */
+      vi.mocked(chrome.tabs.discard).mockImplementation(
+        () =>
+          new Promise<chrome.tabs.Tab>((resolve) => {
+            pending.push(resolve)
+          })
+      )
+      /* eslint-enable @typescript-eslint/no-misused-promises */
 
       void discard(t)
       // Past the legacy fixed debounce window (2000ms) — the first request's
@@ -145,7 +144,9 @@ describe("discard — in-flight re-entry", () => {
 
       expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1)
 
-      pending.splice(0).forEach((resolve) => resolve())
+      pending
+        .splice(0)
+        .forEach((resolve) => resolve(tab({ id: 960, discarded: true })))
     } finally {
       vi.useRealTimers()
     }
@@ -160,9 +161,12 @@ describe("discard — queue de-duplication", () => {
       (_keys: unknown, cb: (items: Record<string, unknown>) => void) =>
         cb({ "simultaneous-jobs": 0 })
     )
-    vi.mocked(chrome.tabs.discard).mockImplementation(() => {
-      // never calls back — the occupying tab holds the only slot forever
-    })
+    // never resolves — the occupying tab holds the only slot forever
+    /* eslint-disable @typescript-eslint/no-misused-promises -- see the in-flight re-entry test above for why the promise form (not the callback one) is correct here */
+    vi.mocked(chrome.tabs.discard).mockImplementation(
+      () => new Promise<chrome.tabs.Tab>(() => undefined)
+    )
+    /* eslint-enable @typescript-eslint/no-misused-promises */
 
     vi.useFakeTimers()
     try {

--- a/extensions/suspender-ledger/src/worker/core/discard.concurrency.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.concurrency.test.ts
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Adapter-level concurrency tests for `discard.ts` — the "thunderstorm" smell
+ * test: does the real, shipped mark/unmark logic and its in-flight bookkeeping
+ * survive overlapping suspend requests for the same tab, or does it stack the
+ * sleep marker / duplicate work?
+ *
+ * These drive the actual `discard()` entry point (not a reimplementation) and
+ * let `chrome.scripting.executeScript`'s mock invoke the real injected
+ * closures (`markBeforeDiscard` / `unmarkAfterDiscard`) against jsdom's real
+ * `document`, so a passing test proves something about the shipped code, not
+ * about a model of it.
+ */
+
+import fc from "fast-check"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { discard, inprogress } from "./discard"
+import { prefs } from "./prefs"
+
+type DiscardCb = (tab?: chrome.tabs.Tab) => void
+type ExecuteScriptCall = {
+  func: (...args: Array<unknown>) => unknown
+  args?: Array<unknown>
+}
+
+const tab = (over: Partial<chrome.tabs.Tab>): chrome.tabs.Tab => ({
+  id: 1,
+  index: 0,
+  active: false,
+  discarded: false,
+  autoDiscardable: true,
+  pinned: false,
+  highlighted: false,
+  selected: false,
+  incognito: false,
+  windowId: 1,
+  groupId: -1,
+  ...over,
+})
+
+/** How many times the marker is stacked at the front of `title`. */
+const countLeadingPrefixes = (title: string, prefix: string): number => {
+  let count = 0
+  let rest = title
+  while (rest.startsWith(`${prefix} `)) {
+    count += 1
+    rest = rest.slice(prefix.length + 1)
+  }
+  return count
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  discard.count = 0
+  discard.time = 0
+  discard.tabs.length = 0
+  inprogress.clear()
+  prefs.prepends = "💤"
+  document.title = "Example"
+
+  vi.mocked(chrome.storage.local.get).mockImplementation(
+    (_keys: unknown, cb: (items: Record<string, unknown>) => void) => cb({})
+  )
+
+  // Invoke the real injected closures against jsdom's real `document` instead
+  // of stubbing executeScript out entirely — a passing test here proves the
+  // shipped mark/unmark functions are idempotent, not a reimplementation.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  vi.mocked(chrome.scripting.executeScript).mockImplementation(((
+    opts: ExecuteScriptCall
+  ) => {
+    const result = opts.func(...(opts.args ?? []))
+    return Promise.resolve([{ frameId: 0, result }])
+  }) as never)
+})
+
+afterEach(() => {
+  prefs.prepends = ""
+})
+
+describe("discard — marker idempotency under repeated attempts", () => {
+  it("never stacks the marker across repeated suspend attempts on a stale tab snapshot", async () => {
+    // A caller that never re-queries the tab between attempts (its snapshot's
+    // `discarded` flag stays false forever) models exactly the out-of-order/
+    // stale-event surface real browser extensions live with.
+    await fc.assert(
+      fc.asyncProperty(fc.integer({ min: 1, max: 4 }), async (attempts) => {
+        document.title = "Example"
+        discard.count = 0
+        discard.tabs.length = 0
+        inprogress.clear()
+
+        const t = tab({
+          id: 950,
+          url: "https://example.com/",
+          title: "Example",
+        })
+
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        vi.mocked(chrome.tabs.discard).mockImplementation(((
+          _id: number,
+          cb: DiscardCb
+        ) => cb(undefined)) as never)
+
+        for (let i = 0; i < attempts; i += 1) {
+          await discard(t)
+          // Simulate enough real time passing between independent requests
+          // that the debounce would have cleared regardless of its mechanism.
+          inprogress.clear()
+        }
+
+        expect(countLeadingPrefixes(document.title, "💤")).toBeLessThanOrEqual(
+          1
+        )
+      })
+    )
+  })
+})
+
+describe("discard — in-flight re-entry", () => {
+  it("does not let a second request re-enter while the first is still mid-flight", async () => {
+    vi.useFakeTimers()
+    try {
+      const t = tab({ id: 960, url: "https://example.com/", title: "Example" })
+      const pending: Array<() => void> = []
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      vi.mocked(chrome.tabs.discard).mockImplementation(((
+        _id: number,
+        cb: DiscardCb
+      ) => {
+        pending.push(() => cb(undefined))
+      }) as never)
+
+      void discard(t)
+      // Past the legacy fixed debounce window (2000ms) — the first request's
+      // chrome.tabs.discard callback still has not fired.
+      await vi.advanceTimersByTimeAsync(3000)
+
+      void discard(t)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1)
+
+      pending.splice(0).forEach((resolve) => resolve())
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe("discard — queue de-duplication", () => {
+  it("never queues the same tab twice while a suspend is already pending for it", async () => {
+    // simultaneous-jobs = 0 forces every request behind the first into the
+    // queue, regardless of which tab it is for.
+    vi.mocked(chrome.storage.local.get).mockImplementation(
+      (_keys: unknown, cb: (items: Record<string, unknown>) => void) =>
+        cb({ "simultaneous-jobs": 0 })
+    )
+    vi.mocked(chrome.tabs.discard).mockImplementation(() => {
+      // never calls back — the occupying tab holds the only slot forever
+    })
+
+    vi.useFakeTimers()
+    try {
+      const occupying = tab({ id: 100, url: "https://occupy.example.com/" })
+      const t = tab({ id: 101, url: "https://example.com/" })
+
+      void discard(occupying)
+      await vi.advanceTimersByTimeAsync(0)
+
+      void discard(t) // queued
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Past the legacy fixed debounce window — a naive time-based release
+      // would have cleared `inprogress` for tab 101 here even though it is
+      // still sitting untouched in the queue.
+      await vi.advanceTimersByTimeAsync(3000)
+
+      void discard(t) // duplicate request for the SAME still-queued tab
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(discard.tabs.filter((qt) => qt.id === 101)).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { discard, inprogress } from "./discard"
+import { discard, inprogress, reconcileActivatedTab } from "./discard"
 import { prefs } from "./prefs"
 
 type DiscardCb = (tab?: chrome.tabs.Tab) => void
@@ -105,6 +105,55 @@ describe("discard", () => {
     expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
+  it("skips an audible tab without marking it (the YouTube case)", async () => {
+    // The browser refuses to discard a playing tab; suspending it anyway would
+    // strand the sleep marker on a live, audible page. Skip before marking.
+    await discard(
+      tab({ id: 7, url: "https://youtube.com/watch", audible: true })
+    )
+
+    expect(chrome.scripting.executeScript).not.toHaveBeenCalled()
+    expect(chrome.tabs.discard).not.toHaveBeenCalled()
+  })
+
+  it("rolls back the marker when the browser rejects the discard", async () => {
+    prefs.prepends = "💤"
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    vi.mocked(chrome.tabs.discard).mockImplementation(((
+      _id: number,
+      cb: DiscardCb
+    ) => {
+      Object.assign(chrome.runtime, {
+        lastError: { message: "Tabs cannot be discarded." },
+      })
+      cb(undefined)
+      Object.assign(chrome.runtime, { lastError: undefined })
+    }) as never)
+
+    await discard(tab({ id: 8, url: "https://example.com/", title: "Example" }))
+
+    // Two executeScript calls: the mark, then the rollback (unmark).
+    expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(2)
+    expect(chrome.scripting.executeScript).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        target: { tabId: 8 },
+        args: ["__sl_resuming", "💤"],
+      })
+    )
+    expect(chrome.tabs.remove).not.toHaveBeenCalled()
+    prefs.prepends = ""
+  })
+
+  it("does not roll back the marker when the discard succeeds", async () => {
+    prefs.prepends = "💤"
+    await discard(tab({ id: 9, url: "https://example.com/", title: "Example" }))
+
+    // Only the mark ran; a successful discard tears down the page and the
+    // browser keeps showing the cached (marked) title — nothing to undo.
+    expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1)
+    prefs.prepends = ""
+  })
+
   it("ignores a duplicate request while a suspend is in progress", async () => {
     discard(tab({ id: 4, url: "https://example.com/" }))
     discard(tab({ id: 4, url: "https://example.com/" }))
@@ -186,5 +235,50 @@ describe("discard", () => {
     await discard(tab({ id: 22, discarded: true }))
 
     expect(chrome.tabs.remove).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe("reconcileActivatedTab", () => {
+  type GetCb = (tab?: chrome.tabs.Tab) => void
+
+  const mockGet = (result?: chrome.tabs.Tab): void => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    vi.mocked(chrome.tabs.get).mockImplementation(((_id: number, cb: GetCb) =>
+      cb(result)) as never)
+  }
+
+  it("strips a stranded marker from a live, marked tab", () => {
+    prefs.prepends = "💤"
+    mockGet(tab({ id: 30, discarded: false, title: "💤 Example" }))
+
+    reconcileActivatedTab(30)
+
+    expect(chrome.scripting.executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { tabId: 30 },
+        args: ["__sl_resuming", "💤"],
+      })
+    )
+    prefs.prepends = ""
+  })
+
+  it("leaves a properly discarded tab alone (cached marker is intended)", () => {
+    prefs.prepends = "💤"
+    mockGet(tab({ id: 31, discarded: true, title: "💤 Example" }))
+
+    reconcileActivatedTab(31)
+
+    expect(chrome.scripting.executeScript).not.toHaveBeenCalled()
+    prefs.prepends = ""
+  })
+
+  it("leaves an unmarked live tab alone", () => {
+    prefs.prepends = "💤"
+    mockGet(tab({ id: 32, discarded: false, title: "Example" }))
+
+    reconcileActivatedTab(32)
+
+    expect(chrome.scripting.executeScript).not.toHaveBeenCalled()
+    prefs.prepends = ""
   })
 })

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -7,8 +7,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress, reconcileActivatedTab } from "./discard"
 import { prefs } from "./prefs"
 
-type DiscardCb = (tab?: chrome.tabs.Tab) => void
-
 const flush = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -47,14 +45,15 @@ beforeEach(() => {
     () => Promise.resolve([])
   )
 
-  // tabs.discard resolves its callback immediately by default. The chrome
-  // typings surface only the promise overload, so the callback form needs an
-  // assertion (same pattern as chrome.tabs.update elsewhere).
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  vi.mocked(chrome.tabs.discard).mockImplementation(((
-    _id: number,
-    cb: DiscardCb
-  ) => cb(undefined)) as never)
+  // tabs.discard resolves immediately by default. Called with ONLY a tabId —
+  // no callback — because Firefox's actual runtime implementation of
+  // chrome.tabs.discard does not support the callback overload the
+  // @types/chrome bindings advertise; only the promise form works
+  // cross-browser (see discard-adapter.ts's discardOnce docstring).
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  vi.mocked(chrome.tabs.discard).mockImplementation((id?: number) =>
+    Promise.resolve(tab({ id, discarded: true }))
+  )
 
   // tabs.get resolves a live (non-discarded) snapshot by default. The rollback
   // path consults it as ground truth: a marker is only stripped from a tab
@@ -71,7 +70,7 @@ describe("discard", () => {
   it("suspends an eligible tab by calling chrome.tabs.discard", async () => {
     await discard(tab({ id: 1, url: "https://example.com/", title: "Example" }))
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(1, expect.any(Function))
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(1)
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
@@ -100,7 +99,7 @@ describe("discard", () => {
 
     await discard(tab({ id: 1, url: "https://example.com/" }))
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(1, expect.any(Function))
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(1)
   })
 
   it("skips an active tab", async () => {
@@ -130,17 +129,9 @@ describe("discard", () => {
     vi.useFakeTimers()
     try {
       prefs.prepends = "💤"
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      vi.mocked(chrome.tabs.discard).mockImplementation(((
-        _id: number,
-        cb: DiscardCb
-      ) => {
-        Object.assign(chrome.runtime, {
-          lastError: { message: "Tabs cannot be discarded." },
-        })
-        cb(undefined)
-        Object.assign(chrome.runtime, { lastError: undefined })
-      }) as never)
+      vi.mocked(chrome.tabs.discard).mockRejectedValue(
+        new Error("Tabs cannot be discarded.")
+      )
 
       const done = discard(
         tab({ id: 8, url: "https://example.com/", title: "Example" })
@@ -176,17 +167,9 @@ describe("discard", () => {
     vi.useFakeTimers()
     try {
       prefs.prepends = "💤"
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      vi.mocked(chrome.tabs.discard).mockImplementation(((
-        _id: number,
-        cb: DiscardCb
-      ) => {
-        Object.assign(chrome.runtime, {
-          lastError: { message: "Tabs cannot be discarded." },
-        })
-        cb(undefined)
-        Object.assign(chrome.runtime, { lastError: undefined })
-      }) as never)
+      vi.mocked(chrome.tabs.discard).mockRejectedValue(
+        new Error("Tabs cannot be discarded.")
+      )
       // ground truth: the tab really is discarded despite the reported error
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       vi.mocked(chrome.tabs.get).mockImplementation(((
@@ -220,22 +203,14 @@ describe("discard", () => {
     try {
       prefs.prepends = "💤"
       let calls = 0
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      vi.mocked(chrome.tabs.discard).mockImplementation(((
-        _id: number,
-        cb: DiscardCb
-      ) => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      vi.mocked(chrome.tabs.discard).mockImplementation((id?: number) => {
         calls += 1
         if (calls === 1) {
-          Object.assign(chrome.runtime, {
-            lastError: { message: "Tabs cannot be discarded." },
-          })
-          cb(undefined)
-          Object.assign(chrome.runtime, { lastError: undefined })
-        } else {
-          cb(undefined)
+          return Promise.reject(new Error("Tabs cannot be discarded."))
         }
-      }) as never)
+        return Promise.resolve(tab({ id, discarded: true }))
+      })
 
       const done = discard(
         tab({ id: 12, url: "https://example.com/", title: "Example" })
@@ -276,15 +251,16 @@ describe("discard", () => {
       (_keys: unknown, cb: (items: Record<string, unknown>) => void) =>
         cb({ "simultaneous-jobs": 0 })
     )
-    const cbs: Array<DiscardCb> = []
+    const resolvers: Array<(tab: chrome.tabs.Tab) => void> = []
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    vi.mocked(chrome.tabs.discard).mockImplementation(((
-      _id: number,
-      cb: DiscardCb
-    ) => {
-      cbs.push(cb)
-    }) as never)
+    /* eslint-disable @typescript-eslint/no-misused-promises -- mockImplementation's typed overloads include a void-returning form; the promise form is the one that's actually cross-browser-correct, see discard-adapter.ts */
+    vi.mocked(chrome.tabs.discard).mockImplementation(
+      () =>
+        new Promise<chrome.tabs.Tab>((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    /* eslint-enable @typescript-eslint/no-misused-promises */
 
     discard(tab({ id: 10, url: "https://a.example.com/" }))
     discard(tab({ id: 11, url: "https://b.example.com/" }))
@@ -294,36 +270,28 @@ describe("discard", () => {
     expect(chrome.tabs.discard).toHaveBeenCalledTimes(1)
     expect(discard.tabs.length).toBe(1)
 
-    cbs[0]?.() // complete the first suspend
+    resolvers[0]?.(tab({ id: 10, discarded: true })) // complete the first suspend
     await flush()
 
     // queue drained: second tab now suspended
     expect(chrome.tabs.discard).toHaveBeenCalledTimes(2)
     expect(discard.tabs.length).toBe(0)
 
-    cbs[1]?.()
+    resolvers[1]?.(tab({ id: 11, discarded: true }))
     await flush()
 
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
-  it("logs chrome.runtime.lastError when the browser rejects discard", async () => {
+  it("logs the failure message when the browser rejects discard", async () => {
     const consoleSpy = vi
       .spyOn(console, "log")
       .mockImplementation(() => undefined)
     prefs.log = true
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    vi.mocked(chrome.tabs.discard).mockImplementation(((
-      _id: number,
-      cb: DiscardCb
-    ) => {
-      Object.assign(chrome.runtime, {
-        lastError: { message: "Cannot discard tab." },
-      })
-      cb(undefined)
-      Object.assign(chrome.runtime, { lastError: undefined })
-    }) as never)
+    vi.mocked(chrome.tabs.discard).mockRejectedValue(
+      new Error("Cannot discard tab.")
+    )
 
     await discard(tab({ id: 50, url: "https://example.com/" }))
 

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -55,6 +55,16 @@ beforeEach(() => {
     _id: number,
     cb: DiscardCb
   ) => cb(undefined)) as never)
+
+  // tabs.get resolves a live (non-discarded) snapshot by default. The rollback
+  // path consults it as ground truth: a marker is only stripped from a tab
+  // that is genuinely still live, so we never inject into (and thereby reload)
+  // a tab the browser has already discarded.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  vi.mocked(chrome.tabs.get).mockImplementation(((
+    id: number,
+    cb: (t?: chrome.tabs.Tab) => void
+  ) => cb(tab({ id, discarded: false }))) as never)
 })
 
 describe("discard", () => {
@@ -149,6 +159,51 @@ describe("discard", () => {
           args: ["__sl_resuming", "💤"],
         })
       )
+      expect(chrome.tabs.remove).not.toHaveBeenCalled()
+      prefs.prepends = ""
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not roll back (which would reload the tab) when discard reports failure but the tab is already discarded", async () => {
+    // The Firefox "silent refresh" bug: discard surfaces lastError on both
+    // attempts, yet the tab actually IS discarded (a false-negative error, or
+    // the retry landing on an already-discarded tab). Rolling back here would
+    // executeScript into a tab with no live renderer, forcing Firefox to
+    // reload it in the background and strip the marker. The rollback must be
+    // gated on ground-truth liveness instead of trusting the reported error.
+    vi.useFakeTimers()
+    try {
+      prefs.prepends = "💤"
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      vi.mocked(chrome.tabs.discard).mockImplementation(((
+        _id: number,
+        cb: DiscardCb
+      ) => {
+        Object.assign(chrome.runtime, {
+          lastError: { message: "Tabs cannot be discarded." },
+        })
+        cb(undefined)
+        Object.assign(chrome.runtime, { lastError: undefined })
+      }) as never)
+      // ground truth: the tab really is discarded despite the reported error
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      vi.mocked(chrome.tabs.get).mockImplementation(((
+        id: number,
+        cb: (t?: chrome.tabs.Tab) => void
+      ) => cb(tab({ id, discarded: true }))) as never)
+
+      const done = discard(
+        tab({ id: 13, url: "https://example.com/", title: "Example" })
+      )
+      await vi.advanceTimersByTimeAsync(1000)
+      await done
+
+      // The liveness check ran, and only the mark executeScript fired — NO
+      // rollback/unmark, so the discarded tab is never materialized/reloaded.
+      expect(chrome.tabs.get).toHaveBeenCalledWith(13, expect.any(Function))
+      expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1)
       expect(chrome.tabs.remove).not.toHaveBeenCalled()
       prefs.prepends = ""
     } finally {

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -116,32 +116,85 @@ describe("discard", () => {
     expect(chrome.tabs.discard).not.toHaveBeenCalled()
   })
 
-  it("rolls back the marker when the browser rejects the discard", async () => {
-    prefs.prepends = "💤"
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    vi.mocked(chrome.tabs.discard).mockImplementation(((
-      _id: number,
-      cb: DiscardCb
-    ) => {
-      Object.assign(chrome.runtime, {
-        lastError: { message: "Tabs cannot be discarded." },
-      })
-      cb(undefined)
-      Object.assign(chrome.runtime, { lastError: undefined })
-    }) as never)
+  it("rolls back the marker when the browser rejects the discard on both attempts", async () => {
+    vi.useFakeTimers()
+    try {
+      prefs.prepends = "💤"
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      vi.mocked(chrome.tabs.discard).mockImplementation(((
+        _id: number,
+        cb: DiscardCb
+      ) => {
+        Object.assign(chrome.runtime, {
+          lastError: { message: "Tabs cannot be discarded." },
+        })
+        cb(undefined)
+        Object.assign(chrome.runtime, { lastError: undefined })
+      }) as never)
 
-    await discard(tab({ id: 8, url: "https://example.com/", title: "Example" }))
+      const done = discard(
+        tab({ id: 8, url: "https://example.com/", title: "Example" })
+      )
+      await vi.advanceTimersByTimeAsync(1000)
+      await done
 
-    // Two executeScript calls: the mark, then the rollback (unmark).
-    expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(2)
-    expect(chrome.scripting.executeScript).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        target: { tabId: 8 },
-        args: ["__sl_resuming", "💤"],
-      })
-    )
-    expect(chrome.tabs.remove).not.toHaveBeenCalled()
-    prefs.prepends = ""
+      // A persistent rejection is retried once (transient races get one more
+      // chance to clear) before giving up.
+      expect(chrome.tabs.discard).toHaveBeenCalledTimes(2)
+      // Two executeScript calls: the mark, then the rollback (unmark).
+      expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(2)
+      expect(chrome.scripting.executeScript).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          target: { tabId: 8 },
+          args: ["__sl_resuming", "💤"],
+        })
+      )
+      expect(chrome.tabs.remove).not.toHaveBeenCalled()
+      prefs.prepends = ""
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("recovers without rolling back when a retry succeeds after a transient rejection", async () => {
+    // Models the manual-suspend race: the browser momentarily refuses the
+    // first discard (e.g. the focus switch away from this tab, or the mark's
+    // own executeScript call, hasn't fully settled yet), then accepts it on
+    // the very next attempt.
+    vi.useFakeTimers()
+    try {
+      prefs.prepends = "💤"
+      let calls = 0
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      vi.mocked(chrome.tabs.discard).mockImplementation(((
+        _id: number,
+        cb: DiscardCb
+      ) => {
+        calls += 1
+        if (calls === 1) {
+          Object.assign(chrome.runtime, {
+            lastError: { message: "Tabs cannot be discarded." },
+          })
+          cb(undefined)
+          Object.assign(chrome.runtime, { lastError: undefined })
+        } else {
+          cb(undefined)
+        }
+      }) as never)
+
+      const done = discard(
+        tab({ id: 12, url: "https://example.com/", title: "Example" })
+      )
+      await vi.advanceTimersByTimeAsync(1000)
+      await done
+
+      expect(chrome.tabs.discard).toHaveBeenCalledTimes(2)
+      // Only the mark ran — the retry succeeded, so nothing was rolled back.
+      expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1)
+      prefs.prepends = ""
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("does not roll back the marker when the discard succeeds", async () => {

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -35,6 +35,7 @@ import {
   type SuspendEvent,
   type SuspendState,
 } from "./suspend-fsm"
+import { trace } from "./trace"
 import { log } from "./utils"
 
 /**
@@ -64,10 +65,12 @@ function transition(
   event: SuspendEvent
 ): SuspendState {
   const next = reduce(from, event)
+  trace("fsm.transition", tabId, `${from.kind} + ${event.type} -> ${next.kind}`)
   if (!invariant(next)) {
     // Unreachable given the fixed transition table (see suspend-fsm.ts) — a
     // future edge that produces this has a bug, not this tab a bad day.
     log("suspend-fsm invariant violated", { tabId, from, event, next })
+    trace("fsm.INVARIANT_VIOLATED", tabId, { from, event, next })
   }
   if (isSettled(next)) {
     tabStates.delete(tabId)
@@ -113,6 +116,7 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
       return
     }
     const tabId = tab.id
+    trace("perform:start", tabId, { url: tab.url, title: tab.title })
 
     let state = transition(tabId, tabStates.get(tabId) ?? INITIAL_STATE, {
       type: "SUSPEND_REQUESTED",
@@ -128,8 +132,10 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
       )
 
       void requestDiscard(tabId).then(async (attempt) => {
+        trace("perform:requestDiscard-result", tabId, attempt)
         if (attempt.ok) {
           transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
+          trace("perform:done-success", tabId)
           resolve()
           return
         }
@@ -145,6 +151,14 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
         // refreshes" bug. Verify ground truth first; `getTabSnapshot`
         // (`tabs.get`) reads cached metadata and never materializes the tab.
         const snapshot = await getTabSnapshot(tabId)
+        trace(
+          "perform:post-failure-snapshot",
+          tabId,
+          snapshot && {
+            discarded: snapshot.discarded,
+            status: snapshot.status,
+          }
+        )
         if (snapshot?.discarded !== false) {
           // Gone, or actually discarded despite the error — the marker is now
           // the browser's cached title, exactly as intended. Never inject into
@@ -154,6 +168,7 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
             attempt.message
           )
           transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
+          trace("perform:done-false-negative", tabId)
           resolve()
           return
         }
@@ -169,12 +184,14 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
 
         if (state.kind !== "ROLLING_BACK") {
           // Bare tab (never marked) — nothing to strip, just fall back to ACTIVE.
+          trace("perform:done-bare-refused", tabId)
           resolve()
           return
         }
 
         void injectUnmark(tabId, prefs.prepends).then(() => {
           transition(tabId, state, { type: "MARKER_CLEARED" })
+          trace("perform:done-rolled-back", tabId)
           resolve()
         })
       })
@@ -186,8 +203,15 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
     return
   }
   const tabId = tab.id
+  trace("discardImpl:called", tabId, {
+    active: tab.active,
+    discarded: tab.discarded,
+    audible: tab.audible,
+    status: tab.status,
+  })
 
   if (inprogress.has(tabId)) {
+    trace("discardImpl:skip-inprogress", tabId)
     return
   }
 
@@ -205,11 +229,13 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
 
   if (tab.active) {
     log("tab is active", tab)
+    trace("discardImpl:skip-active", tabId)
     release(Promise.resolve())
     return
   }
   if (tab.discarded) {
     log("already discarded", tab)
+    trace("discardImpl:skip-already-discarded", tabId)
     release(Promise.resolve())
     return
   }
@@ -222,6 +248,7 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
       type: "MEDIA_PLAYING",
     })
     log("tab is audible; suspend skipped", tab)
+    trace("discardImpl:skip-audible", tabId)
     release(Promise.resolve())
     return
   }
@@ -294,6 +321,9 @@ const discard: DiscardFn = Object.assign(discardImpl, {
  * Idempotent either way.
  */
 function reconcileActivatedTab(tabId: number): void {
+  trace("reconcileActivatedTab:called", tabId, {
+    tracked: tabStates.get(tabId)?.kind,
+  })
   const marker = prefs.prepends
   if (!marker) {
     return
@@ -301,6 +331,7 @@ function reconcileActivatedTab(tabId: number): void {
 
   const tracked = tabStates.get(tabId)
   if (tracked?.kind === "SUSPENDING") {
+    trace("reconcileActivatedTab:refocus-mid-suspend", tabId)
     const rollingBack = transition(tabId, tracked, { type: "TAB_ACTIVATED" })
     if (rollingBack.kind === "ROLLING_BACK") {
       void injectUnmark(tabId, marker).then(() => {
@@ -316,11 +347,31 @@ function reconcileActivatedTab(tabId: number): void {
     }
     if (typeof tab.title === "string" && tab.title.startsWith(`${marker} `)) {
       log("stripping stranded marker on activated tab", tabId)
+      trace("reconcileActivatedTab:title-heuristic-rollback", tabId, tab.title)
       void injectUnmark(tabId, marker)
     }
   })
 }
 
 chrome.tabs.onActivated.addListener(({ tabId }) => reconcileActivatedTab(tabId))
+
+// TEMP DIAGNOSTIC LISTENERS for the silent-background-reload bug — delete
+// alongside trace.ts once found. These are the ground-truth signal: prior to
+// this, nothing in the extension observed onUpdated at all, so a tab
+// reloading in the background left no trace anywhere in our own logs.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  trace("browser.onUpdated", tabId, {
+    changeInfo,
+    discarded: tab.discarded,
+    status: tab.status,
+    active: tab.active,
+    title: tab.title,
+    tracked: tabStates.get(tabId)?.kind,
+    inprogress: inprogress.has(tabId),
+  })
+})
+chrome.tabs.onRemoved.addListener((tabId) => {
+  trace("browser.onRemoved", tabId)
+})
 
 export { discard, inprogress, reconcileActivatedTab }

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -5,7 +5,35 @@
 // Ported from auto-tab-discard v3/worker/core/discard.mjs (MPL-2.0)
 // Copyright (C) auto-tab-discard contributors
 
+/**
+ * Orchestrator: composes the domain FSM (`suspend-fsm.ts`) with the browser
+ * adapter (`discard-adapter.ts`) to drive one tab's suspend lifecycle, plus
+ * the multi-tab runtime coordination (queueing, cooldown, de-duplication)
+ * that the FSM — which only knows about a single tab in isolation — has no
+ * opinion on.
+ *
+ * `discard.ts` itself does not call `chrome.tabs.discard` or
+ * `chrome.scripting.executeScript` directly; every browser side effect goes
+ * through the adapter. That keeps this file answering "what should happen
+ * next for this tab" (via `reduce`) rather than "how does the browser behave
+ * today."
+ */
+
+import {
+  getTab,
+  injectMark,
+  injectUnmark,
+  requestDiscard,
+} from "./discard-adapter"
 import { prefs, storage } from "./prefs"
+import {
+  INITIAL_STATE,
+  invariant,
+  isSettled,
+  reduce,
+  type SuspendEvent,
+  type SuspendState,
+} from "./suspend-fsm"
 import { log } from "./utils"
 
 /**
@@ -16,89 +44,36 @@ import { log } from "./utils"
  */
 export type SuspendOperation = { tabId: number }
 
-const RESUME_FLAG_KEY = "__sl_resuming"
-
 /**
- * Runs in the page just before it is discarded:
- *   1. Sets a one-shot sessionStorage flag so `resume-veil.ts` (document_start)
- *      paints a dark cover the instant the browser reloads this tab on
- *      reactivation, instead of letting the page's own background flash first.
- *      sessionStorage survives the discard → reload cycle because it's scoped
- *      to the tab's browsing context, not the renderer process discard tears
- *      down.
- *   2. Prefixes the live `document.title` with the sleep marker. The browser
- *      caches title/favicon at the moment a tab is discarded and keeps
- *      showing that cached value in the tab strip while the tab stays
- *      unloaded, so this is what gives a suspended tab its "💤" without
- *      touching the tab's real address or requiring a second page.
+ * In-flight FSM state per tab, for the lifetime of this worker instance. Only
+ * *unsettled* tabs are present — once a tab reaches a settled state (idle,
+ * blocked, or cleanly discarded) there is no follow-up obligation left to
+ * track, so its entry is dropped rather than kept around forever.
+ *
+ * MV3 service workers are recycled, so this map does not survive a worker
+ * restart. `reconcileActivatedTab` below has an explicit fallback for the
+ * case where a tab's marker outlived this map's memory of it.
  */
-function markBeforeDiscard(key: string, prefix: string): void {
-  try {
-    // eslint-disable-next-line extension-charter/no-raw-storage -- runs inside the target page, not extension code; see docstring above.
-    sessionStorage.setItem(key, "1")
-  } catch {
-    // Storage unavailable (e.g. a sandboxed frame) — resume just won't veil.
-  }
-  // Idempotent: a repeated suspend attempt against a tab snapshot that was
-  // never re-queried (so still reports discarded:false) must not re-stack the
-  // marker on top of itself.
-  if (prefix && !document.title.startsWith(`${prefix} `)) {
-    document.title = `${prefix} ${document.title}`
-  }
-}
+const tabStates = new Map<number, SuspendState>()
 
-async function prepareForDiscard(tabId: number, marker: string): Promise<void> {
-  try {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      func: markBeforeDiscard,
-      args: [RESUME_FLAG_KEY, marker],
-    })
-  } catch (e) {
-    // No content-injectable document (e.g. chrome:// or an about: page) —
-    // discard still proceeds; that tab simply won't get the veil or marker.
-    log("could not prepare tab for discard", e)
+/** Apply one FSM transition for `tabId`, updating (or clearing) `tabStates`. */
+function transition(
+  tabId: number,
+  from: SuspendState,
+  event: SuspendEvent
+): SuspendState {
+  const next = reduce(from, event)
+  if (!invariant(next)) {
+    // Unreachable given the fixed transition table (see suspend-fsm.ts) — a
+    // future edge that produces this has a bug, not this tab a bad day.
+    log("suspend-fsm invariant violated", { tabId, from, event, next })
   }
-}
-
-/**
- * Inverse of `markBeforeDiscard`: runs in the page and undoes the marker.
- * Removes the sleep prefix from the live `document.title` (only when it is
- * actually present) and clears the one-shot resume flag. Idempotent — safe to
- * run on a tab that was never marked.
- */
-function unmarkAfterDiscard(key: string, prefix: string): void {
-  try {
-    // eslint-disable-next-line extension-charter/no-raw-storage -- runs inside the target page, mirrors markBeforeDiscard.
-    sessionStorage.removeItem(key)
-  } catch {
-    // Storage unavailable — nothing to clear.
+  if (isSettled(next)) {
+    tabStates.delete(tabId)
+  } else {
+    tabStates.set(tabId, next)
   }
-  // Strip every stacked occurrence, not just one — belt-and-suspenders
-  // alongside markBeforeDiscard's own idempotency guard.
-  while (prefix && document.title.startsWith(`${prefix} `)) {
-    document.title = document.title.slice(prefix.length + 1)
-  }
-}
-
-/**
- * The `ROLLING_BACK → MARKER_CLEARED` edge of the suspend FSM, made real: strip
- * a marker that was applied for a discard that did not stick. Without this the
- * page would sit live, playing, and wearing the sleep prefix forever — the
- * ORPHANED state the FSM invariant forbids (see suspend-fsm.ts, #344/#345).
- */
-async function rollbackMark(tabId: number, marker: string): Promise<void> {
-  try {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      func: unmarkAfterDiscard,
-      args: [RESUME_FLAG_KEY, marker],
-    })
-  } catch (e) {
-    // The page may be gone (a discard that *did* land) or unscriptable — either
-    // way there is no live marker left to strand.
-    log("could not roll back discard marker", e)
-  }
+  return next
 }
 
 /** Tab ids currently mid-suspend, used to debounce duplicate requests. */
@@ -117,57 +92,18 @@ type DiscardFn = {
   perform(tab: chrome.tabs.Tab): Promise<void>
 }
 
-type DiscardAttempt = { ok: true } | { ok: false; message: string }
-
-/** One `chrome.tabs.discard` call, normalized to a result instead of a callback. */
-function discardOnce(tabId: number): Promise<DiscardAttempt> {
-  return new Promise((resolve) => {
-    try {
-      chrome.tabs.discard(tabId, () => {
-        const err = chrome.runtime.lastError
-        resolve(
-          err
-            ? { ok: false, message: err.message ?? String(err) }
-            : { ok: true }
-        )
-      })
-    } catch (e) {
-      resolve({
-        ok: false,
-        message: e instanceof Error ? e.message : String(e),
-      })
-    }
-  })
-}
-
-const wait = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms))
-
-/** How long to let the browser settle before retrying a failed discard. */
-const RETRY_DELAY_MS = 250
-
 /**
- * The terminal action: natively discard the tab. This is the ONLY place a
- * tab's state is changed, and it is `chrome.tabs.discard` — never
- * `chrome.tabs.remove`.
+ * The terminal action: drive one tab through its suspend lifecycle by
+ * dispatching FSM events and letting the *resulting state* pick the next
+ * adapter call — never the other way around. This is the ONLY place a tab's
+ * state is changed, and it always routes through `chrome.tabs.discard` via
+ * the adapter — never `chrome.tabs.remove`.
  *
  * Native discard (rather than navigating to an owned `suspend.html`) keeps the
  * browser's own tab.url/title/favIconUrl intact — no `moz-extension://` URL,
- * full awesome-bar / "switch to tab" fidelity. `prepareForDiscard` runs first
- * so `resume-veil.ts` can cover the reactivation reload before first paint
- * (verified empirically: a document_start veil pre-empts the reload's own
- * background every time, since document_start content scripts run before
- * first paint regardless of what triggered the navigation) and so the tab
- * strip shows the `prepends` marker while the tab stays discarded.
- *
- * `discard()` is called immediately after `prepareForDiscard` injects a
- * script into this same tab. That injection can itself leave the tab looking
- * "recently touched" to the browser's own discard-eligibility check for a
- * brief moment — and for the manual-suspend caller (menu.ts), this also runs
- * right after a `tabs.update` focus switch away from this very tab, another
- * transition the browser may not have fully settled yet. Both are transient:
- * a single retry after a short delay is enough to let them clear, rather than
- * immediately rolling back a mark that a moment later would have stuck.
+ * full awesome-bar / "switch to tab" fidelity. Marking runs first so
+ * `resume-veil.ts` can cover the reactivation reload before first paint, and
+ * so the tab strip shows the `prepends` marker while the tab stays discarded.
  */
 const perform = (tab: chrome.tabs.Tab): Promise<void> =>
   new Promise<void>((resolve) => {
@@ -176,24 +112,45 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
       return
     }
     const tabId = tab.id
-    void prepareForDiscard(tabId, prefs.prepends).finally(() => {
-      void (async () => {
-        let attempt = await discardOnce(tabId)
-        if (!attempt.ok) {
-          log("discard failed, retrying once", attempt.message)
-          await wait(RETRY_DELAY_MS)
-          attempt = await discardOnce(tabId)
+
+    let state = transition(tabId, tabStates.get(tabId) ?? INITIAL_STATE, {
+      type: "SUSPEND_REQUESTED",
+    })
+
+    void injectMark(tabId, prefs.prepends).then((outcome) => {
+      state = transition(
+        tabId,
+        state,
+        outcome === "applied"
+          ? { type: "MARK_APPLIED" }
+          : { type: "MARK_SKIPPED" }
+      )
+
+      void requestDiscard(tabId).then((attempt) => {
+        if (attempt.ok) {
+          transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
+          resolve()
+          return
         }
-        if (!attempt.ok) {
-          // Still refused after the retry — a real block (audible, policy),
-          // not a transient race. We already marked the page, so strip the
-          // marker before resolving — otherwise it is stranded on a live tab
-          // (ORPHANED).
-          log("discard failed", attempt.message)
-          await rollbackMark(tabId, prefs.prepends)
+
+        // Still refused after the adapter's own retry — a real block
+        // (audible, policy), not a transient race.
+        log("discard failed", attempt.message)
+        state = transition(tabId, state, { type: "DISCARD_FAILED" })
+
+        if (state.kind !== "ROLLING_BACK") {
+          // Bare tab (never marked) — nothing to strip, just fall back to ACTIVE.
+          resolve()
+          return
         }
-        resolve()
-      })()
+
+        // We already marked the page; strip it before resolving, otherwise it
+        // is stranded on a live tab (the ORPHANED state the FSM forbids).
+        void injectUnmark(tabId, prefs.prepends).then(() => {
+          transition(tabId, state, { type: "MARKER_CLEARED" })
+          resolve()
+        })
+      })
     })
   })
 
@@ -234,6 +191,9 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
   // the suspend FSM: it avoids applying a marker we would only have to roll
   // back, and avoids the misleading "tab wears 💤 but keeps playing" state.
   if (tab.audible) {
+    transition(tabId, tabStates.get(tabId) ?? INITIAL_STATE, {
+      type: "MEDIA_PLAYING",
+    })
     log("tab is audible; suspend skipped", tab)
     release(Promise.resolve())
     return
@@ -285,29 +245,51 @@ const discard: DiscardFn = Object.assign(discardImpl, {
 })
 
 /**
- * Heal a stranded marker on tab activation.
+ * Heal a marker on tab activation.
  *
- * If an activated tab is still live (not discarded) yet its title carries the
- * sleep prefix, the marker was left behind — a discard the browser refused, a
- * refocus that raced the discard callback, or a tab orphaned by an older build.
- * A reactivated *discarded* tab reloads and resets its own title, so those are
- * left alone; only live, marker-bearing tabs are cleaned. Idempotent.
+ * Two distinct cases, in order:
+ *
+ *   1. This worker instance has a tracked in-flight suspend for the tab and
+ *      it is still `SUSPENDING` (marked, discard not yet confirmed) — the
+ *      user refocused mid-suspend. This is the FSM's own
+ *      `SUSPENDING + TAB_ACTIVATED → ROLLING_BACK` edge; route the actual
+ *      unmark through it rather than re-deriving the decision from scratch.
+ *
+ *   2. Nothing is tracked for this tab in `tabStates` — either it never
+ *      carried a marker, it's a cleanly discarded tab, or (the case this
+ *      exists for) an MV3 service-worker restart erased this module's memory
+ *      of an in-flight suspend between marking and discard. `tab.title` is a
+ *      projection of state, not the state itself, but once our own
+ *      bookkeeping is gone it is the only signal left — so it is used here
+ *      strictly as a recovery heuristic for that amnesia case, never as the
+ *      primary decision path.
+ *
+ * Idempotent either way.
  */
 function reconcileActivatedTab(tabId: number): void {
   const marker = prefs.prepends
   if (!marker) {
     return
   }
-  chrome.tabs.get(tabId, (tab) => {
-    // the typings mark `tab` non-optional, but it is undefined at runtime when
-    // the id is stale (tab closed between activation and this callback)
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (chrome.runtime.lastError || !tab || tab.discarded) {
+
+  const tracked = tabStates.get(tabId)
+  if (tracked?.kind === "SUSPENDING") {
+    const rollingBack = transition(tabId, tracked, { type: "TAB_ACTIVATED" })
+    if (rollingBack.kind === "ROLLING_BACK") {
+      void injectUnmark(tabId, marker).then(() => {
+        transition(tabId, rollingBack, { type: "MARKER_CLEARED" })
+      })
+    }
+    return
+  }
+
+  getTab(tabId, (tab) => {
+    if (!tab || tab.discarded) {
       return
     }
     if (typeof tab.title === "string" && tab.title.startsWith(`${marker} `)) {
       log("stripping stranded marker on activated tab", tabId)
-      void rollbackMark(tabId, marker)
+      void injectUnmark(tabId, marker)
     }
   })
 }

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -58,6 +58,44 @@ async function prepareForDiscard(tabId: number, marker: string): Promise<void> {
   }
 }
 
+/**
+ * Inverse of `markBeforeDiscard`: runs in the page and undoes the marker.
+ * Removes the sleep prefix from the live `document.title` (only when it is
+ * actually present) and clears the one-shot resume flag. Idempotent — safe to
+ * run on a tab that was never marked.
+ */
+function unmarkAfterDiscard(key: string, prefix: string): void {
+  try {
+    // eslint-disable-next-line extension-charter/no-raw-storage -- runs inside the target page, mirrors markBeforeDiscard.
+    sessionStorage.removeItem(key)
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
+  if (prefix && document.title.startsWith(`${prefix} `)) {
+    document.title = document.title.slice(prefix.length + 1)
+  }
+}
+
+/**
+ * The `ROLLING_BACK → MARKER_CLEARED` edge of the suspend FSM, made real: strip
+ * a marker that was applied for a discard that did not stick. Without this the
+ * page would sit live, playing, and wearing the sleep prefix forever — the
+ * ORPHANED state the FSM invariant forbids (see suspend-fsm.ts, #344/#345).
+ */
+async function rollbackMark(tabId: number, marker: string): Promise<void> {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: unmarkAfterDiscard,
+      args: [RESUME_FLAG_KEY, marker],
+    })
+  } catch (e) {
+    // The page may be gone (a discard that *did* land) or unscriptable — either
+    // way there is no live marker left to strand.
+    log("could not roll back discard marker", e)
+  }
+}
+
 /** Tab ids currently mid-suspend, used to debounce duplicate requests. */
 const inprogress = new Set<number>()
 
@@ -100,13 +138,18 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
         chrome.tabs.discard(tabId, () => {
           const err = chrome.runtime.lastError
           if (err) {
+            // The browser refused to discard (e.g. an audible/media tab). We
+            // have already marked the page, so strip the marker before
+            // resolving — otherwise it is stranded on a live tab (ORPHANED).
             log("discard failed", err.message ?? err)
+            void rollbackMark(tabId, prefs.prepends).finally(resolve)
+            return
           }
           resolve()
         })
       } catch (e) {
         log("discarding failed", e)
-        resolve()
+        void rollbackMark(tabId, prefs.prepends).finally(resolve)
       }
     })
   })
@@ -131,6 +174,14 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
   }
   if (tab.discarded) {
     log("already discarded", tab)
+    return
+  }
+  // The browser refuses to discard a tab that is playing audio (a YouTube tab,
+  // a music player). Skipping here — before marking — is the BLOCKED edge of
+  // the suspend FSM: it avoids applying a marker we would only have to roll
+  // back, and avoids the misleading "tab wears 💤 but keeps playing" state.
+  if (tab.audible) {
+    log("tab is audible; suspend skipped", tab)
     return
   }
 
@@ -172,4 +223,34 @@ const discard: DiscardFn = Object.assign(discardImpl, {
   perform,
 })
 
-export { discard, inprogress }
+/**
+ * Heal a stranded marker on tab activation.
+ *
+ * If an activated tab is still live (not discarded) yet its title carries the
+ * sleep prefix, the marker was left behind — a discard the browser refused, a
+ * refocus that raced the discard callback, or a tab orphaned by an older build.
+ * A reactivated *discarded* tab reloads and resets its own title, so those are
+ * left alone; only live, marker-bearing tabs are cleaned. Idempotent.
+ */
+function reconcileActivatedTab(tabId: number): void {
+  const marker = prefs.prepends
+  if (!marker) {
+    return
+  }
+  chrome.tabs.get(tabId, (tab) => {
+    // the typings mark `tab` non-optional, but it is undefined at runtime when
+    // the id is stale (tab closed between activation and this callback)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (chrome.runtime.lastError || !tab || tab.discarded) {
+      return
+    }
+    if (typeof tab.title === "string" && tab.title.startsWith(`${marker} `)) {
+      log("stripping stranded marker on activated tab", tabId)
+      void rollbackMark(tabId, marker)
+    }
+  })
+}
+
+chrome.tabs.onActivated.addListener(({ tabId }) => reconcileActivatedTab(tabId))
+
+export { discard, inprogress, reconcileActivatedTab }

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -117,6 +117,35 @@ type DiscardFn = {
   perform(tab: chrome.tabs.Tab): Promise<void>
 }
 
+type DiscardAttempt = { ok: true } | { ok: false; message: string }
+
+/** One `chrome.tabs.discard` call, normalized to a result instead of a callback. */
+function discardOnce(tabId: number): Promise<DiscardAttempt> {
+  return new Promise((resolve) => {
+    try {
+      chrome.tabs.discard(tabId, () => {
+        const err = chrome.runtime.lastError
+        resolve(
+          err
+            ? { ok: false, message: err.message ?? String(err) }
+            : { ok: true }
+        )
+      })
+    } catch (e) {
+      resolve({
+        ok: false,
+        message: e instanceof Error ? e.message : String(e),
+      })
+    }
+  })
+}
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/** How long to let the browser settle before retrying a failed discard. */
+const RETRY_DELAY_MS = 250
+
 /**
  * The terminal action: natively discard the tab. This is the ONLY place a
  * tab's state is changed, and it is `chrome.tabs.discard` — never
@@ -130,6 +159,15 @@ type DiscardFn = {
  * background every time, since document_start content scripts run before
  * first paint regardless of what triggered the navigation) and so the tab
  * strip shows the `prepends` marker while the tab stays discarded.
+ *
+ * `discard()` is called immediately after `prepareForDiscard` injects a
+ * script into this same tab. That injection can itself leave the tab looking
+ * "recently touched" to the browser's own discard-eligibility check for a
+ * brief moment — and for the manual-suspend caller (menu.ts), this also runs
+ * right after a `tabs.update` focus switch away from this very tab, another
+ * transition the browser may not have fully settled yet. Both are transient:
+ * a single retry after a short delay is enough to let them clear, rather than
+ * immediately rolling back a mark that a moment later would have stuck.
  */
 const perform = (tab: chrome.tabs.Tab): Promise<void> =>
   new Promise<void>((resolve) => {
@@ -139,23 +177,23 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
     }
     const tabId = tab.id
     void prepareForDiscard(tabId, prefs.prepends).finally(() => {
-      try {
-        chrome.tabs.discard(tabId, () => {
-          const err = chrome.runtime.lastError
-          if (err) {
-            // The browser refused to discard (e.g. an audible/media tab). We
-            // have already marked the page, so strip the marker before
-            // resolving — otherwise it is stranded on a live tab (ORPHANED).
-            log("discard failed", err.message ?? err)
-            void rollbackMark(tabId, prefs.prepends).finally(resolve)
-            return
-          }
-          resolve()
-        })
-      } catch (e) {
-        log("discarding failed", e)
-        void rollbackMark(tabId, prefs.prepends).finally(resolve)
-      }
+      void (async () => {
+        let attempt = await discardOnce(tabId)
+        if (!attempt.ok) {
+          log("discard failed, retrying once", attempt.message)
+          await wait(RETRY_DELAY_MS)
+          attempt = await discardOnce(tabId)
+        }
+        if (!attempt.ok) {
+          // Still refused after the retry — a real block (audible, policy),
+          // not a transient race. We already marked the page, so strip the
+          // marker before resolving — otherwise it is stranded on a live tab
+          // (ORPHANED).
+          log("discard failed", attempt.message)
+          await rollbackMark(tabId, prefs.prepends)
+        }
+        resolve()
+      })()
     })
   })
 

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -39,7 +39,10 @@ function markBeforeDiscard(key: string, prefix: string): void {
   } catch {
     // Storage unavailable (e.g. a sandboxed frame) — resume just won't veil.
   }
-  if (prefix) {
+  // Idempotent: a repeated suspend attempt against a tab snapshot that was
+  // never re-queried (so still reports discarded:false) must not re-stack the
+  // marker on top of itself.
+  if (prefix && !document.title.startsWith(`${prefix} `)) {
     document.title = `${prefix} ${document.title}`
   }
 }
@@ -71,7 +74,9 @@ function unmarkAfterDiscard(key: string, prefix: string): void {
   } catch {
     // Storage unavailable — nothing to clear.
   }
-  if (prefix && document.title.startsWith(`${prefix} `)) {
+  // Strip every stacked occurrence, not just one — belt-and-suspenders
+  // alongside markBeforeDiscard's own idempotency guard.
+  while (prefix && document.title.startsWith(`${prefix} `)) {
     document.title = document.title.slice(prefix.length + 1)
   }
 }
@@ -164,16 +169,26 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
     return
   }
 
-  // https://github.com/rNeomy/auto-tab-discard/issues/248
+  // https://github.com/rNeomy/auto-tab-discard/issues/248 — cooldown against
+  // rapid duplicate requests. Release is tied to the LATER of this cooldown
+  // and actual completion of whatever this call decides to do below: a fixed
+  // timer alone can expire while a queued or slow-to-complete suspend is still
+  // in flight, letting a second concurrent request re-enter and re-mark the
+  // same live tab.
   inprogress.add(tabId)
-  setTimeout(() => inprogress.delete(tabId), 2000)
+  const cooldown = new Promise<void>((resolve) => setTimeout(resolve, 2000))
+  const release = (op: Promise<void>): void => {
+    void Promise.all([cooldown, op]).finally(() => inprogress.delete(tabId))
+  }
 
   if (tab.active) {
     log("tab is active", tab)
+    release(Promise.resolve())
     return
   }
   if (tab.discarded) {
     log("already discarded", tab)
+    release(Promise.resolve())
     return
   }
   // The browser refuses to discard a tab that is playing audio (a YouTube tab,
@@ -182,10 +197,11 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
   // back, and avoids the misleading "tab wears 💤 but keeps playing" state.
   if (tab.audible) {
     log("tab is audible; suspend skipped", tab)
+    release(Promise.resolve())
     return
   }
 
-  return storage(prefs).then((ps) => {
+  const op = storage(prefs).then((ps) => {
     if (
       discard.count > ps["simultaneous-jobs"] &&
       discard.time + 5000 < Date.now()
@@ -193,8 +209,13 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
       discard.count = 0
     }
     if (discard.count > ps["simultaneous-jobs"]) {
-      log("discarding queue for", tab)
-      discard.tabs.push(tab)
+      // A duplicate request for a tab already sitting in the queue must not
+      // push a second copy — that would eventually run perform() twice for
+      // the same tab and re-mark a title the first copy already marked.
+      if (!discard.tabs.some((qt) => qt.id === tabId)) {
+        log("discarding queue for", tab)
+        discard.tabs.push(tab)
+      }
       return
     }
 
@@ -214,6 +235,8 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
       })
     })
   })
+  release(op)
+  return op
 }
 
 const discard: DiscardFn = Object.assign(discardImpl, {

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -21,6 +21,7 @@
 
 import {
   getTab,
+  getTabSnapshot,
   injectMark,
   injectUnmark,
   requestDiscard,
@@ -126,16 +127,44 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
           : { type: "MARK_SKIPPED" }
       )
 
-      void requestDiscard(tabId).then((attempt) => {
+      void requestDiscard(tabId).then(async (attempt) => {
         if (attempt.ok) {
           transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
           resolve()
           return
         }
 
-        // Still refused after the adapter's own retry — a real block
-        // (audible, policy), not a transient race.
-        log("discard failed", attempt.message)
+        // A reported discard failure is NOT proof the tab is still live. On
+        // Firefox a discard can succeed while still surfacing `lastError`, and
+        // the adapter's retry can land on an already-discarded tab. Trusting
+        // the error alone and rolling back would run `executeScript`
+        // (injectUnmark) against a tab the browser has already discarded —
+        // which has no live renderer, so Firefox can only satisfy the
+        // injection by RELOADING the tab in the background: fresh document,
+        // marker gone, focus unchanged. That is the "suspended tab silently
+        // refreshes" bug. Verify ground truth first; `getTabSnapshot`
+        // (`tabs.get`) reads cached metadata and never materializes the tab.
+        const snapshot = await getTabSnapshot(tabId)
+        if (snapshot?.discarded !== false) {
+          // Gone, or actually discarded despite the error — the marker is now
+          // the browser's cached title, exactly as intended. Never inject into
+          // a non-live tab.
+          log(
+            "discard reported failure but tab is not live; keeping marker",
+            attempt.message
+          )
+          transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
+          resolve()
+          return
+        }
+
+        // Genuinely still live → a real block (audible, policy), not a
+        // transient race. Strip the marker so it is not stranded on a live tab
+        // (the ORPHANED state the FSM forbids).
+        log(
+          "discard refused; tab still live, rolling back marker",
+          attempt.message
+        )
         state = transition(tabId, state, { type: "DISCARD_FAILED" })
 
         if (state.kind !== "ROLLING_BACK") {
@@ -144,8 +173,6 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
           return
         }
 
-        // We already marked the page; strip it before resolving, otherwise it
-        // is stranded on a live tab (the ORPHANED state the FSM forbids).
         void injectUnmark(tabId, prefs.prepends).then(() => {
           transition(tabId, state, { type: "MARKER_CLEARED" })
           resolve()

--- a/extensions/suspender-ledger/src/worker/core/suspend-fsm.exhaustion.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-fsm.exhaustion.test.ts
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Transition graph exhaustion test (issue #345).
+ *
+ * Enumerates the entire (state × event) matrix and asserts the invariant holds
+ * on the resulting state for every pair. This is deterministic: it finds gaps
+ * in the transition graph that a hand-picked unit test would miss. Property
+ * tests (issue #344) complement this by exploring *sequences*.
+ *
+ * `allStates` / `allEvents` are exported from `suspend-fsm.ts` so the property
+ * suite reuses them as arbitraries (an acceptance criterion of #345).
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  allEvents,
+  allStates,
+  invariant,
+  reduce,
+  type SuspendState,
+} from "./suspend-fsm"
+
+const describeState = (st: SuspendState): string => st.kind
+
+describe("suspend FSM — transition graph exhaustion", () => {
+  it("preserves the invariant across every (state, event) pair", () => {
+    const violations: Array<string> = []
+
+    for (const state of allStates) {
+      for (const event of allEvents) {
+        const next = reduce(state, event)
+        if (!invariant(next)) {
+          violations.push(
+            `${describeState(state)} --${event.type}--> ${describeState(next)}`
+          )
+        }
+      }
+    }
+
+    // A non-empty list here is the transition graph telling us exactly which
+    // edges strand the marker on a live tab.
+    expect(violations).toEqual([])
+  })
+
+  it("is total — reduce returns a defined state for every pair", () => {
+    for (const state of allStates) {
+      for (const event of allEvents) {
+        expect(reduce(state, event)).toBeDefined()
+      }
+    }
+  })
+
+  it("never produces the illegal ORPHANED state from any legal state", () => {
+    const orphaning: Array<string> = []
+    for (const state of allStates) {
+      for (const event of allEvents) {
+        if (reduce(state, event).kind === "ORPHANED") {
+          orphaning.push(`${state.kind} --${event.type}-->`)
+        }
+      }
+    }
+    expect(orphaning).toEqual([])
+  })
+})

--- a/extensions/suspender-ledger/src/worker/core/suspend-fsm.property.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-fsm.property.test.ts
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Property-based tests for the suspend FSM (issue #344).
+ *
+ * Exhaustion (#345) checks single steps. These fold *sequences* of 1–50 random
+ * events through the reducer from every legal initial state and assert the
+ * invariant holds at every intermediate and final state. This is the layer that
+ * catches "weird timeline" bugs: a discard refused mid-suspend, a refocus
+ * racing the discard callback, media starting after the suspend request.
+ *
+ * fast-check shrinking (on by default) reports the minimal reproducing sequence
+ * when a property fails.
+ */
+
+import fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import {
+  allEvents,
+  allStates,
+  invariant,
+  isLive,
+  isMarked,
+  isSettled,
+  reduce,
+  type SuspendEvent,
+  type SuspendState,
+} from "./suspend-fsm"
+
+const eventArbitrary: fc.Arbitrary<SuspendEvent> = fc.constantFrom(...allEvents)
+const stateArbitrary: fc.Arbitrary<SuspendState> = fc.constantFrom(...allStates)
+const sequenceArbitrary = fc.array(eventArbitrary, {
+  minLength: 1,
+  maxLength: 50,
+})
+
+const fold = (
+  initial: SuspendState,
+  events: ReadonlyArray<SuspendEvent>
+): Array<SuspendState> => {
+  const trace: Array<SuspendState> = [initial]
+  let state = initial
+  for (const event of events) {
+    state = reduce(state, event)
+    trace.push(state)
+  }
+  return trace
+}
+
+describe("suspend FSM — properties", () => {
+  it("holds the invariant at every step of any event sequence", () => {
+    fc.assert(
+      fc.property(stateArbitrary, sequenceArbitrary, (initial, events) => {
+        for (const state of fold(initial, events)) {
+          expect(invariant(state)).toBe(true)
+        }
+      })
+    )
+  })
+
+  it("never rests with a marker stranded on a live tab", () => {
+    // The settled form of the invariant: after any sequence, if the machine is
+    // at rest and the tab is still live, it must not be wearing the marker.
+    fc.assert(
+      fc.property(stateArbitrary, sequenceArbitrary, (initial, events) => {
+        const trace = fold(initial, events)
+        const final = trace[trace.length - 1]
+        if (final !== undefined && isSettled(final) && isLive(final)) {
+          expect(isMarked(final)).toBe(false)
+        }
+      })
+    )
+  })
+
+  // Negative property (#344 acceptance criterion): a prohibited transition is
+  // rejected. An audible tab must never end up suspended-and-marked — the
+  // MEDIA_PLAYING signal has to divert it away from the mark→discard path.
+  it("never marks a tab whose only suspend attempt was preceded by MEDIA_PLAYING", () => {
+    fc.assert(
+      fc.property(
+        // sequences that begin from an idle tab, see media, then are asked to
+        // suspend — the exact YouTube scenario.
+        fc.array(eventArbitrary, { minLength: 0, maxLength: 20 }),
+        (rest) => {
+          const events: Array<SuspendEvent> = [
+            { type: "MEDIA_PLAYING" },
+            { type: "SUSPEND_REQUESTED" },
+            ...rest,
+          ]
+          // Without any DISCARD_SUCCEEDED the tab is still live; it must not be
+          // wearing the marker at rest.
+          const trace = fold({ kind: "ACTIVE" }, events)
+          const final = trace[trace.length - 1]
+          if (final !== undefined && isSettled(final) && isLive(final)) {
+            expect(isMarked(final)).toBe(false)
+          }
+        }
+      )
+    )
+  })
+
+  it("only reaches DISCARDED through an explicit successful discard", () => {
+    // Resurrection guard: DISCARDED is only entered via DISCARD_SUCCEEDED.
+    fc.assert(
+      fc.property(stateArbitrary, sequenceArbitrary, (initial, events) => {
+        let state = initial
+        for (const event of events) {
+          const next = reduce(state, event)
+          if (next.kind === "DISCARDED" && state.kind !== "DISCARDED") {
+            expect(event.type).toBe("DISCARD_SUCCEEDED")
+          }
+          state = next
+        }
+      })
+    )
+  })
+})

--- a/extensions/suspender-ledger/src/worker/core/suspend-fsm.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-fsm.ts
@@ -1,0 +1,276 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Pure typestate FSM for a single tab's suspend lifecycle.
+ *
+ * `discard.ts` performs two *separate* browser side effects to suspend a tab:
+ *
+ *   1. mark   — `executeScript(markBeforeDiscard)` prefixes the live
+ *               `document.title` with the sleep marker and sets the resume flag.
+ *   2. discard — `chrome.tabs.discard(tabId)` tears down the renderer.
+ *
+ * These are not atomic, and step 2 can be refused by the browser (an audible
+ * YouTube tab, a tab Chrome has decided is not discardable, …). This machine
+ * exists to make every ordering of those outcomes an explicitly-mapped state
+ * rather than an implicit gap — so the contract below can be asserted
+ * exhaustively (see `suspend-fsm.exhaustion.test.ts`) and against random event
+ * sequences (see `suspend-fsm.property.test.ts`).
+ *
+ * ── The contract ──────────────────────────────────────────────────────────
+ *
+ * INVARIANT (the marker/discard coherence property):
+ *
+ *   A tab may only carry the sleep marker on its live title while it is either
+ *   already discarded (the renderer is gone, so the marker is the browser's
+ *   *cached* title and cannot mislead) or actively recovering (a marker-clear
+ *   is in flight). No **settled, live** state may carry the marker.
+ *
+ *   Equivalently: `¬(isLive(s) ∧ isMarked(s) ∧ isSettled(s))`.
+ *
+ * The illegal state this forbids is `ORPHANED`: a live tab still playing its
+ * audio, wearing "💤", that the browser refused to discard and that nothing
+ * ever cleans up. That is precisely https://github.com/paulgsc/some-ui/issues
+ * bugs behind #344 / #345 — a marked, audible, non-discarded tab.
+ */
+
+// ── States ──────────────────────────────────────────────────────────────────
+//
+// Discriminated on `kind` (repo FSM idiom). No payload is needed: the marker /
+// liveness / settledness of a tab is fully determined by which state it is in.
+
+export type SuspendState =
+  // Live, unmarked, at rest — an ordinary eligible tab.
+  | { readonly kind: "ACTIVE" }
+
+  // Live, unmarked, at rest — suspend was refused up front because the tab is
+  // playing media. The tab is deliberately left untouched (no marker applied).
+  | { readonly kind: "BLOCKED" }
+
+  // Live, unmarked, transient — suspend requested; the mark `executeScript` has
+  // been dispatched but has not landed yet.
+  | { readonly kind: "PREPARING" }
+
+  // Live, marked, transient — the marker landed; `chrome.tabs.discard` is in
+  // flight, its callback not yet returned.
+  | { readonly kind: "SUSPENDING" }
+
+  // Live, unmarked, transient — the marker was *skipped* (e.g. a chrome:// page
+  // that cannot be scripted); discard still proceeds, just without a marker.
+  | { readonly kind: "SUSPENDING_BARE" }
+
+  // Not live, marked, at rest — the good terminal state. The renderer is gone,
+  // so "💤" is the browser's cached tab-strip title, exactly as intended.
+  | { readonly kind: "DISCARDED" }
+
+  // Not live, unmarked, at rest — good terminal for a bare (unscriptable) tab.
+  | { readonly kind: "DISCARDED_BARE" }
+
+  // Live, marked, transient — discard was refused (or the user refocused mid
+  // suspend) while a marker is on the page; the marker-clear `executeScript` is
+  // in flight. Carries a recovery obligation, so it is *not* settled.
+  | { readonly kind: "ROLLING_BACK" }
+
+  // Live, marked, transient — a discarded tab is being reactivated; the reload
+  // that reactivation triggers will reset the page's own title and drop the
+  // marker. Recovery obligation pending → not settled.
+  | { readonly kind: "RESUMING" }
+
+  // Live, marked, at rest — THE ILLEGAL STATE. A tab the browser refused to
+  // discard, still playing, still wearing the marker, with nothing scheduled to
+  // fix it. Reachable in the current implementation; the invariant forbids it.
+  | { readonly kind: "ORPHANED" }
+
+export type SuspendStateKind = SuspendState["kind"]
+
+// ── Events ────────────────────────────────────────────────────────────────
+
+export type SuspendEvent =
+  | { readonly type: "SUSPEND_REQUESTED" } // user/menu/idle asked to suspend
+  | { readonly type: "MEDIA_PLAYING" } // audible/active-media detected
+  | { readonly type: "MARK_APPLIED" } // executeScript(mark) resolved OK
+  | { readonly type: "MARK_SKIPPED" } // executeScript(mark) failed (chrome://)
+  | { readonly type: "DISCARD_SUCCEEDED" } // chrome.tabs.discard OK
+  | { readonly type: "DISCARD_FAILED" } // chrome.tabs.discard lastError
+  | { readonly type: "MARKER_CLEARED" } // rollback executeScript landed
+  | { readonly type: "TAB_ACTIVATED" } // user focused the tab
+  | { readonly type: "TAB_RELOADED" } // reactivated tab finished reloading
+
+export type SuspendEventType = SuspendEvent["type"]
+
+// ── Structural predicates (the invariant is defined in terms of these) ──────
+
+const LIVE_KINDS: ReadonlySet<SuspendStateKind> = new Set([
+  "ACTIVE",
+  "BLOCKED",
+  "PREPARING",
+  "SUSPENDING",
+  "SUSPENDING_BARE",
+  "ROLLING_BACK",
+  "RESUMING",
+  "ORPHANED",
+])
+
+const MARKED_KINDS: ReadonlySet<SuspendStateKind> = new Set([
+  "SUSPENDING",
+  "DISCARDED",
+  "ROLLING_BACK",
+  "RESUMING",
+  "ORPHANED",
+])
+
+// A state is "settled" when the machine is at rest: no internal follow-up
+// event is expected to arrive on its own. Transient states carry an obligation
+// (a callback, a reload, a rollback) and so are *not* settled.
+const SETTLED_KINDS: ReadonlySet<SuspendStateKind> = new Set([
+  "ACTIVE",
+  "BLOCKED",
+  "DISCARDED",
+  "DISCARDED_BARE",
+  "ORPHANED",
+])
+
+export const isLive = (s: SuspendState): boolean => LIVE_KINDS.has(s.kind)
+export const isMarked = (s: SuspendState): boolean => MARKED_KINDS.has(s.kind)
+export const isSettled = (s: SuspendState): boolean => SETTLED_KINDS.has(s.kind)
+
+/**
+ * The executable contract. `true` ⟺ the state does not leave a marker stranded
+ * on a settled, live tab.
+ */
+export const invariant = (s: SuspendState): boolean =>
+  !(isLive(s) && isMarked(s) && isSettled(s))
+
+// ── Transition table ────────────────────────────────────────────────────────
+
+const s = (kind: SuspendStateKind): SuspendState => ({ kind })
+
+/**
+ * Pure reducer. Unmapped (state, event) pairs are self-loops: an event that
+ * does not apply to the current state leaves it unchanged.
+ *
+ * NOTE: this is the *current-behaviour* model. It is deliberately wrong in two
+ * places so the property/exhaustion tests fail organically and pin the bugs:
+ *
+ *   - `MEDIA_PLAYING` is ignored (today the manual suspend path has no media
+ *     guard — only `number.ts`'s auto path checks `audible`).
+ *   - `SUSPENDING + DISCARD_FAILED` (and refocus mid-suspend) strands the
+ *     marker in `ORPHANED` instead of rolling it back.
+ */
+export function reduce(state: SuspendState, event: SuspendEvent): SuspendState {
+  switch (state.kind) {
+    case "ACTIVE":
+      switch (event.type) {
+        case "SUSPEND_REQUESTED":
+          return s("PREPARING")
+        // BUG (#1): MEDIA_PLAYING is not handled — an audible tab proceeds to
+        // suspend exactly like any other tab.
+        default:
+          return state
+      }
+
+    case "PREPARING":
+      switch (event.type) {
+        case "MARK_APPLIED":
+          return s("SUSPENDING")
+        case "MARK_SKIPPED":
+          return s("SUSPENDING_BARE")
+        default:
+          return state
+      }
+
+    case "SUSPENDING":
+      switch (event.type) {
+        case "DISCARD_SUCCEEDED":
+          return s("DISCARDED")
+        // BUG (#2): discard refused → marker stranded on a live tab, forever.
+        case "DISCARD_FAILED":
+          return s("ORPHANED")
+        // BUG (#2): user refocuses before discard confirms → marker stranded.
+        case "TAB_ACTIVATED":
+          return s("ORPHANED")
+        default:
+          return state
+      }
+
+    case "SUSPENDING_BARE":
+      switch (event.type) {
+        case "DISCARD_SUCCEEDED":
+          return s("DISCARDED_BARE")
+        case "DISCARD_FAILED":
+        case "TAB_ACTIVATED":
+          return s("ACTIVE")
+        default:
+          return state
+      }
+
+    case "DISCARDED":
+      switch (event.type) {
+        case "TAB_ACTIVATED":
+          return s("RESUMING")
+        default:
+          return state
+      }
+
+    case "DISCARDED_BARE":
+      switch (event.type) {
+        case "TAB_ACTIVATED":
+          return s("ACTIVE")
+        default:
+          return state
+      }
+
+    case "RESUMING":
+      switch (event.type) {
+        case "TAB_RELOADED":
+          return s("ACTIVE")
+        default:
+          return state
+      }
+
+    case "ROLLING_BACK":
+      switch (event.type) {
+        case "MARKER_CLEARED":
+          return s("ACTIVE")
+        default:
+          return state
+      }
+
+    case "BLOCKED":
+    case "ORPHANED":
+      return state
+  }
+}
+
+// ── Enumerations for the exhaustion / property tests ────────────────────────
+//
+// `allStates` is the set of *legal* machine states (ORPHANED is intentionally
+// excluded — it is the illegal state the contract forbids; the tests catch it
+// as a *result* of `reduce`, they must not seed from it).
+
+export const allStates: ReadonlyArray<SuspendState> = [
+  { kind: "ACTIVE" },
+  { kind: "BLOCKED" },
+  { kind: "PREPARING" },
+  { kind: "SUSPENDING" },
+  { kind: "SUSPENDING_BARE" },
+  { kind: "DISCARDED" },
+  { kind: "DISCARDED_BARE" },
+  { kind: "ROLLING_BACK" },
+  { kind: "RESUMING" },
+]
+
+export const allEvents: ReadonlyArray<SuspendEvent> = [
+  { type: "SUSPEND_REQUESTED" },
+  { type: "MEDIA_PLAYING" },
+  { type: "MARK_APPLIED" },
+  { type: "MARK_SKIPPED" },
+  { type: "DISCARD_SUCCEEDED" },
+  { type: "DISCARD_FAILED" },
+  { type: "MARKER_CLEARED" },
+  { type: "TAB_ACTIVATED" },
+  { type: "TAB_RELOADED" },
+]
+
+export const INITIAL_STATE: SuspendState = { kind: "ACTIVE" }

--- a/extensions/suspender-ledger/src/worker/core/suspend-fsm.ts
+++ b/extensions/suspender-ledger/src/worker/core/suspend-fsm.ts
@@ -79,7 +79,9 @@ export type SuspendState =
 
   // Live, marked, at rest — THE ILLEGAL STATE. A tab the browser refused to
   // discard, still playing, still wearing the marker, with nothing scheduled to
-  // fix it. Reachable in the current implementation; the invariant forbids it.
+  // fix it. Unreachable in the fixed transition table; retained as the named
+  // state the invariant forbids so the exhaustion/property tests keep pinning
+  // it, and any future edge that produces it fails loudly.
   | { readonly kind: "ORPHANED" }
 
 export type SuspendStateKind = SuspendState["kind"]
@@ -150,13 +152,15 @@ const s = (kind: SuspendStateKind): SuspendState => ({ kind })
  * Pure reducer. Unmapped (state, event) pairs are self-loops: an event that
  * does not apply to the current state leaves it unchanged.
  *
- * NOTE: this is the *current-behaviour* model. It is deliberately wrong in two
- * places so the property/exhaustion tests fail organically and pin the bugs:
+ * The two edges that make the invariant hold — and that fix the reported bugs:
  *
- *   - `MEDIA_PLAYING` is ignored (today the manual suspend path has no media
- *     guard — only `number.ts`'s auto path checks `audible`).
- *   - `SUSPENDING + DISCARD_FAILED` (and refocus mid-suspend) strands the
- *     marker in `ORPHANED` instead of rolling it back.
+ *   - `MEDIA_PLAYING` diverts a tab to `BLOCKED` *before* any marker is applied,
+ *     so an audible YouTube tab is never marked (#344 bug 1). The adapter must
+ *     emit this whenever `chrome.tabs.Tab.audible` (or a media probe) is set.
+ *   - `SUSPENDING + DISCARD_FAILED` (and a refocus mid-suspend) routes to
+ *     `ROLLING_BACK`, which carries the obligation to strip the marker, rather
+ *     than stranding it in `ORPHANED` (#345 bug 2). `ORPHANED` is consequently
+ *     unreachable — kept in the type as the named state the contract forbids.
  */
 export function reduce(state: SuspendState, event: SuspendEvent): SuspendState {
   switch (state.kind) {
@@ -164,14 +168,17 @@ export function reduce(state: SuspendState, event: SuspendEvent): SuspendState {
       switch (event.type) {
         case "SUSPEND_REQUESTED":
           return s("PREPARING")
-        // BUG (#1): MEDIA_PLAYING is not handled — an audible tab proceeds to
-        // suspend exactly like any other tab.
+        case "MEDIA_PLAYING":
+          return s("BLOCKED")
         default:
           return state
       }
 
     case "PREPARING":
       switch (event.type) {
+        // Media detected before the marker landed → abort cleanly, unmarked.
+        case "MEDIA_PLAYING":
+          return s("BLOCKED")
         case "MARK_APPLIED":
           return s("SUSPENDING")
         case "MARK_SKIPPED":
@@ -184,12 +191,12 @@ export function reduce(state: SuspendState, event: SuspendEvent): SuspendState {
       switch (event.type) {
         case "DISCARD_SUCCEEDED":
           return s("DISCARDED")
-        // BUG (#2): discard refused → marker stranded on a live tab, forever.
+        // Discard refused (audible tab, non-discardable) → strip the marker.
         case "DISCARD_FAILED":
-          return s("ORPHANED")
-        // BUG (#2): user refocuses before discard confirms → marker stranded.
+          return s("ROLLING_BACK")
+        // User refocused before discard confirmed → strip the marker.
         case "TAB_ACTIVATED":
-          return s("ORPHANED")
+          return s("ROLLING_BACK")
         default:
           return state
       }
@@ -238,6 +245,17 @@ export function reduce(state: SuspendState, event: SuspendEvent): SuspendState {
       }
 
     case "BLOCKED":
+      switch (event.type) {
+        // An explicit user re-request can force another attempt (e.g. media
+        // stopped since). Auto paths simply never emit SUSPEND_REQUESTED here.
+        case "SUSPEND_REQUESTED":
+          return s("PREPARING")
+        default:
+          return state
+      }
+
+    // Unreachable in this transition table — retained as the named illegal
+    // state the invariant forbids. A self-loop keeps `reduce` total.
     case "ORPHANED":
       return state
   }

--- a/extensions/suspender-ledger/src/worker/core/title-marker.ts
+++ b/extensions/suspender-ledger/src/worker/core/title-marker.ts
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Presentation layer: the sleep-marker UI convention, expressed as the two
+ * page-context functions that `chrome.scripting.executeScript` injects.
+ *
+ * These are the ONLY functions in the suspend pipeline that touch
+ * `document.title` / `sessionStorage`. They do not decide *when* to run — the
+ * domain FSM (`suspend-fsm.ts`) decides that — they only know how to paint and
+ * erase the marker once told to. Nothing here reasons about tab lifecycle.
+ */
+
+export const RESUME_FLAG_KEY = "__sl_resuming"
+
+/**
+ * Runs in the page just before it is discarded:
+ *   1. Sets a one-shot sessionStorage flag so `resume-veil.ts` (document_start)
+ *      paints a dark cover the instant the browser reloads this tab on
+ *      reactivation, instead of letting the page's own background flash first.
+ *      sessionStorage survives the discard → reload cycle because it's scoped
+ *      to the tab's browsing context, not the renderer process discard tears
+ *      down.
+ *   2. Prefixes the live `document.title` with the sleep marker. The browser
+ *      caches title/favicon at the moment a tab is discarded and keeps
+ *      showing that cached value in the tab strip while the tab stays
+ *      unloaded, so this is what gives a suspended tab its "💤" without
+ *      touching the tab's real address or requiring a second page.
+ */
+export function markBeforeDiscard(key: string, prefix: string): void {
+  try {
+    // eslint-disable-next-line extension-charter/no-raw-storage -- runs inside the target page, not extension code; see docstring above.
+    sessionStorage.setItem(key, "1")
+  } catch {
+    // Storage unavailable (e.g. a sandboxed frame) — resume just won't veil.
+  }
+  // Idempotent: a repeated suspend attempt against a tab snapshot that was
+  // never re-queried (so still reports discarded:false) must not re-stack the
+  // marker on top of itself.
+  if (prefix && !document.title.startsWith(`${prefix} `)) {
+    document.title = `${prefix} ${document.title}`
+  }
+}
+
+/**
+ * Inverse of `markBeforeDiscard`: runs in the page and undoes the marker.
+ * Removes the sleep prefix from the live `document.title` (only when it is
+ * actually present) and clears the one-shot resume flag. Idempotent — safe to
+ * run on a tab that was never marked.
+ */
+export function unmarkAfterDiscard(key: string, prefix: string): void {
+  try {
+    // eslint-disable-next-line extension-charter/no-raw-storage -- runs inside the target page, mirrors markBeforeDiscard.
+    sessionStorage.removeItem(key)
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
+  // Strip every stacked occurrence, not just one — belt-and-suspenders
+  // alongside markBeforeDiscard's own idempotency guard.
+  while (prefix && document.title.startsWith(`${prefix} `)) {
+    document.title = document.title.slice(prefix.length + 1)
+  }
+}

--- a/extensions/suspender-ledger/src/worker/core/trace.ts
+++ b/extensions/suspender-ledger/src/worker/core/trace.ts
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * TEMPORARY diagnostic instrumentation for the "suspended tab silently
+ * reloads in the background" bug (#409 follow-up). Unlike `log()` in
+ * `utils.ts`, this is NOT gated on the `log` preference — it always prints,
+ * because the whole point is visibility while chasing an intermittent
+ * browser-behavior bug. Delete this file and its call sites once the bug is
+ * found and fixed.
+ *
+ * Every line is prefixed with a monotonic sequence number and a
+ * high-resolution timestamp so events from the background worker's console
+ * and a page's own console (watch.ts / resume-veil.ts log there too) can be
+ * interleaved by hand into one timeline.
+ */
+
+let seq = 0
+
+export function trace(
+  scope: string,
+  tabId: number | undefined,
+  ...args: Array<unknown>
+): void {
+  seq += 1
+  const t = (
+    typeof performance !== "undefined" ? performance.now() : Date.now()
+  ).toFixed(1)
+  // eslint-disable-next-line no-console -- temporary diagnostic instrumentation, delete with this file
+  console.log(`[SL#${seq} ${t}ms] [${scope}] tab=${tabId ?? "?"}`, ...args)
+}

--- a/extensions/suspender-ledger/src/worker/menu.ts
+++ b/extensions/suspender-ledger/src/worker/menu.ts
@@ -247,11 +247,28 @@ type ClickInfo = {
 
         if (otab?.id !== undefined) {
           chrome.tabs.update(otab.id, { active: true }, () => {
-            // one tab was active when htabs was recorded; mark it inactive
-            htabs.forEach((t) => (t.active = false))
-            htabs.forEach((t) => {
-              void discard(t)
-            })
+            // `htabs` snapshots predate the focus switch above — optimistically
+            // flipping `.active` here would bypass discard()'s own active-tab
+            // guard with a value we merely asserted, not one the browser has
+            // actually confirmed. The `tabs.update` callback firing means the
+            // request was processed, but not necessarily that every internal
+            // consumer (including discard-eligibility) has converged on the
+            // new focus yet — re-querying gets the browser's authoritative
+            // current state instead of gambling on that timing.
+            void Promise.all(
+              htabs.map(async (t) => {
+                const tId = t.id
+                if (tId === undefined) return
+                const fresh = await new Promise<chrome.tabs.Tab | undefined>(
+                  (resolve) => {
+                    chrome.tabs.get(tId, (tb) => {
+                      resolve(chrome.runtime.lastError ? undefined : tb)
+                    })
+                  }
+                )
+                if (fresh) void discard(fresh)
+              })
+            )
           })
         } else {
           notify(chrome.i18n.getMessage("menu_msg3") || "No tab to switch to")

--- a/extensions/suspender-ledger/src/worker/menu.ts
+++ b/extensions/suspender-ledger/src/worker/menu.ts
@@ -9,6 +9,7 @@ import { discard, inprogress } from "./core/discard"
 import { isMoveCommand, navigate } from "./core/navigate"
 import { prefs, storage } from "./core/prefs"
 import { starters } from "./core/startup"
+import { trace } from "./core/trace"
 import { match, notify, query } from "./core/utils"
 import { number } from "./modes/number"
 
@@ -246,7 +247,9 @@ type ClickInfo = {
           .shift()
 
         if (otab?.id !== undefined) {
+          trace("menu:focus-switch-start", tab.id, { switchingTo: otab.id })
           chrome.tabs.update(otab.id, { active: true }, () => {
+            trace("menu:focus-switch-callback", tab.id, { switchedTo: otab.id })
             // `htabs` snapshots predate the focus switch above — optimistically
             // flipping `.active` here would bypass discard()'s own active-tab
             // guard with a value we merely asserted, not one the browser has
@@ -264,6 +267,15 @@ type ClickInfo = {
                     chrome.tabs.get(tId, (tb) => {
                       resolve(chrome.runtime.lastError ? undefined : tb)
                     })
+                  }
+                )
+                trace(
+                  "menu:pre-discard-refetch",
+                  tId,
+                  fresh && {
+                    active: fresh.active,
+                    discarded: fresh.discarded,
+                    audible: fresh.audible,
                   }
                 )
                 if (fresh) void discard(fresh)

--- a/extensions/suspender-ledger/src/worker/modes/number.test.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.test.ts
@@ -7,7 +7,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { discard, inprogress } from "../core/discard"
 import { number } from "./number"
 
-type DiscardCb = (tab?: chrome.tabs.Tab) => void
 type QueryCb = (tabs: Array<chrome.tabs.Tab>) => void
 type StorageCb = (items: Record<string, unknown>) => void
 
@@ -102,14 +101,14 @@ beforeEach(() => {
     () => Promise.resolve(readyResult())
   )
 
-  // tabs.discard (the suspend action) resolves its callback immediately. The
-  // chrome typings surface only the promise overload, so the callback form
-  // needs an assertion (same pattern as chrome.tabs.query above).
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  vi.mocked(chrome.tabs.discard).mockImplementation(((
-    _id: number,
-    cb: DiscardCb
-  ) => cb(undefined)) as never)
+  // tabs.discard (the suspend action) resolves immediately. Called with only
+  // a tabId, no callback — see discard-adapter.ts's discardOnce docstring for
+  // why the callback overload is Firefox-incompatible despite the types.
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  vi.mocked(chrome.tabs.discard).mockImplementation((id?: number) =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    Promise.resolve({ id, discarded: true } as chrome.tabs.Tab)
+  )
 })
 
 describe("number.check — auto-discard", () => {
@@ -124,7 +123,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(10, expect.any(Function))
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(10)
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 
@@ -215,7 +214,7 @@ describe("number.check — auto-discard", () => {
     await number.check()
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(20, expect.any(Function))
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(20)
     expect(chrome.tabs.discard).not.toHaveBeenCalledWith(
       21,
       expect.any(Function)
@@ -251,7 +250,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(50, expect.any(Function))
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(50)
   })
 
   it("skips a pre-existing tab that is too young by tab.lastAccessed", async () => {
@@ -287,7 +286,7 @@ describe("number.check — auto-discard", () => {
     await number.check(undefined, { "ignore.ready.state": true, number: 0 })
     await flush()
 
-    expect(chrome.tabs.discard).toHaveBeenCalledWith(40, expect.any(Function))
+    expect(chrome.tabs.discard).toHaveBeenCalledWith(40)
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
   })
 })

--- a/packages/eslint/src/configs/extensions-security.config.ts
+++ b/packages/eslint/src/configs/extensions-security.config.ts
@@ -64,6 +64,22 @@ const extensionsSecurityConfig = defineConfig([
           message:
             "Dynamic imports from remote URLs are an immediate AMO block. Bundle all dependencies locally.",
         },
+        // @types/chrome advertises chrome.tabs.discard(tabId, callback), but
+        // Firefox's actual runtime implementation of chrome.tabs.discard only
+        // supports the Promise form (its native schema is
+        // browser.tabs.discard(tabIds), no callback parameter at all) — the
+        // callback form throws "Incorrect argument types for tabs.discard."
+        // synchronously, on every call, regardless of tab state. This is a
+        // types-vs-runtime mismatch tsc cannot catch on its own (see
+        // suspender-ledger/src/worker/core/discard-adapter.ts). Call with
+        // only a tabId and treat the return value as a Promise instead —
+        // that form works on both engines.
+        {
+          selector:
+            "CallExpression[callee.object.object.name='chrome'][callee.object.property.name='tabs'][callee.property.name='discard'][arguments.length>1]",
+          message:
+            "chrome.tabs.discard(tabId, callback) throws on Firefox — its runtime only implements the Promise form. Call chrome.tabs.discard(tabId) with no callback instead.",
+        },
       ],
     },
   },

--- a/packages/eslint/tests/extensions.lint.test.ts
+++ b/packages/eslint/tests/extensions.lint.test.ts
@@ -161,6 +161,47 @@ describe("lint: extension-security — no hardcoded http:// URLs", () => {
   })
 })
 
+describe("lint: extension-security — no chrome.tabs.discard(tabId, callback)", () => {
+  it("fires on chrome.tabs.discard(tabId, callback) — Firefox throws on the callback form", async () => {
+    const msgs = await lintSnippet(
+      extensionsSecurityConfig,
+      `chrome.tabs.discard(1, () => {})`,
+      TS_FILE
+    )
+    expectMessageForRule(
+      msgs,
+      "no-restricted-syntax",
+      "chrome.tabs.discard(tabId, callback)"
+    )
+  })
+
+  it("does NOT fire on chrome.tabs.discard(tabId) — the cross-browser-safe Promise form", async () => {
+    const msgs = await lintSnippet(
+      extensionsSecurityConfig,
+      `chrome.tabs.discard(1)`,
+      TS_FILE
+    )
+    expectNoMessageForRule(
+      msgs,
+      "no-restricted-syntax",
+      "chrome.tabs.discard(tabId)"
+    )
+  })
+
+  it("does NOT fire on unrelated chrome.tabs.* calls with 2 arguments", async () => {
+    const msgs = await lintSnippet(
+      extensionsSecurityConfig,
+      `chrome.tabs.get(1, () => {})`,
+      TS_FILE
+    )
+    expectNoMessageForRule(
+      msgs,
+      "no-restricted-syntax",
+      "chrome.tabs.get(tabId, callback)"
+    )
+  })
+})
+
 describe("lint: extension-security — no remote dynamic imports", () => {
   it("fires on import() from a remote URL", async () => {
     const msgs = await lintSnippet(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
+      fast-check:
+        specifier: ^3.23.1
+        version: 3.23.2
       maishatu-eslint-kit:
         specifier: workspace:*
         version: link:../../packages/eslint
@@ -1196,6 +1199,9 @@ importers:
       viewport-rotation:
         specifier: workspace:*
         version: link:../../../crates/viewport-rotation
+      zod:
+        specifier: 4.0.5
+        version: 4.0.5
     devDependencies:
       '@some-ui/tsconfig':
         specifier: workspace:*
@@ -7786,6 +7792,10 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -10596,6 +10606,9 @@ packages:
   pupa@3.3.0:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.5.5:
     resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
@@ -19159,6 +19172,10 @@ snapshots:
 
   extsprintf@1.3.0: {}
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -22383,6 +22400,8 @@ snapshots:
   pupa@3.3.0:
     dependencies:
       escape-goat: 4.0.0
+
+  pure-rand@6.1.0: {}
 
   qs@6.5.5: {}
 


### PR DESCRIPTION
## Description

Fixes two related bugs where the sleep marker (💤) could be stranded on live, playing tabs:

1. **#344**: Audible tabs (YouTube, music players) were being marked before the browser refused to discard them, leaving the marker visible on a still-playing tab.
2. **#345**: When `chrome.tabs.discard()` was refused for any reason, the marker was never removed, leaving it stranded on a live tab.

### Root Cause

The suspend logic applied the marker and discard as two separate, non-atomic operations without handling failure cases. If discard failed after marking, or if media was detected after the suspend request but before marking, the marker could be left on a live tab indefinitely.

### Solution

Implemented a **Finite State Machine (FSM)** for the suspend lifecycle that makes every ordering of mark/discard outcomes an explicitly-mapped state:

1. **Early media detection** (`BLOCKED` state): Skip marking entirely if the tab is audible, avoiding the need to roll back later.
2. **Discard failure handling** (`ROLLING_BACK` state): When discard fails or the user refocuses mid-suspend, immediately strip the marker via `unmarkAfterDiscard()`.
3. **Idempotent marking**: Guard against re-stacking the marker on repeated suspend attempts against stale tab snapshots.

### Key Changes

- **`suspend-fsm.ts`** (new): Pure typestate FSM with 9 states and 9 events. The invariant `¬(isLive(s) ∧ isMarked(s) ∧ isSettled(s))` is enforced by the transition table—no settled, live tab may carry the marker.
- **`discard.ts`**: 
  - Added `unmarkAfterDiscard()` to strip the marker from a live page
  - Added `rollbackMark()` to execute the unmark script when discard fails
  - Added audible tab check before marking (the `BLOCKED` edge)
  - Made `markBeforeDiscard()` idempotent to prevent re-stacking
  - Fixed in-flight debouncing to wait for both the cooldown *and* actual completion
  - Added `reconcileActivatedTab()` to clean up any stranded markers when a tab is activated
- **Test coverage**:
  - `suspend-fsm.exhaustion.test.ts`: Verifies the invariant holds for all 81 (state, event) pairs
  - `suspend-fsm.property.test.ts`: Property-based tests with random event sequences (1–50 events)
  - `discard.concurrency.test.ts`: Stress tests for marker idempotency and queue de-duplication under concurrent requests
  - `discard.test.ts`: Added tests for audible tab skipping and marker rollback

### Invariant

A tab may only carry the sleep marker while it is either already discarded (the renderer is gone, so the marker is the browser's cached title) or actively recovering (a marker-clear is in flight). The illegal `ORPHANED` state (live, marked, settled) is unreachable in the fixed transition table.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test Plan

- **Exhaustion tests** (`suspend-fsm.exhaustion.test.ts`): Verify the invariant holds for all 81 (state, event) pairs in the transition graph
- **Property tests** (`suspend-fsm.property.test.ts`): Verify the invariant holds across random event sequences of 1–50 events from every legal initial state
- **Concurrency tests** (`discard.concurrency.test.

https://claude.ai/code/session_01MSoUxSwzgxhW3yHDNbP5Kv