### PR TITLE
DRM-STORY + DRM-VIS: interaction stories, typed fixtures, wireframe-floor parity

### DIFF
--- a/extensions/some-drama/src/components/__fixtures__/card-state.ts
+++ b/extensions/some-drama/src/components/__fixtures__/card-state.ts
@@ -1,0 +1,130 @@
+// ── Story fixtures ────────────────────────────────────────────────────────────
+// Typed CardState fixtures for some-drama stories (DRM-STORY S2).
+//
+// Everything here is derived from the canonical `DramaEntry` type in
+// `src/types`, then projected to the `CardState` the card actually renders.
+// Building the full entry first means a story fixture can never drift from the
+// real data shape — if `DramaEntry` changes, these stop compiling.
+
+import type { CardSize, CardState, DramaEntry, MoodType } from "@drama/types"
+
+let seq = 0
+
+/**
+ * A realistic, fully-populated `DramaEntry`. Pass overrides for the fields a
+ * given fixture cares about; everything else stays typical.
+ */
+export function dramaEntry(overrides: Partial<DramaEntry> = {}): DramaEntry {
+  return {
+    id: `fixture-${++seq}`,
+    addedAt: 0,
+
+    // ── Structural (factual / scrapable) ──────────────────────────────────────
+    title: "Queen of Tears",
+    episode: "Ep 12 / 16",
+    network: "tvN",
+    year: "2024",
+    genre: "Romance",
+    note: "",
+    color: "#e06c9f",
+    url: "https://example.test/watch",
+    posterUrl: null,
+    timestamp: "27:53",
+    progress: 0.63,
+    isPlaying: true,
+
+    // ── Opinionated (feeling-at-the-moment) ───────────────────────────────────
+    rating: 8.6,
+    completionLikelihood: 0.92,
+    activeMood: "love",
+    featuredQuote: "Don't look at me like that",
+    emotionLabel: "heart eyes",
+    overallProgress: 0.74,
+    axes: { connection: 70, hope: -30, trust: -80, control: 40 },
+    transition: { before: "hopeful", after: "devastated" },
+    tags: ["handTouch", "reveal"],
+    peakLine: "The umbrella scene in the rain",
+    momentum: { value: 75, direction: "falling" },
+
+    ...overrides,
+  }
+}
+
+/** Project a `DramaEntry` onto the `CardState` the card consumes. */
+export function cardStateFromEntry(entry: DramaEntry): CardState {
+  return {
+    dramaTitle: entry.title,
+    posterUrl: entry.posterUrl,
+    episode: entry.episode,
+    timestamp: entry.timestamp,
+    progress: entry.progress,
+    overallProgress: entry.overallProgress,
+    rating: entry.rating,
+    completionLikelihood: entry.completionLikelihood,
+    activeMood: entry.activeMood,
+    featuredQuote: entry.featuredQuote,
+    emotionLabel: entry.emotionLabel,
+    isPlaying: entry.isPlaying,
+    axes: entry.axes,
+    transition: entry.transition,
+    tags: entry.tags,
+    peakLine: entry.peakLine,
+    momentum: entry.momentum,
+  }
+}
+
+/** Shorthand: build a `CardState` straight from entry overrides. */
+export function cardState(overrides: Partial<DramaEntry> = {}): CardState {
+  return cardStateFromEntry(dramaEntry(overrides))
+}
+
+// ── State-matrix fixtures (empty · typical · extreme) ─────────────────────────
+
+/** Nothing captured yet — every slide in its empty/prompt shape. */
+export const EMPTY_STATE: CardState = cardState({
+  posterUrl: null,
+  activeMood: null,
+  featuredQuote: "",
+  emotionLabel: "",
+  peakLine: "",
+  tags: [],
+  transition: { before: "", after: "" },
+  axes: { connection: 0, hope: 0, trust: 0, control: 0 },
+  momentum: { value: 0, direction: "steady" },
+  rating: 0,
+})
+
+/** The default, well-populated middle-of-the-road card. */
+export const TYPICAL_STATE: CardState = cardState()
+
+/** Everything pushed to its edge — axes at ±100, tag overflow, falling fast. */
+export const EXTREME_STATE: CardState = cardState({
+  axes: { connection: 100, hope: -100, trust: -100, control: 100 },
+  tags: [
+    "confession",
+    "handTouch",
+    "kiss",
+    "reveal",
+    "argument",
+    "goodbye",
+    "betrayal",
+  ],
+  momentum: { value: 100, direction: "falling" },
+  rating: 10,
+  peakLine: "Everything, all at once, in the rain",
+})
+
+// ── Axes for the matrix stories ───────────────────────────────────────────────
+
+/** The three card sizes, in cycle order. */
+export const SIZES: ReadonlyArray<CardSize> = ["min", "compact", "full"]
+
+/** Every mood — drives `--dc-mood-hue`. */
+export const MOOD_MATRIX: ReadonlyArray<MoodType> = [
+  "joy",
+  "love",
+  "sadness",
+  "tension",
+  "cringe",
+  "neutral",
+]

--- a/extensions/some-drama/src/components/drama-card/interactions.stories.tsx
+++ b/extensions/some-drama/src/components/drama-card/interactions.stories.tsx
@@ -1,0 +1,182 @@
+import "@drama/styles/content.css"
+
+import { useEffect, useRef } from "react"
+import { cardState } from "@drama/components/__fixtures__/card-state"
+import type { CardSize, CardState, MoodType } from "@drama/types"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, fn, userEvent, waitFor } from "@storybook/test"
+
+import { DramaCard } from "."
+
+// ── Interaction bridge ────────────────────────────────────────────────────────
+// Mounts a full DramaCard with spy event handlers so play functions can pin the
+// card's behaviour (DRM-STORY S3): circle-click slide advance, the size cycle,
+// capture-panel toggle, and mood emission. Event args are asserted via the
+// `fn()` spies, which Storybook resets between stories.
+
+type InteractionArgs = {
+  size: CardSize
+  onMoodSelect: (mood: MoodType) => void
+  onSizeChange: (size: CardSize) => void
+  onDragEnd: (x: number, y: number) => void
+}
+
+const FIXTURE: CardState = cardState({ activeMood: "love" })
+
+const InteractiveCard = ({
+  size,
+  onMoodSelect,
+  onSizeChange,
+  onDragEnd,
+}: InteractionArgs) => {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const cardRef = useRef<DramaCard | null>(null)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host || cardRef.current) return
+
+    const card = new DramaCard(
+      host,
+      { ...FIXTURE },
+      { onMoodSelect, onSizeChange, onDragEnd }
+    )
+    card.setPosition(120, 120)
+    card.setSize(size, /* emit */ false)
+    cardRef.current = card
+
+    return () => {
+      card.destroy()
+      cardRef.current = null
+    }
+    // Mount once — play functions drive the instance directly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div
+      ref={hostRef}
+      style={{
+        width: "100vw",
+        height: "100vh",
+        position: "relative",
+        overflow: "hidden",
+        background:
+          "linear-gradient(135deg, hsl(220 30% 18%), hsl(240 25% 12%))",
+      }}
+    />
+  )
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const rootEl = (c: HTMLElement): HTMLElement =>
+  c.querySelector<HTMLElement>("#dc-root")!
+
+const find = <T extends HTMLElement>(c: HTMLElement, sel: string): Promise<T> =>
+  waitFor((): T => {
+    const node = c.querySelector<T>(sel)
+    if (!node) throw new Error(`element not found: ${sel}`)
+    return node
+  })
+
+const activeSlideIndex = (c: HTMLElement): number =>
+  Array.from(c.querySelectorAll(".dc-slide")).findIndex((s) =>
+    s.classList.contains("dc-slide-active")
+  )
+
+// ── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<InteractionArgs> = {
+  title: "Extensions/Drama/DramaCard/Interactions",
+  component: InteractiveCard,
+  parameters: { layout: "fullscreen" },
+  args: {
+    size: "compact",
+    onMoodSelect: fn(),
+    onSizeChange: fn(),
+    onDragEnd: fn(),
+  },
+  argTypes: {
+    onMoodSelect: { table: { disable: true } },
+    onSizeChange: { table: { disable: true } },
+    onDragEnd: { table: { disable: true } },
+  },
+  tags: ["!autodocs"],
+}
+
+export default meta
+type Story = StoryObj<InteractionArgs>
+
+// ── Stories ──────────────────────────────────────────────────────────────────
+
+/** Clicking the circle advances the slideshow by one slide. */
+export const CircleAdvancesSlide: Story = {
+  play: async ({ canvasElement }) => {
+    const wrap = await find(canvasElement, ".dc-circle-wrap")
+    await waitFor(() => expect(activeSlideIndex(canvasElement)).toBe(0))
+    const count = canvasElement.querySelectorAll(".dc-slide").length
+    await userEvent.click(wrap)
+    await waitFor(() => expect(activeSlideIndex(canvasElement)).toBe(1 % count))
+  },
+}
+
+/**
+ * The size button cycles compact → full → min → compact, and minimising
+ * auto-closes an open capture panel.
+ */
+export const SizeCycleClosesPanelOnMin: Story = {
+  play: async ({ canvasElement }) => {
+    const root = rootEl(canvasElement)
+    const wrap = await find(canvasElement, ".dc-circle-wrap")
+    const sizeBtn = await find(canvasElement, ".dc-size-btn")
+    const panel = await find(canvasElement, ".dc-capture-panel")
+
+    await waitFor(() => expect(root.dataset.size).toBe("compact"))
+
+    // Open the capture panel (a click inside the card toggles it).
+    await userEvent.click(wrap)
+    await waitFor(() =>
+      expect(panel.classList.contains("dc-panel-open")).toBe(true)
+    )
+
+    // compact → full — panel stays open.
+    await userEvent.click(sizeBtn)
+    await waitFor(() => expect(root.dataset.size).toBe("full"))
+    await waitFor(() =>
+      expect(panel.classList.contains("dc-panel-open")).toBe(true)
+    )
+
+    // full → min — panel auto-closes.
+    await userEvent.click(sizeBtn)
+    await waitFor(() => expect(root.dataset.size).toBe("min"))
+    await waitFor(() =>
+      expect(panel.classList.contains("dc-panel-open")).toBe(false)
+    )
+
+    // min → compact — cycle wraps.
+    await userEvent.click(sizeBtn)
+    await waitFor(() => expect(root.dataset.size).toBe("compact"))
+  },
+}
+
+/** Selecting an emotion in the capture panel emits `onMoodSelect` with the mood. */
+export const MoodSelectEmitsEvent: Story = {
+  play: async ({ canvasElement, args }) => {
+    const wrap = await find(canvasElement, ".dc-circle-wrap")
+
+    // Open the capture panel, then pick "Joy".
+    await userEvent.click(wrap)
+    const joyBtn = await find<HTMLButtonElement>(
+      canvasElement,
+      '.dc-emo-btn[title="Joy"]'
+    )
+    await waitFor(() => expect(joyBtn).toBeVisible())
+    await userEvent.click(joyBtn)
+
+    await waitFor(() => expect(args.onMoodSelect).toHaveBeenCalledWith("joy"))
+    await waitFor(() =>
+      expect(joyBtn.classList.contains("dc-emo-selected")).toBe(true)
+    )
+  },
+}

--- a/extensions/some-drama/src/components/slideshow/interactions.stories.tsx
+++ b/extensions/some-drama/src/components/slideshow/interactions.stories.tsx
@@ -1,0 +1,142 @@
+import "@drama/styles/content.css"
+
+import { useEffect, useRef } from "react"
+import { cardState } from "@drama/components/__fixtures__/card-state"
+import { Slideshow } from "@drama/components/slideshow"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, userEvent, waitFor } from "@storybook/test"
+
+// ── Interaction bridge ────────────────────────────────────────────────────────
+// Mounts a bare Slideshow and pins its *behaviour* with play functions, isolated
+// from the card shell. Mirrors the wiring DramaCard applies so the pinned
+// behaviour matches what ships:
+//   • auto-advance walks the slides on an interval;
+//   • a click on the circle stops the timer, advances one slide, and (when
+//     auto-advancing) restarts it — i.e. a manual advance resets the timer.
+//
+// @storybook/test exposes no fake-timer control, so auto-advance is pinned with
+// a deliberately short interval polled by `waitFor` — deterministic, not a raw
+// real-time sleep.
+
+type BridgeProps = {
+  autoAdvance: boolean
+  intervalMs: number
+}
+
+const FIXTURE = cardState({ tags: ["handTouch", "reveal"] })
+
+const InteractiveSlideshow = ({ autoAdvance, intervalMs }: BridgeProps) => {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const ssRef = useRef<Slideshow | null>(null)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host || ssRef.current) return
+
+    // A #dc-root ancestor scopes the size/slide selectors. The shipped
+    // #dc-root rule parks the card off-screen (left/top: -9999px) until JS
+    // positions it, so pin it back on-screen for the isolated harness.
+    const root = document.createElement("div")
+    root.id = "dc-root"
+    root.dataset.size = "full"
+    root.style.cssText =
+      "position:relative; display:inline-block; left:0; top:0;"
+
+    const ss = new Slideshow()
+    Object.assign(ss.wrap.style, { width: "120px", height: "120px" })
+
+    ss.onSlideClick = (): void => {
+      ss.stopAutoAdvance()
+      ss.setSlide((ss.current + 1) % ss.slideCount)
+      if (autoAdvance) ss.startAutoAdvance(intervalMs)
+    }
+
+    const s = FIXTURE
+    ss.applyAxesState(s.axes)
+    ss.applyTransitionState(s.transition)
+    ss.applyPosterState(s)
+    ss.applyTagsState(s.tags, s.peakLine)
+    ss.applyMomentumState(s.momentum)
+    ss.applyAtmosphereState(s.axes)
+    ss.applyRatingState(s.rating)
+    ss.applySummaryState(s)
+    ss.setSlide(0)
+
+    root.appendChild(ss.wrap)
+    host.appendChild(root)
+    ssRef.current = ss
+
+    if (autoAdvance) ss.startAutoAdvance(intervalMs)
+
+    return () => {
+      ss.destroy()
+      ssRef.current = null
+      root.remove()
+    }
+  }, [autoAdvance, intervalMs])
+
+  return (
+    <div
+      ref={hostRef}
+      style={{
+        width: "100vw",
+        height: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background:
+          "linear-gradient(135deg, hsl(220 30% 14%), hsl(240 25% 8%))",
+      }}
+    />
+  )
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const activeSlideIndex = (canvasElement: HTMLElement): number =>
+  Array.from(canvasElement.querySelectorAll(".dc-slide")).findIndex((s) =>
+    s.classList.contains("dc-slide-active")
+  )
+
+// ── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<BridgeProps> = {
+  title: "Extensions/Drama/Components/Slideshow/Interactions",
+  component: InteractiveSlideshow,
+  parameters: { layout: "fullscreen" },
+  tags: ["!autodocs"],
+}
+
+export default meta
+type Story = StoryObj<BridgeProps>
+
+// ── Stories ──────────────────────────────────────────────────────────────────
+
+/** Auto-advance walks forward through the slides on its interval. */
+export const AutoAdvanceCycles: Story = {
+  args: { autoAdvance: true, intervalMs: 60 },
+  play: async ({ canvasElement }) => {
+    // Starts on slide 0; several ticks should carry it well past the first.
+    await waitFor(
+      () => expect(activeSlideIndex(canvasElement)).toBeGreaterThanOrEqual(2),
+      { timeout: 3000 }
+    )
+  },
+}
+
+/** Clicking the circle advances exactly one slide (auto-advance off). */
+export const ClickAdvancesSlide: Story = {
+  args: { autoAdvance: false, intervalMs: 5000 },
+  play: async ({ canvasElement }) => {
+    const wrap = await waitFor((): HTMLElement => {
+      const w = canvasElement.querySelector<HTMLElement>(".dc-circle-wrap")
+      if (!w) throw new Error(".dc-circle-wrap not found")
+      return w
+    })
+    await waitFor(() => expect(activeSlideIndex(canvasElement)).toBe(0))
+    await userEvent.click(wrap)
+    await waitFor(() => expect(activeSlideIndex(canvasElement)).toBe(1))
+    await userEvent.click(wrap)
+    await waitFor(() => expect(activeSlideIndex(canvasElement)).toBe(2))
+  },
+}

--- a/extensions/some-drama/src/styles/components/capture-panel.css
+++ b/extensions/some-drama/src/styles/components/capture-panel.css
@@ -4,17 +4,17 @@
    ────────────────────────────────────────────────────────────────────────── */
 
 .dc-capture-panel {
-  width: 100%;
   max-height: 0;
-  overflow: hidden;
   opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
   transform: scale(0.96) translateY(6px) translateZ(0);
+  transform-origin: top right;
   transition:
     max-height 350ms var(--dc-ease),
     opacity 250ms var(--dc-ease),
     transform 250ms var(--dc-ease);
-  transform-origin: top right;
-  pointer-events: none;
+  width: 100%;
 
   /* Prevent jitter */
   will-change: max-height, opacity, transform;
@@ -23,38 +23,37 @@
 .dc-capture-panel.dc-panel-open {
   max-height: 220px;
   opacity: 1;
-  transform: scale(1) translateY(0) translateZ(0);
   pointer-events: auto;
+  transform: scale(1) translateY(0) translateZ(0);
 }
 
 .dc-capture-inner {
-  /* Solid dark background */
+  backdrop-filter: var(--dc-blur);
+
+  /* Cool cinematic surface (floor) */
   background: linear-gradient(
     135deg,
-    hsl(25 25% 16% / 0.97) 0%,
-    hsl(340 20% 14% / 0.96) 100%
+    var(--dc-surface) 0%,
+    var(--dc-surface-2) 100%
   );
-  backdrop-filter: var(--dc-blur);
-  -webkit-backdrop-filter: var(--dc-blur);
-  border: 1.5px solid var(--dc-border-strong);
+  border: 1px solid var(--dc-line-strong);
   border-radius: var(--dc-r-card);
-  padding: 16px 18px;
-  margin-top: 8px;
 
-  /* Glow shadow */
+  /* Deep, quiet shadow */
   box-shadow:
     0 6px 28px var(--dc-shadow),
-    0 0 50px hsl(340 60% 50% / 0.12),
-    inset 0 1px 0 hsl(340 40% 50% / 0.15);
+    inset 0 1px 0 hsl(0deg 0% 100% / 5%);
+  margin-top: 8px;
+  padding: 16px 18px;
 }
 
 /* Panel heading */
 .dc-panel-title {
-  font-size: 10px;
+  color: var(--dc-text-secondary);
   font-family: Georgia, serif;
+  font-size: 10px;
   font-style: italic;
   font-weight: bold;
-  color: var(--dc-text-secondary);
   letter-spacing: 0.07em;
   margin-bottom: 12px;
   text-shadow: var(--dc-text-glow-subtle);
@@ -62,48 +61,42 @@
 
 /* Emotion button grid */
 .dc-emo-btn {
-  width: 42px;
-  height: 42px;
+  /* Cool hairline button surface (floor) */
+  background: hsl(0deg 0% 100% / 3%);
+  border: 1px solid var(--dc-line);
   border-radius: 12px;
-
-  /* Dark button surface */
-  background: hsl(340 20% 22% / 0.9);
-  border: 1.5px solid var(--dc-border);
-
-  font-size: 20px;
-  cursor: pointer;
 
   /* Subtle shadow */
   box-shadow:
-    0 2px 8px hsl(0 0% 0% / 0.3),
-    inset 0 1px 0 hsl(340 30% 40% / 0.2);
-
+    0 2px 8px hsl(0deg 0% 0% / 30%),
+    inset 0 1px 0 hsl(0deg 0% 100% / 4%);
+  cursor: pointer;
+  font-size: 20px;
+  height: 42px;
   transition:
     transform 200ms var(--dc-ease-bounce),
     background 200ms var(--dc-ease),
     border-color 200ms var(--dc-ease),
     box-shadow 200ms var(--dc-ease);
+  width: 42px;
 }
 
 .dc-emo-btn:hover {
-  transform: scale(1.12) translateY(-3px);
-  background: hsl(340 25% 28% / 0.95);
-  border-color: var(--dc-border-strong);
+  background: hsl(0deg 0% 100% / 6%);
+  border-color: var(--dc-line-strong);
   box-shadow:
-    0 6px 16px hsl(340 50% 40% / 0.35),
-    0 0 24px hsl(340 60% 50% / 0.2),
-    inset 0 1px 0 hsl(340 40% 50% / 0.25);
+    0 6px 16px hsl(0deg 0% 0% / 40%),
+    inset 0 1px 0 hsl(0deg 0% 100% / 6%);
+  transform: scale(1.12) translateY(-3px);
 }
 
 .dc-emo-btn.dc-emo-selected {
-  /* Vibrant gradient for selected state */
-  background: linear-gradient(135deg, var(--dc-peach), var(--dc-rose));
-  border-color: var(--dc-rose);
-
+  /* Accent-spectrum gradient for selected state (floor pink → violet) */
+  background: linear-gradient(135deg, var(--dc-pink), var(--dc-violet));
+  border-color: var(--dc-pink);
   box-shadow:
-    0 4px 18px hsl(340 70% 55% / 0.5),
-    0 0 30px hsl(18 80% 60% / 0.3),
-    inset 0 0 0 2px hsl(0 0% 100% / 0.2);
+    0 4px 18px hsl(var(--dc-mood-hue) 70% 55% / 50%),
+    inset 0 0 0 2px hsl(0deg 0% 100% / 20%);
 }
 
 .dc-emo-btn.dc-emo-selected:hover {

--- a/extensions/some-drama/src/styles/components/card-shell.css
+++ b/extensions/some-drama/src/styles/components/card-shell.css
@@ -4,60 +4,57 @@
    ────────────────────────────────────────────────────────────────────────── */
 
 .dc-card {
-  /* Solid dark background with warm tint — visible on any dark page */
-  background: linear-gradient(
-    135deg,
-    hsl(25 25% 16% / 0.97) 0%,
-    hsl(340 20% 14% / 0.95) 50%,
-    hsl(20 25% 15% / 0.97) 100%
-  );
-  backdrop-filter: var(--dc-blur);
-  -webkit-backdrop-filter: var(--dc-blur);
+  /* Mood-driven accent — the floor's per-card --accent, here from mood hue */
+  --accent: hsl(var(--dc-mood-hue) 68% 64%);
 
-  /* Visible border with glow */
-  border: 1.5px solid var(--dc-border-strong);
+  backdrop-filter: var(--dc-blur);
+
+  /* Cinematic cool surface with a soft accent bloom from the top (floor) */
+  background: radial-gradient(
+      140% 90% at 50% -10%,
+      color-mix(in oklab, var(--accent) 14%, transparent),
+      transparent 55%
+    ),
+    linear-gradient(180deg, var(--dc-surface) 0%, #101019 100%);
+
+  /* Hairline border (floor) */
+  border: 1px solid var(--dc-line);
   border-radius: var(--dc-r-card);
 
-  /* Layered shadows for depth + glow effect */
+  /* Deep black layered shadow (floor) */
   box-shadow:
-    0 0 0 1px hsl(340 50% 40% / 0.15),
-    0 8px 32px var(--dc-shadow-strong),
-    0 0 60px hsl(340 60% 50% / 0.15),
-    inset 0 1px 0 hsl(340 40% 50% / 0.2),
-    inset 0 -1px 0 hsl(340 30% 30% / 0.3);
+    0 1px 0 rgb(255 255 255 / 4%) inset,
+    0 30px 80px -30px rgb(0 0 0 / 80%),
+    0 0 0 1px rgb(0 0 0 / 40%);
+  transform: translateZ(0);
+  transition:
+    filter 200ms var(--dc-ease),
+    transform 200ms var(--dc-ease),
+    border-color 200ms var(--dc-ease);
 
   /* Prevent jitter */
-  will-change: box-shadow;
-  transform: translateZ(0);
-
-  transition:
-    box-shadow 300ms var(--dc-ease),
-    border-color 300ms var(--dc-ease);
+  will-change: filter, transform;
 }
 
 .dc-card:hover {
-  border-color: var(--dc-rose);
-  box-shadow:
-    0 0 0 1px hsl(340 60% 50% / 0.3),
-    0 12px 48px var(--dc-shadow-strong),
-    0 0 80px hsl(340 70% 55% / 0.2),
-    inset 0 1px 0 hsl(340 50% 55% / 0.25),
-    inset 0 -1px 0 hsl(340 30% 30% / 0.3);
+  border-color: var(--dc-line-strong);
+  filter: brightness(1.02);
+  transform: translateY(-1px) translateZ(0);
 }
 
 /* Drag handle affordance — subtle pill that appears on hover */
 .dc-card::before {
+  background: var(--dc-line-strong);
+  border-radius: 2px;
   content: "";
+  height: 4px;
+  left: 50%;
+  opacity: 0;
   position: absolute;
   top: 10px;
-  left: 50%;
   transform: translateX(-50%);
-  width: 32px;
-  height: 4px;
-  border-radius: 2px;
-  background: hsl(340 40% 50% / 0.4);
-  opacity: 0;
   transition: opacity 300ms var(--dc-ease);
+  width: 32px;
 }
 
 .dc-card:hover::before {
@@ -66,26 +63,26 @@
 
 /* Size toggle button — top-right corner */
 .dc-size-btn {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 24px;
-  height: 24px;
+  background: rgb(255 255 255 / 3%);
+  border: 1px solid var(--dc-line-strong);
   border-radius: 50%;
-  background: hsl(340 30% 25% / 0.8);
-  border: 1px solid var(--dc-border);
+  color: var(--dc-text-dim);
   cursor: pointer;
-  color: var(--dc-text-secondary);
   font-size: 10px;
-  z-index: 20;
+  height: 24px;
+  position: absolute;
+  right: 10px;
+  top: 10px;
   transition:
-    background 200ms var(--dc-ease),
-    color 200ms var(--dc-ease),
-    border-color 200ms var(--dc-ease);
+    background 180ms var(--dc-ease),
+    color 180ms var(--dc-ease),
+    border-color 180ms var(--dc-ease);
+  width: 24px;
+  z-index: 20;
 }
 
 .dc-size-btn:hover {
-  background: hsl(340 40% 35% / 0.9);
-  color: var(--dc-text-primary);
-  border-color: var(--dc-border-strong);
+  background: rgb(255 255 255 / 6%);
+  border-color: rgb(255 255 255 / 30%);
+  color: var(--dc-text);
 }

--- a/extensions/some-drama/src/styles/components/right-panel.css
+++ b/extensions/some-drama/src/styles/components/right-panel.css
@@ -4,39 +4,38 @@
    ────────────────────────────────────────────────────────────────────────── */
 
 .dc-card-right {
-  min-width: 140px;
   max-width: 170px;
+  min-width: 140px;
   padding-left: 4px;
 }
 
 /* ── Episode row ─────────────────────────────────────────────────────────── */
 
 .dc-ep-badge {
-  /* Vibrant gradient background */
-  background: linear-gradient(90deg, var(--dc-peach), var(--dc-rose));
+  /* Accent-spectrum gradient (floor pink → violet) */
+  background: linear-gradient(90deg, var(--dc-pink), var(--dc-violet));
   border-radius: 8px;
-  padding: 4px 10px;
-  font-size: 10px;
+
+  /* Mood-tinted glow */
+  box-shadow:
+    0 2px 12px hsl(var(--dc-mood-hue) 70% 55% / 40%),
+    inset 0 1px 0 hsl(0deg 0% 100% / 20%);
+  color: hsl(0deg 0% 100%);
   font-family: Georgia, serif;
+  font-size: 10px;
   font-style: italic;
   font-weight: bold;
-  color: hsl(0 0% 100%);
   letter-spacing: 0.05em;
+  padding: 4px 10px;
+  text-shadow: 0 1px 2px hsl(0deg 0% 0% / 50%);
   white-space: nowrap;
-
-  /* Glow effect */
-  box-shadow:
-    0 2px 12px hsl(340 70% 55% / 0.45),
-    0 0 20px hsl(18 85% 60% / 0.25),
-    inset 0 1px 0 hsl(0 0% 100% / 0.25);
-  text-shadow: 0 1px 2px hsl(340 60% 25% / 0.5);
 }
 
 .dc-timestamp {
-  font-size: 11px;
-  font-family: "Courier New", monospace;
-  font-weight: bold;
   color: var(--dc-text-secondary);
+  font-family: "Courier New", monospace;
+  font-size: 11px;
+  font-weight: bold;
   letter-spacing: 0.1em;
   text-shadow: var(--dc-text-glow-subtle);
 }
@@ -47,53 +46,49 @@
 }
 
 .dc-progress-labels {
-  font-size: 9px;
-  font-family: "Courier New", monospace;
-  font-weight: bold;
   color: var(--dc-text-secondary);
+  font-family: "Courier New", monospace;
+  font-size: 9px;
+  font-weight: bold;
   text-shadow: var(--dc-text-glow-subtle);
 }
 
 .dc-progress-track {
-  height: 6px;
-  background: hsl(340 20% 25%);
+  background: var(--dc-line-strong);
   border-radius: 4px;
+  box-shadow: inset 0 1px 3px hsl(0deg 0% 0% / 40%);
+  height: 6px;
   overflow: hidden;
   position: relative;
-  box-shadow:
-    inset 0 1px 3px hsl(0 0% 0% / 0.4),
-    0 1px 0 hsl(340 30% 35% / 0.3);
 }
 
 .dc-progress-fill {
-  height: 100%;
-  background: linear-gradient(to right, var(--dc-peach), var(--dc-rose));
+  background: linear-gradient(to right, var(--dc-pink), var(--dc-violet));
   border-radius: 4px;
-  width: var(--dc-prog-pct, 0%);
-  transition: width 1s linear;
-  position: relative;
 
-  /* Glow on the fill */
-  box-shadow:
-    0 0 10px hsl(340 70% 60% / 0.5),
-    0 0 20px hsl(18 80% 60% / 0.3);
+  /* Mood-tinted glow on the fill */
+  box-shadow: 0 0 10px hsl(var(--dc-mood-hue) 70% 60% / 50%);
+  height: 100%;
+  position: relative;
+  transition: width 1s linear;
+  width: var(--dc-prog-pct, 0%);
 }
 
 /* Glint dot at fill tip */
 .dc-progress-fill::after {
+  background: hsl(0deg 0% 100%);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 2px var(--dc-pink),
+    0 0 12px hsl(var(--dc-mood-hue) 80% 65% / 80%),
+    0 0 24px hsl(var(--dc-mood-hue) 70% 60% / 50%);
   content: "";
+  height: 10px;
   position: absolute;
   right: 0;
   top: 50%;
   translate: 50% -50%;
   width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: hsl(0 0% 100%);
-  box-shadow:
-    0 0 0 2px var(--dc-rose),
-    0 0 12px hsl(340 80% 65% / 0.8),
-    0 0 24px hsl(340 70% 60% / 0.5);
 }
 
 /* ── Stats row ───────────────────────────────────────────────────────────── */
@@ -103,19 +98,19 @@
 }
 
 .dc-stat-label {
-  font-size: 8px;
   color: var(--dc-text-muted);
   font-family: Georgia, serif;
+  font-size: 8px;
   font-style: italic;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
   text-shadow: var(--dc-text-glow-subtle);
+  text-transform: uppercase;
 }
 
 .dc-stat-value {
-  font-size: 12px;
   color: var(--dc-text-primary);
   font-family: Georgia, serif;
+  font-size: 12px;
   font-weight: bold;
   letter-spacing: 0.03em;
   text-shadow: var(--dc-text-glow-warm);
@@ -124,14 +119,14 @@
 /* ── Mood strip ──────────────────────────────────────────────────────────── */
 
 .dc-mood-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
   background: hsl(var(--dc-mood-hue) 65% 55%);
-  opacity: 0.4;
-  border: 1.5px solid hsl(var(--dc-mood-hue) 50% 45% / 0.5);
-  transition: all 350ms var(--dc-ease);
+  border: 1.5px solid hsl(var(--dc-mood-hue) 50% 45% / 50%);
+  border-radius: 50%;
   cursor: pointer;
+  height: 10px;
+  opacity: 0.4;
+  transition: all 350ms var(--dc-ease);
+  width: 10px;
 }
 
 .dc-mood-dot:hover {
@@ -140,24 +135,24 @@
 }
 
 .dc-mood-dot.dc-mood-active {
+  border-color: hsl(var(--dc-mood-hue) 60% 60%);
+  box-shadow:
+    0 0 12px hsl(var(--dc-mood-hue) 70% 55% / 70%),
+    0 0 24px hsl(var(--dc-mood-hue) 65% 50% / 40%),
+    0 0 4px hsl(var(--dc-mood-hue) 80% 70%);
   opacity: 1;
   transform: scale(1.4);
-  box-shadow:
-    0 0 12px hsl(var(--dc-mood-hue) 70% 55% / 0.7),
-    0 0 24px hsl(var(--dc-mood-hue) 65% 50% / 0.4),
-    0 0 4px hsl(var(--dc-mood-hue) 80% 70%);
-  border-color: hsl(var(--dc-mood-hue) 60% 60%);
 }
 
 .dc-mood-label {
-  font-size: 10px;
+  color: hsl(var(--dc-mood-hue) 50% 70%);
   font-family: Georgia, serif;
+  font-size: 10px;
   font-style: italic;
   font-weight: bold;
-  color: hsl(var(--dc-mood-hue) 50% 70%);
   margin-left: 4px;
   text-shadow:
-    0 0 8px hsl(var(--dc-mood-hue) 60% 50% / 0.4),
-    0 1px 2px hsl(0 0% 0% / 0.5);
+    0 0 8px hsl(var(--dc-mood-hue) 60% 50% / 40%),
+    0 1px 2px hsl(0deg 0% 0% / 50%);
   transition: color 400ms var(--dc-ease);
 }

--- a/extensions/some-drama/src/styles/components/slideshow.css
+++ b/extensions/some-drama/src/styles/components/slideshow.css
@@ -1,44 +1,54 @@
 /* ── Circular Slideshow ──────────────────────────────────────────────────────
    Ring animation, slide transitions, slide content styles, nav dots,
    and the chat bubble.
-   Fixed: Solid slide backgrounds, high-contrast text, reduced jitter.
+
+   DRM-VIS S2 (#438) + S3 (#439): reconciled to the drama-capture-ui floor —
+   the ring carries the full emotional spectrum (blue → violet → magenta →
+   pink → peach → gold, mirroring the wireframe legend bar), slide surfaces are
+   the cool cinematic base, and nav dots adopt the floor treatment (faint pip,
+   elongated active dot with a pink→violet gradient).
+
+   NOTE: also un-nests the slide-interior rules, which had been swallowed by a
+   missing brace on `.dc-bubble-quote` and therefore never applied.
    ────────────────────────────────────────────────────────────────────────── */
 
 /* ── Circle wrapper ──────────────────────────────────────────────────────── */
 .dc-circle-wrap {
-  position: relative;
-  width: 108px;
-  height: 108px;
   flex-shrink: 0;
-
-  /* Prevent jitter */
-  will-change: width, height;
+  height: 108px;
+  position: relative;
   transform: translateZ(0);
-
   transition:
     width 300ms var(--dc-ease),
     height 300ms var(--dc-ease);
+  width: 108px;
+
+  /* Prevent jitter */
+  will-change: width, height;
 }
 
-/* Spinning conic-gradient ring — bright and saturated */
+/* Spinning conic-gradient ring — the floor's emotional spectrum */
 .dc-circle-ring {
-  position: absolute;
-  inset: -4px;
-  border-radius: 50%;
+  animation: dc-ring-spin 10s linear infinite;
   background: conic-gradient(
     from 0deg,
+    var(--dc-blue),
+    var(--dc-violet),
+    var(--dc-magenta),
+    var(--dc-pink),
     var(--dc-peach),
-    var(--dc-rose),
     var(--dc-gold),
-    var(--dc-peach)
+    var(--dc-blue)
   );
+  border-radius: 50%;
 
-  /* Glow effect */
-  filter: drop-shadow(0 0 8px hsl(340 70% 55% / 0.5));
+  /* Mood-tinted glow */
+  filter: drop-shadow(0 0 8px hsl(var(--dc-mood-hue) 70% 55% / 50%));
+  inset: -4px;
+  position: absolute;
 
   /* Smooth rotation */
   will-change: transform;
-  animation: dc-ring-spin 10s linear infinite;
   z-index: 0;
 }
 
@@ -50,156 +60,156 @@
 
 /* Mask — covers ring interior so only the border shows */
 .dc-circle-ring::after {
-  content: "";
-  position: absolute;
-  inset: 4px;
+  background: var(--dc-surface);
   border-radius: 50%;
-  background: hsl(25 25% 14%);
+  content: "";
+  inset: 4px;
+  position: absolute;
 }
 
 /* Clipped slideshow surface */
 .dc-slideshow {
-  position: absolute;
-  inset: 0;
   border-radius: 50%;
+  inset: 0;
   overflow: hidden;
+  position: absolute;
   z-index: 1;
 }
 
 .dc-slideshow-inner {
-  width: 100%;
   height: 100%;
   position: relative;
+  width: 100%;
 }
 
 /* ── Individual slides ───────────────────────────────────────────────────── */
 .dc-slide {
-  position: absolute;
-  inset: 0;
-  display: flex;
   align-items: center;
-  justify-content: center;
+  backface-visibility: hidden;
   border-radius: 50%;
-  overflow: hidden;
-
+  display: flex;
+  inset: 0;
+  justify-content: center;
   opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+  position: absolute;
   transform: scale(0.92) translateZ(0);
   transition:
     opacity 500ms var(--dc-ease),
     transform 500ms var(--dc-ease);
-  pointer-events: none;
 
   /* Prevent jitter */
   will-change: opacity, transform;
-  backface-visibility: hidden;
 }
 
 .dc-slide.dc-slide-active {
   opacity: 1;
-  transform: scale(1) translateZ(0);
   pointer-events: auto;
+  transform: scale(1) translateZ(0);
 }
 
-/* Slide 1: poster */
+/* Slide 2: poster */
 .dc-slide-poster img {
-  width: 100%;
+  border-radius: 50%;
   height: 100%;
   object-fit: cover;
-  border-radius: 50%;
+  width: 100%;
 }
 
 .dc-slide-poster-placeholder {
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(135deg, var(--dc-peach), var(--dc-rose));
-  display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 40px;
+  background: linear-gradient(135deg, var(--dc-pink), var(--dc-violet));
   border-radius: 50%;
-  filter: drop-shadow(0 2px 8px hsl(340 60% 40% / 0.4));
+  display: flex;
+  filter: drop-shadow(0 2px 8px rgb(0 0 0 / 50%));
+  font-size: 40px;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
 }
 
-/* Slide 2: rating — vibrant gradient background */
+/* Slide 6: rating — accent-spectrum gradient background */
 .dc-slide-rating {
   background: linear-gradient(
     135deg,
-    hsl(340 70% 45%) 0%,
-    hsl(18 85% 55%) 100%
+    var(--dc-magenta) 0%,
+    var(--dc-violet) 100%
   );
   flex-direction: column;
   gap: 6px;
 }
 
 .dc-rating-value {
+  animation: dc-scale-in 400ms var(--dc-ease-bounce) both;
+  color: hsl(0deg 0% 100%);
   font-family: Georgia, serif;
   font-size: 32px;
   font-weight: bold;
-  color: hsl(0 0% 100%);
   line-height: 1;
   text-shadow:
-    0 2px 4px hsl(340 60% 25% / 0.5),
-    0 0 20px hsl(0 0% 100% / 0.3);
+    0 2px 4px rgb(0 0 0 / 50%),
+    0 0 20px hsl(0deg 0% 100% / 30%);
 
   /* Prevent jitter on animation */
   will-change: transform, opacity;
-  animation: dc-scale-in 400ms var(--dc-ease-bounce) both;
 }
 
 @keyframes dc-scale-in {
   from {
-    transform: scale(0.6) translateZ(0);
     opacity: 0;
+    transform: scale(0.6) translateZ(0);
   }
+
   to {
-    transform: scale(1) translateZ(0);
     opacity: 1;
+    transform: scale(1) translateZ(0);
   }
 }
 
 .dc-rating-stars {
+  color: var(--dc-gold);
   font-size: 15px;
   letter-spacing: 2px;
-  color: var(--dc-gold);
   text-shadow: var(--dc-text-glow-gold);
 }
 
 .dc-rating-label {
-  font-size: 10px;
+  color: hsl(0deg 0% 100% / 90%);
   font-family: Georgia, serif;
+  font-size: 10px;
   font-style: italic;
-  color: hsl(0 0% 100% / 0.9);
   letter-spacing: 0.06em;
-  text-shadow: 0 1px 3px hsl(340 50% 25% / 0.5);
+  text-shadow: 0 1px 3px rgb(0 0 0 / 50%);
 }
 
-/* Slide 3: emotion — dynamic mood background */
+/* Legacy emotion slide (unused by the current builder, kept mood-driven) */
 .dc-slide-emotion {
   flex-direction: column;
   gap: 8px;
 }
 
 .dc-emotion-backdrop {
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
   background: radial-gradient(
     circle,
-    hsl(var(--dc-mood-hue) 70% 50% / 0.95),
-    hsl(var(--dc-mood-hue) 60% 38% / 0.9)
+    hsl(var(--dc-mood-hue) 70% 50% / 95%),
+    hsl(var(--dc-mood-hue) 60% 38% / 90%)
   );
+  border-radius: 50%;
+  inset: 0;
+  position: absolute;
   transition: background 600ms var(--dc-ease);
 }
 
 .dc-emotion-emoji {
+  animation: dc-emoji-float 4s ease-in-out infinite;
+  filter: drop-shadow(0 3px 8px hsl(var(--dc-mood-hue) 60% 30% / 50%));
   font-size: 42px;
   position: relative;
-  z-index: 1;
-  filter: drop-shadow(0 3px 8px hsl(var(--dc-mood-hue) 60% 30% / 0.5));
 
   /* Gentle float — reduced movement to prevent jitter */
   will-change: transform;
-  animation: dc-emoji-float 4s ease-in-out infinite;
+  z-index: 1;
 }
 
 @keyframes dc-emoji-float {
@@ -207,384 +217,403 @@
   100% {
     transform: translateY(0) translateZ(0);
   }
+
   50% {
     transform: translateY(-4px) translateZ(0);
   }
 }
 
 .dc-slide-label {
-  font-size: 10px;
+  color: hsl(0deg 0% 100%);
   font-family: Georgia, serif;
+  font-size: 10px;
   font-style: italic;
   font-weight: bold;
-  color: hsl(0 0% 100%);
-  text-align: center;
-  position: relative;
-  z-index: 1;
   letter-spacing: 0.05em;
+  position: relative;
+  text-align: center;
   text-shadow:
-    0 1px 3px hsl(var(--dc-mood-hue) 50% 20% / 0.6),
-    0 0 12px hsl(0 0% 100% / 0.3);
+    0 1px 3px hsl(var(--dc-mood-hue) 50% 20% / 60%),
+    0 0 12px hsl(0deg 0% 100% / 30%);
+  z-index: 1;
 }
 
-/* ── Slide nav dots ──────────────────────────────────────────────────────── */
+/* ── Slide nav dots (floor treatment) ────────────────────────────────────── */
 .dc-slide-dots {
-  position: absolute;
   bottom: 8px;
-  left: 50%;
-  transform: translateX(-50%);
   display: flex;
   gap: 6px;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
   z-index: 12;
 }
 
 .dc-slide-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: hsl(0 0% 100% / 0.4);
-  border: 1px solid hsl(0 0% 100% / 0.2);
-  transition: all 300ms var(--dc-ease);
+  background: var(--dc-text-faint);
+  border-radius: 999px;
   cursor: pointer;
+  height: 6px;
+  transition: all 300ms var(--dc-ease);
+  width: 6px;
 }
 
 .dc-slide-dot:hover {
-  background: hsl(0 0% 100% / 0.6);
+  background: var(--dc-text-dim);
 }
 
 .dc-slide-dot.dc-dot-active {
-  background: hsl(0 0% 100%);
-  width: 14px;
-  border-radius: 4px;
-  box-shadow: 0 0 8px hsl(0 0% 100% / 0.6);
+  background: linear-gradient(90deg, var(--dc-pink), var(--dc-violet));
+  border-radius: 999px;
+  box-shadow: 0 0 8px hsl(var(--dc-mood-hue) 70% 55% / 50%);
+  width: 18px;
+}
+
+/* ── Slide surfaces — cool cinematic base ────────────────────────────────── */
+.dc-slide-axes,
+.dc-slide-transition,
+.dc-slide-tags,
+.dc-slide-momentum,
+.dc-slide-summary {
+  background: linear-gradient(
+    135deg,
+    var(--dc-surface) 0%,
+    var(--dc-surface-2) 100%
+  );
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+}
+
+/* ── Slide 0: axes ───────────────────────────────────────────────────────── */
+.dc-slide-axes {
+  gap: 5px;
+  padding: 12px;
+}
+
+.dc-axis-bar {
+  align-items: center;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: 22px 1fr 22px;
+  width: 100%;
+}
+
+.dc-axis-bar-label {
+  color: var(--dc-text-dim);
+  font-size: 7px;
+  letter-spacing: 0.02em;
+}
+
+.dc-axis-bar-track {
+  background: var(--dc-line-strong);
+  border-radius: 99px;
+  height: 4px;
+  overflow: hidden;
+}
+
+.dc-axis-bar-fill {
+  background: var(--dc-text-faint);
+  border-radius: 99px;
+  height: 100%;
+  transition:
+    width 400ms var(--dc-ease),
+    background 400ms var(--dc-ease);
+  width: var(--fill, 50%);
+}
+
+.dc-axis-pos .dc-axis-bar-fill {
+  background: var(--dc-warm);
+}
+
+.dc-axis-neg .dc-axis-bar-fill {
+  background: var(--dc-cool);
+}
+
+.dc-axis-bar-val {
+  color: var(--dc-text);
+  font-size: 7px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+/* ── Slide 1: transition ─────────────────────────────────────────────────── */
+.dc-trans-pair {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dc-trans-before {
+  color: var(--dc-warm);
+  font-family: Georgia, serif;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.dc-trans-arrow {
+  color: var(--dc-text-faint);
+  font-size: 12px;
+}
+
+.dc-trans-after {
+  color: var(--dc-cool);
+  font-family: Georgia, serif;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.dc-trans-prompt {
+  color: var(--dc-text-faint);
+  font-family: Georgia, serif;
+  font-size: 11px;
+  font-style: italic;
+}
+
+/* ── Slide 3: tags ───────────────────────────────────────────────────────── */
+.dc-tags-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: center;
+  max-width: 84px;
+}
+
+.dc-tag-chip {
+  align-items: center;
+  background: rgb(255 255 255 / 3%);
+  border: 1px solid var(--dc-line-strong);
+  border-radius: 50%;
+  display: flex;
+  font-size: 12px;
+  height: 22px;
+  justify-content: center;
+  width: 22px;
+}
+
+.dc-tag-more {
+  color: hsl(var(--dc-mood-hue) 70% 80%);
+  font-size: 9px;
+  font-weight: bold;
+}
+
+.dc-tags-peak {
+  -webkit-box-orient: vertical;
+  color: var(--dc-text-dim);
+  display: -webkit-box;
+  font-family: Georgia, serif;
+  font-size: 8px;
+  font-style: italic;
+  -webkit-line-clamp: 2;
+  line-height: 1.3;
+  margin-top: 4px;
+  max-width: 84px;
+  overflow: hidden;
+  text-align: center;
+}
+
+/* ── Slide 4: momentum ───────────────────────────────────────────────────── */
+.dc-mom-value {
+  color: hsl(0deg 0% 100%);
+  font-family: Georgia, serif;
+  font-size: 30px;
+  font-weight: bold;
+  line-height: 1;
+  text-shadow: 0 0 16px var(--dc-tension);
+}
+
+.dc-mom-arc {
+  height: 24px;
+  width: 60px;
+}
+
+.dc-mom-arc path {
+  stroke: var(--dc-tension);
+  stroke-linecap: round;
+  stroke-width: 2;
+}
+
+.dc-mom-dir {
+  color: var(--dc-text-dim);
+  font-family: Georgia, serif;
+  font-size: 9px;
+  font-style: italic;
+  letter-spacing: 0.04em;
+}
+
+/* ── Slide 5: atmosphere (derived, ambient, no text) ─────────────────────── */
+.dc-slide-atmosphere {
+  --dc-atmo-warm: 0.5;
+  --dc-atmo-tension: 0;
+  --dc-atmo-blur: 0px;
+
+  overflow: hidden;
+  padding: 0;
+}
+
+.dc-atmo-layer {
+  animation: dc-atmo-drift 14s ease-in-out infinite;
+  background: radial-gradient(
+      circle at 35% 30%,
+      var(--dc-tension) 0%,
+      transparent 60%
+    ),
+    color-mix(
+      in oklab,
+      var(--dc-warm) calc(var(--dc-atmo-warm) * 100%),
+      var(--dc-cool)
+    );
+  border-radius: 50%;
+  filter: blur(var(--dc-atmo-blur));
+  inset: 0;
+  position: absolute;
+  will-change: transform;
+}
+
+/* Tension vignette — opacity driven by JS-set custom property */
+.dc-atmo-layer::after {
+  background: radial-gradient(circle, transparent 40%, var(--dc-tension) 130%);
+  border-radius: 50%;
+  content: "";
+  inset: 0;
+  opacity: var(--dc-atmo-tension);
+  position: absolute;
+}
+
+@keyframes dc-atmo-drift {
+  0%,
+  100% {
+    transform: scale(1) translate(0, 0);
+  }
+
+  50% {
+    transform: scale(1.08) translate(2px, -2px);
+  }
+}
+
+/* ── Slide 7: summary (compressed journal read) ──────────────────────────── */
+.dc-slide-summary {
+  justify-content: center;
+}
+
+.dc-summary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-width: 86px;
+  width: 100%;
+}
+
+.dc-summary-row {
+  display: flex;
+  font-family: Georgia, serif;
+  font-size: 7.5px;
+  gap: 4px;
+  justify-content: space-between;
+  line-height: 1.3;
+}
+
+.dc-summary-label {
+  color: var(--dc-text-faint);
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+
+.dc-summary-value {
+  color: var(--dc-text-dim);
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Rating slide — small momentum badge below the stars (ADR-002 §3-7) */
+.dc-rating-momentum {
+  color: hsl(0deg 0% 100% / 85%);
+  font-family: Georgia, serif;
+  font-size: 8px;
+  font-style: italic;
+  letter-spacing: 0.04em;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 50%);
 }
 
 /* ── Chat bubble ─────────────────────────────────────────────────────────────
-   Position below circle, solid background, high-contrast text.
+   Sits below the circle. Cool dark surface, high-contrast quote text.
+   (Full bubble/particle parity is DRM-VIS S5 #441.)
    ────────────────────────────────────────────────────────────────────────── */
 .dc-chat-bubble {
-  /* Position: sits BELOW the circle with breathing room */
-  position: absolute;
+  animation: dc-bubble-in 400ms var(--dc-ease-bounce) both;
+  background: var(--dc-surface-glass);
+  border: 1px solid var(--dc-line-strong);
+  border-radius: 6px 16px 16px;
   bottom: -44px;
-  left: 6px;
-  z-index: 10;
-
-  /* Solid dark background */
-  background: hsl(340 25% 18% / 0.97);
-  border: 1.5px solid var(--dc-border-strong);
-  border-radius: 6px 16px 16px 16px;
-  padding: 8px 12px 9px;
-  max-width: 120px;
-
-  /* Glow shadow */
   box-shadow:
     0 4px 20px var(--dc-shadow),
-    0 0 30px hsl(340 60% 50% / 0.1),
-    inset 0 1px 0 hsl(340 40% 40% / 0.2);
-
+    inset 0 1px 0 rgb(255 255 255 / 5%);
+  left: 6px;
+  max-width: 120px;
+  padding: 8px 12px 9px;
+  position: absolute;
   will-change: transform, opacity;
-  animation: dc-bubble-in 400ms var(--dc-ease-bounce) both;
+  z-index: 10;
 }
 
 /* Tail triangle pointing up toward circle */
 .dc-chat-bubble::before {
-  content: "";
-  position: absolute;
-  top: -8px;
-  left: 12px;
-  width: 0;
-  height: 0;
+  border-bottom: 8px solid var(--dc-line-strong);
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
-  border-bottom: 8px solid var(--dc-border-strong);
+  content: "";
+  height: 0;
+  left: 12px;
+  position: absolute;
+  top: -8px;
+  width: 0;
 }
 
 .dc-chat-bubble::after {
-  content: "";
-  position: absolute;
-  top: -6px;
-  left: 13px;
-  width: 0;
-  height: 0;
+  border-bottom: 7px solid var(--dc-surface-2);
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
-  border-bottom: 7px solid hsl(340 25% 18% / 0.97);
+  content: "";
+  height: 0;
+  left: 13px;
+  position: absolute;
+  top: -6px;
+  width: 0;
 }
 
 @keyframes dc-bubble-in {
   from {
-    transform: scale(0.85) translateY(-6px) translateZ(0);
     opacity: 0;
+    transform: scale(0.85) translateY(-6px) translateZ(0);
   }
+
   to {
-    transform: scale(1) translateY(0) translateZ(0);
     opacity: 1;
+    transform: scale(1) translateY(0) translateZ(0);
   }
 }
 
-/* Quote text — bright, bold, glowing */
+/* Quote text — bright, legible on the cool surface */
 .dc-bubble-quote {
-  font-size: 10px;
+  -webkit-box-orient: vertical;
+  color: var(--dc-text);
+  display: -webkit-box;
   font-family: Georgia, serif;
+  font-size: 10px;
   font-style: italic;
   font-weight: bold;
-  color: var(--dc-text-primary);
-  line-height: 1.5;
-  white-space: normal;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  max-width: 104px;
-
-  /* Warm glow for legibility */
-  text-shadow: var(--dc-text-glow-subtle);
   letter-spacing: 0.03em;
-
-  /* Shared dark base so white text reads on the non-poster slides */
-  .dc-slide-axes,
-  .dc-slide-transition,
-  .dc-slide-tags,
-  .dc-slide-momentum,
-  .dc-slide-summary {
-    flex-direction: column;
-    gap: 4px;
-    padding: 10px;
-    background: linear-gradient(135deg, hsl(25 25% 14%), hsl(340 20% 12%));
-  }
-
-  /* ── Slide 0: axes ────────────────────────────────────────────────────────── */
-  .dc-slide-axes {
-    gap: 5px;
-    padding: 12px;
-  }
-  .dc-axis-bar {
-    display: grid;
-    grid-template-columns: 22px 1fr 22px;
-    align-items: center;
-    gap: 4px;
-    width: 100%;
-  }
-  .dc-axis-bar-label {
-    font-size: 7px;
-    color: hsl(30 12% 65%);
-    letter-spacing: 0.02em;
-  }
-  .dc-axis-bar-track {
-    height: 4px;
-    border-radius: 99px;
-    background: hsl(0 0% 100% / 0.12);
-    overflow: hidden;
-  }
-  .dc-axis-bar-fill {
-    height: 100%;
-    width: var(--fill, 50%);
-    border-radius: 99px;
-    background: hsl(0 0% 70%);
-    transition:
-      width 400ms var(--dc-ease),
-      background 400ms var(--dc-ease);
-  }
-  .dc-axis-pos .dc-axis-bar-fill {
-    background: var(--dc-warm);
-  }
-  .dc-axis-neg .dc-axis-bar-fill {
-    background: var(--dc-cool);
-  }
-  .dc-axis-bar-val {
-    font-size: 7px;
-    text-align: right;
-    color: hsl(30 14% 78%);
-    font-variant-numeric: tabular-nums;
-  }
-
-  /* ── Slide 1: transition ──────────────────────────────────────────────────── */
-  .dc-trans-pair {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-  }
-  .dc-trans-before {
-    font-family: Georgia, serif;
-    font-size: 12px;
-    font-weight: bold;
-    color: var(--dc-warm);
-    text-align: center;
-    line-height: 1.2;
-  }
-  .dc-trans-arrow {
-    color: hsl(0 0% 100% / 0.5);
-    font-size: 12px;
-  }
-  .dc-trans-after {
-    font-family: Georgia, serif;
-    font-size: 12px;
-    font-weight: bold;
-    color: var(--dc-cool);
-    text-align: center;
-    line-height: 1.2;
-  }
-  .dc-trans-prompt {
-    font-family: Georgia, serif;
-    font-style: italic;
-    font-size: 11px;
-    color: hsl(30 12% 55%);
-  }
-
-  /* ── Slide 3: tags ────────────────────────────────────────────────────────── */
-  .dc-tags-chips {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 4px;
-    max-width: 84px;
-  }
-  .dc-tag-chip {
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 12px;
-    background: hsl(340 30% 22% / 0.85);
-    border: 1px solid hsl(340 50% 55% / 0.5);
-  }
-  .dc-tag-more {
-    font-size: 9px;
-    font-weight: bold;
-    color: hsl(340 70% 80%);
-  }
-  .dc-tags-peak {
-    margin-top: 4px;
-    max-width: 84px;
-    font-family: Georgia, serif;
-    font-style: italic;
-    font-size: 8px;
-    line-height: 1.3;
-    text-align: center;
-    color: hsl(30 16% 72%);
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  /* ── Slide 4: momentum ────────────────────────────────────────────────────── */
-  .dc-mom-value {
-    font-family: Georgia, serif;
-    font-size: 30px;
-    font-weight: bold;
-    color: hsl(0 0% 100%);
-    line-height: 1;
-    text-shadow: 0 0 16px var(--dc-tension);
-  }
-  .dc-mom-arc {
-    width: 60px;
-    height: 24px;
-  }
-  .dc-mom-arc path {
-    stroke: var(--dc-tension);
-    stroke-width: 2;
-    stroke-linecap: round;
-  }
-  .dc-mom-dir {
-    font-family: Georgia, serif;
-    font-style: italic;
-    font-size: 9px;
-    color: hsl(322 60% 78%);
-    letter-spacing: 0.04em;
-  }
-
-  /* ── Slide 5: atmosphere (derived, ambient, no text) ──────────────────────── */
-  .dc-slide-atmosphere {
-    --dc-atmo-warm: 0.5;
-    --dc-atmo-tension: 0;
-    --dc-atmo-blur: 0px;
-    padding: 0;
-    overflow: hidden;
-  }
-  .dc-atmo-layer {
-    position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    background: radial-gradient(
-        circle at 35% 30%,
-        var(--dc-tension) 0%,
-        transparent 60%
-      ),
-      color-mix(
-        in oklab,
-        var(--dc-warm) calc(var(--dc-atmo-warm) * 100%),
-        var(--dc-cool)
-      );
-    filter: blur(var(--dc-atmo-blur));
-    will-change: transform;
-    animation: dc-atmo-drift 14s ease-in-out infinite;
-  }
-  /* Tension vignette — opacity driven by JS-set custom property */
-  .dc-atmo-layer::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    background: radial-gradient(
-      circle,
-      transparent 40%,
-      var(--dc-tension) 130%
-    );
-    opacity: var(--dc-atmo-tension);
-  }
-  @keyframes dc-atmo-drift {
-    0%,
-    100% {
-      transform: scale(1) translate(0, 0);
-    }
-    50% {
-      transform: scale(1.08) translate(2px, -2px);
-    }
-  }
-
-  /* ── Slide 7: summary (compressed journal read) ───────────────────────────── */
-  .dc-slide-summary {
-    justify-content: center;
-  }
-  .dc-summary-body {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    width: 100%;
-    max-width: 86px;
-  }
-  .dc-summary-row {
-    display: flex;
-    justify-content: space-between;
-    gap: 4px;
-    font-family: Georgia, serif;
-    font-size: 7.5px;
-    line-height: 1.3;
-  }
-  .dc-summary-label {
-    color: hsl(30 10% 55%);
-    letter-spacing: 0.02em;
-    flex-shrink: 0;
-  }
-  .dc-summary-value {
-    color: hsl(30 18% 82%);
-    text-align: right;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* Rating slide — small momentum badge below the stars (ADR-002 §3-7) */
-  .dc-rating-momentum {
-    font-size: 8px;
-    font-family: Georgia, serif;
-    font-style: italic;
-    color: hsl(0 0% 100% / 0.85);
-    letter-spacing: 0.04em;
-    text-shadow: 0 1px 3px hsl(340 50% 25% / 0.5);
-  }
+  -webkit-line-clamp: 3;
+  line-height: 1.5;
+  max-width: 104px;
+  overflow: hidden;
+  text-shadow: var(--dc-text-glow-subtle);
+  white-space: normal;
 }

--- a/extensions/some-drama/src/styles/components/title-pill.css
+++ b/extensions/some-drama/src/styles/components/title-pill.css
@@ -4,28 +4,26 @@
    ────────────────────────────────────────────────────────────────────────── */
 
 .dc-title-pill {
-  /* Solid dark background with warm undertone */
-  background: hsl(25 25% 15% / 0.95);
+  animation: dc-float-gentle 5s ease-in-out infinite;
   backdrop-filter: var(--dc-blur);
-  -webkit-backdrop-filter: var(--dc-blur);
 
-  /* Glowing border */
-  border: 1.5px solid var(--dc-border-strong);
+  /* Cool dark surface (floor) */
+  background: var(--dc-surface-glass);
+
+  /* Hairline border (floor) */
+  border: 1px solid var(--dc-line-strong);
   border-radius: var(--dc-r-pill);
-  padding: 7px 16px 7px 12px;
-  gap: 10px;
 
-  /* Layered shadow + glow */
+  /* Deep, quiet shadow */
   box-shadow:
     0 4px 24px var(--dc-shadow),
-    0 0 40px hsl(340 60% 50% / 0.12),
-    inset 0 1px 0 hsl(340 40% 50% / 0.15);
-
+    inset 0 1px 0 rgb(255 255 255 / 5%);
+  gap: 10px;
   max-width: 280px;
+  padding: 7px 16px 7px 12px;
 
   /* Prevent jitter — use subtle float instead of bob */
   will-change: transform;
-  animation: dc-float-gentle 5s ease-in-out infinite;
 }
 
 @keyframes dc-float-gentle {
@@ -33,6 +31,7 @@
   100% {
     transform: translateY(0) translateZ(0);
   }
+
   50% {
     transform: translateY(-3px) translateZ(0);
   }
@@ -40,50 +39,50 @@
 
 /* Live indicator dot — bright and glowing */
 .dc-title-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--dc-peach);
-  flex-shrink: 0;
-
-  /* Strong glow for visibility */
-  box-shadow:
-    0 0 8px var(--dc-peach),
-    0 0 16px hsl(18 95% 65% / 0.5);
-
   animation: dc-dot-pulse 2.5s ease-in-out infinite;
+  background: hsl(var(--dc-mood-hue) 72% 64%);
+  border-radius: 50%;
+
+  /* Mood-tinted glow for a live-indicator feel */
+  box-shadow:
+    0 0 8px hsl(var(--dc-mood-hue) 72% 64%),
+    0 0 16px hsl(var(--dc-mood-hue) 70% 60% / 50%);
+  flex-shrink: 0;
+  height: 8px;
+  width: 8px;
 }
 
 @keyframes dc-dot-pulse {
   0%,
   100% {
-    transform: scale(1);
+    box-shadow:
+      0 0 8px hsl(var(--dc-mood-hue) 72% 64%),
+      0 0 16px hsl(var(--dc-mood-hue) 70% 60% / 50%);
     opacity: 1;
-    box-shadow:
-      0 0 8px var(--dc-peach),
-      0 0 16px hsl(18 95% 65% / 0.5);
+    transform: scale(1);
   }
+
   50% {
-    transform: scale(1.3);
-    opacity: 0.8;
     box-shadow:
-      0 0 12px var(--dc-peach),
-      0 0 24px hsl(18 95% 65% / 0.6);
+      0 0 12px hsl(var(--dc-mood-hue) 72% 64%),
+      0 0 24px hsl(var(--dc-mood-hue) 70% 60% / 60%);
+    opacity: 0.8;
+    transform: scale(1.3);
   }
 }
 
 /* Drama title text — high contrast with warm glow */
 .dc-title-text {
+  color: var(--dc-text-primary);
   font-family: Georgia, serif;
   font-size: 12px;
   font-style: italic;
   font-weight: bold;
-  color: var(--dc-text-primary);
-  white-space: nowrap;
+  letter-spacing: 0.04em;
   overflow: hidden;
   text-overflow: ellipsis;
-  letter-spacing: 0.04em;
 
   /* Glow for text to pop */
   text-shadow: var(--dc-text-glow-warm);
+  white-space: nowrap;
 }

--- a/extensions/some-drama/src/styles/tokens/tokens.css
+++ b/extensions/some-drama/src/styles/tokens/tokens.css
@@ -1,49 +1,73 @@
 /* ── Drama Tracker — Design Tokens ─────────────────────────────────────────
    All CSS custom properties in one place for easy theming.
-   Optimized for dark theme environments while maintaining a bright, colorful mood.
+
+   DRM-VIS S1 (#437): reconciled to the drama-capture-ui wireframe floor — a
+   cinematic cool near-black blue-violet base with a full emotional-spectrum
+   accent range (gold → peach → pink → magenta → violet → indigo → blue),
+   white-alpha hairlines, and deep black shadows. The old warm-rose values are
+   projected onto the floor's palette; every token name is preserved so no
+   component references break while later DRM-VIS stories (S2–S5) refine the
+   pieces that still hardcode warm values.
    ────────────────────────────────────────────────────────────────────────── */
 
 :root {
   /* ── UnoCSS spacing scale (not emitted when preflights are off) ─────── */
   --spacing: 0.25rem;
 
-  /* ── Core Brand Colors — Vibrant & saturated for dark backgrounds ─────── */
-  --dc-peach: hsl(18 95% 65%);
-  --dc-rose: hsl(340 85% 60%);
-  --dc-gold: hsl(42 100% 55%);
-  --dc-coral: hsl(12 90% 62%);
+  /* ── Floor base — cinematic cool dark (wireframe drama.css) ───────────── */
+  --dc-bg: #0a0a12;
+  --dc-surface: #141420;
+  --dc-surface-2: #1b1b2a;
+  --dc-line: rgb(255 255 255 / 8%);
+  --dc-line-strong: rgb(255 255 255 / 16%);
+  --dc-text: #ece9f5;
+  --dc-text-dim: #9b96b3;
+  --dc-text-faint: #6b6782;
 
-  /* ── Surface Colors — Semi-opaque with solid fallbacks ────────────────── */
-  --dc-surface-solid: hsl(25 30% 18%);
-  --dc-surface-glass: hsl(25 25% 15% / 0.92);
-  --dc-surface-elevated: hsl(25 20% 22% / 0.96);
+  /* ── Emotional spectrum (wireframe floor) ─────────────────────────────── */
+  --dc-gold: #f2b35c;
+  --dc-peach: #f0997a;
+  --dc-pink: #e87aa0;
+  --dc-magenta: #d65794;
+  --dc-violet: #8b6fc4;
+  --dc-indigo: #5f6fc0;
+  --dc-blue: #5aa0d6;
 
-  /* ── Text Colors — High contrast for legibility ───────────────────────── */
-  --dc-text-primary: hsl(30 20% 95%);
-  --dc-text-secondary: hsl(30 15% 75%);
-  --dc-text-muted: hsl(30 10% 55%);
-  --dc-text-dark: hsl(25 50% 12%);
+  /* ── Legacy aliases — mapped onto the spectrum ────────────────────────── */
+  --dc-rose: var(--dc-pink); /* primary accent ≈ floor pink */
+  --dc-coral: #ef8f6e;
 
-  /* ── Border Colors — Visible but subtle ───────────────────────────────── */
-  --dc-border: hsl(340 40% 45% / 0.5);
-  --dc-border-strong: hsl(340 50% 55% / 0.7);
-  --dc-border-glow: hsl(340 60% 65% / 0.4);
+  /* ── Surface Colors — cool dark, semi-opaque with solid fallbacks ─────── */
+  --dc-surface-solid: var(--dc-surface);
+  --dc-surface-glass: rgb(20 20 32 / 92%);
+  --dc-surface-elevated: rgb(27 27 42 / 96%);
 
-  /* ── Shadows — Colored shadows for depth on dark backgrounds ──────────── */
-  --dc-shadow: hsl(340 60% 20% / 0.5);
-  --dc-shadow-strong: hsl(340 70% 15% / 0.7);
-  --dc-shadow-glow: hsl(340 80% 55% / 0.35);
+  /* ── Text Colors — floor scale (aliases kept for existing consumers) ──── */
+  --dc-text-primary: var(--dc-text);
+  --dc-text-secondary: var(--dc-text-dim);
+  --dc-text-muted: var(--dc-text-faint);
+  --dc-text-dark: #0a0a12;
 
-  /* ── Text Shadows — For text to pop on any background ─────────────────── */
-  --dc-text-glow-warm: 0 0 12px hsl(18 90% 60% / 0.5),
-    0 0 4px hsl(0 0% 0% / 0.8), 0 1px 2px hsl(0 0% 0% / 0.6);
-  --dc-text-glow-gold: 0 0 10px hsl(42 100% 55% / 0.6),
-    0 0 4px hsl(0 0% 0% / 0.8);
-  --dc-text-glow-subtle: 0 1px 3px hsl(0 0% 0% / 0.7),
-    0 0 8px hsl(340 60% 50% / 0.3);
+  /* ── Border Colors — white-alpha hairlines (floor) ────────────────────── */
+  --dc-border: var(--dc-line);
+  --dc-border-strong: var(--dc-line-strong);
+  --dc-border-glow: hsl(var(--dc-mood-hue) 65% 62% / 40%);
+
+  /* ── Shadows — deep black for cinematic depth on dark surfaces ────────── */
+  --dc-shadow: rgb(0 0 0 / 50%);
+  --dc-shadow-strong: rgb(0 0 0 / 72%);
+  --dc-shadow-glow: hsl(var(--dc-mood-hue) 70% 55% / 30%);
+
+  /* ── Text Shadows — subtle legibility, not warm glow ──────────────────── */
+  --dc-text-glow-warm: 0 1px 2px hsl(0deg 0% 0% / 70%),
+    0 0 10px hsl(var(--dc-mood-hue) 70% 55% / 25%);
+  --dc-text-glow-gold: 0 0 10px hsl(38deg 85% 60% / 45%),
+    0 1px 2px hsl(0deg 0% 0% / 70%);
+  --dc-text-glow-subtle: 0 1px 3px hsl(0deg 0% 0% / 70%),
+    0 0 8px hsl(var(--dc-mood-hue) 60% 55% / 22%);
 
   /* ── Radii ────────────────────────────────────────────────────────────── */
-  --dc-r-card: 20px;
+  --dc-r-card: 22px;
   --dc-r-pill: 999px;
   --dc-r-sm: 8px;
 
@@ -56,17 +80,16 @@
   --dc-mood-hue: 340;
   --dc-prog-pct: 0%;
 
-  /* ── Emotion vector spectrum (ADR-002) ────────────────────────────────── */
-  --dc-warm: hsl(36 90% 64%);
-  --dc-cool: hsl(250 70% 68%);
-  --dc-tension: hsl(322 78% 62%);
-
+  /* ── Emotion vector spectrum (ADR-002) — aligned to the floor legend ──── */
+  --dc-warm: var(--dc-gold);
+  --dc-cool: var(--dc-indigo);
+  --dc-tension: var(--dc-magenta);
   --dj-bg: #fcfbf9; /* Notebook soft paper background */
   --dj-text: #2c2a29; /* High contrast readability charcoal */
   --dj-border: #e6e3df; /* Organic subtle baseline lines */
   --dj-accent: #634eb8; /* Single warm violet character accent color */
   --dj-muted: #8c8782; /* Auxiliary guidance text color */
-  --dj-surface: #ffffff; /* Foreground pristine element backing */
+  --dj-surface: #fff; /* Foreground pristine element backing */
   --dj-preview-bg: linear-gradient(
     135deg,
     #1e1b24 0%,


### PR DESCRIPTION
## Description

Lands the tractable, independently-verified stories from two progressive epics:

- **DRM-STORY** (#436) — Storybook coverage for the slideshow card surface
- **DRM-VIS** (#442) — visual parity with the `paulgsc/drama-capture-ui` wireframe floor

### DRM-STORY

- S1 (#432) audit was already satisfied — every `some-drama` component already ships a co-located story.
- S2 (#433): typed `CardState`/`DramaEntry` fixtures (`components/__fixtures__/card-state.ts`), derived from the canonical `DramaEntry` type so they can't drift from `src/types`.
- S3 (#434): play-function interaction stories for the slideshow (auto-advance cycling, click-to-advance) and the card (circle-click advance, size cycle with capture-panel auto-close on `min`, mood emission via `fn()` spy).

Every pinned behavior was verified end-to-end by driving the real `Slideshow`/`DramaCard` components in Chromium (not just the Storybook decorators, which currently can't build in this environment due to an unrelated `polyhedron` wasm dependency) — 15/15 checks passed.

### DRM-VIS

Ported the wireframe's design language (tokens, shell, ring, slide surfaces, panels) into the extension's existing DOM — pure presentation, no DOM restructure. The wireframe is a full-page 480px carousel and the extension is a small floating circular overlay, so "parity" here means the palette/radii/shadows/typography language, not cloning the carousel markup.

- S1 (#437): tokens, card shell, title pill — rerouted the warm-rose palette to the floor's cinematic cool base (`#0a0a12`/`#141420`, white-alpha hairlines, deep black shadows) plus the full emotional spectrum (gold→peach→pink→magenta→violet→indigo→blue). All legacy token names preserved/aliased so nothing else broke.
- S2 (#438): slideshow ring, slide surface, nav dots — ring now carries the emotional spectrum; nav dots use the floor's elongated-pill active state.
- S3 (#439): the eight slides — recolored to the spectrum. Also fixes a latent bug: every slide-interior rule was CSS-nested under `.dc-bubble-quote` (missing closing brace) and therefore never applied — this is why the axes slide previously rendered as unstyled overflowing text.
- S4 (#440): right panel & capture panel — episode badge/progress bar move to the spectrum with mood-tinted glow; capture panel gets the cool hairline treatment.
- S5 (#441): chat bubble & particle layer — bubble reconciled to the cool surface (landed as part of the S2/S3 slideshow commit, since its CSS lives in `slideshow.css`); the particle layer is emoji-based geometry with nothing to recolor and no rAF changes permitted, so no further change was needed.

Not included: **S4 of DRM-STORY (#435, Chromatic baselines)** — needs a Chromatic project token wired into CI, which is out of scope for this session. DRM-STORY's parent epic (#436) is left open pending that story.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (N/A — none needed)

## Checklist

- [x] My code follows the style guidelines of this project (eslint, prettier, stylelint, `tsc --noEmit` all green)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (Storybook play functions; behavior additionally verified by driving the real components in Chromium — 15/15 checks)
- [x] New and existing unit tests pass locally with my changes

## Screenshots

Before → after (full-size card): warm rose/brown shell and ring, with the axes slide rendering as unstyled overflowing text due to the CSS nesting bug, versus the reconciled cool cinematic floor with a working spectrum ring and correctly-rendered axes slide.

Closes #432
Closes #433
Closes #434
Closes #437
Closes #438
Closes #439
Closes #440
Closes #441
Closes #442


---
_Generated by [Claude Code](https://claude.ai/code/session_0178Ai2N4hL4yFLnTm9WZn6v)_