### PR TITLE
Refine extension detection to exclude non-buildable packages

### DIFF
--- a/.github/workflows/_extension-detect.yml
+++ b/.github/workflows/_extension-detect.yml
@@ -2,7 +2,14 @@ name: Extension Context Detection
 # Detects which extensions need verification/signing based on changed paths.
 #
 # Strategy: scan extensions/ at runtime — no hardcoded enumeration.
-# An extension is included if:
+# A directory under extensions/ is treated as a real extension only if it
+# ships a WebExtension manifest source (manifest*.json outside node_modules/
+# dist) — this excludes shared, non-buildable workspace packages like
+# extensions/common (shared Vite config) or extensions/some-scrobbler (a
+# library package), which have package.json but nothing for `web-ext lint`
+# to check.
+#
+# Given that, an extension is included if:
 #   a) CI config changed (force-all), OR
 #   b) a workspace package that extensions transitively depend on changed (force-all), OR
 #   c) any file under extensions/<name>/ appears in the git diff, OR
@@ -237,6 +244,16 @@ jobs:
             # Skip directories that aren't real packages (e.g. extensions/docs,
             # which holds markdown only) — they have no package.json to build.
             [ -f "${ext_path}package.json" ] || continue
+
+            # Skip workspace packages that don't ship a WebExtension manifest
+            # source (e.g. extensions/common — shared Vite config, or
+            # extensions/some-scrobbler — a library package). They have
+            # package.json but nothing for `web-ext lint` to check, so
+            # including them in the matrix is a guaranteed false failure.
+            MANIFEST_SRC=$(find "$ext_path" -maxdepth 3 -iname 'manifest*.json' \
+              -not -path '*/node_modules/*' -not -path '*/dist/*' | head -1)
+            [ -n "$MANIFEST_SRC" ] || continue
+
             name=$(basename "$ext_path")
 
             CHANGED="false"

--- a/.github/workflows/_extension-detect.yml
+++ b/.github/workflows/_extension-detect.yml
@@ -2,12 +2,11 @@ name: Extension Context Detection
 # Detects which extensions need verification/signing based on changed paths.
 #
 # Strategy: scan extensions/ at runtime — no hardcoded enumeration.
-# A directory under extensions/ is treated as a real extension only if it
-# ships a WebExtension manifest source (manifest*.json outside node_modules/
-# dist) — this excludes shared, non-buildable workspace packages like
-# extensions/common (shared Vite config) or extensions/some-scrobbler (a
-# library package), which have package.json but nothing for `web-ext lint`
-# to check.
+# An extension is identified by the presence of a WebExtension manifest
+# source (manifest*.json outside node_modules/dist), not by the presence
+# of a package.json. This excludes workspace packages under extensions/
+# that hold shared code or build infrastructure but ship no manifest for
+# `web-ext lint` to validate.
 #
 # Given that, an extension is included if:
 #   a) CI config changed (force-all), OR
@@ -245,11 +244,10 @@ jobs:
             # which holds markdown only) — they have no package.json to build.
             [ -f "${ext_path}package.json" ] || continue
 
-            # Skip workspace packages that don't ship a WebExtension manifest
-            # source (e.g. extensions/common — shared Vite config, or
-            # extensions/some-scrobbler — a library package). They have
-            # package.json but nothing for `web-ext lint` to check, so
-            # including them in the matrix is a guaranteed false failure.
+            # Skip workspace packages that aren't themselves WebExtensions —
+            # they may have a package.json but no manifest for `web-ext lint`
+            # to check, so including them in the matrix is a guaranteed
+            # false failure.
             MANIFEST_SRC=$(find "$ext_path" -maxdepth 3 -iname 'manifest*.json' \
               -not -path '*/node_modules/*' -not -path '*/dist/*' | head -1)
             [ -n "$MANIFEST_SRC" ] || continue


### PR DESCRIPTION
## Description

This change improves the extension context detection workflow by adding a stricter filter to exclude workspace packages that don't ship a WebExtension manifest. Previously, the workflow would include directories like `extensions/common` (shared Vite config) or library packages in the build matrix, leading to guaranteed failures when `web-ext lint` found nothing to check.

The fix adds a check for the presence of a WebExtension manifest source file (`manifest*.json`) outside of `node_modules/` and `dist/` directories. Only directories containing such a manifest are now treated as real extensions and included in the CI matrix.

### Changes Made

- Updated the extension detection logic in `.github/workflows/_extension-detect.yml` to verify that a directory contains a WebExtension manifest before treating it as a buildable extension
- Added clarifying documentation explaining the distinction between real extensions and shared workspace packages
- The check uses `find` to locate manifest files up to 3 levels deep, excluding build artifacts and dependencies

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Rationale

This prevents false CI failures caused by attempting to lint non-extension workspace packages that have `package.json` but no WebExtension manifest to validate. The change makes the extension detection more robust and reduces noise in CI runs.

## Test Plan

The workflow changes are validated by the CI system itself—if the detection logic is incorrect, it will either fail to detect real extensions or incorrectly include non-extensions in the matrix. Existing CI runs will verify the fix works as intended.

https://claude.ai/code/session_015vFAQLJFyN9hhpJJcFvdpg