### PR TITLE
[UTL-FOUND] Land S2 census + S3 scaffold convention

### DIFF
--- a/crates/pkg_cloner/src/cloner/interaction.rs
+++ b/crates/pkg_cloner/src/cloner/interaction.rs
@@ -1,4 +1,4 @@
-use crate::Package;
+use crate::{find_closest_match, Package};
 use dialoguer::{theme::ColorfulTheme, Input, Select};
 use std::io::{Error, ErrorKind, Result as IoResult};
 
@@ -21,8 +21,15 @@ pub fn select_template_package(packages: &[Package]) -> IoResult<&Package> {
     Ok(&packages[selection])
 }
 
-/// Prompts user to enter a new package name with validation
-pub fn get_new_package_name(existing_names: &[String]) -> IoResult<String> {
+/// Prompts user to enter a new package name with validation.
+///
+/// Beyond rejecting exact duplicates, this flags names that are a near-miss of an
+/// existing package (e.g. a plural/singular slip or a single-character typo) via
+/// Levenshtein similarity, since an exact-match check alone lets those through silently
+/// and produces a confusingly-named sibling package instead of the one the user meant.
+pub fn get_new_package_name(existing_names: &[String], similarity_threshold: f64) -> IoResult<String> {
+    let candidates: Vec<&str> = existing_names.iter().map(String::as_str).collect();
+
     loop {
         let name: String = Input::with_theme(&ColorfulTheme::default())
             .with_prompt("Enter new package name")
@@ -39,6 +46,13 @@ pub fn get_new_package_name(existing_names: &[String]) -> IoResult<String> {
         if existing_names.contains(&name) {
             println!("Package '{}' already exists. Please choose a different name.", name);
             continue;
+        }
+
+        if let Some(closest) = find_closest_match(&name, &candidates, similarity_threshold) {
+            let proceed = confirm_action(&format!("'{name}' is very similar to the existing package '{closest}'. Did you mean to create a new, distinct package?"))?;
+            if !proceed {
+                continue;
+            }
         }
 
         return Ok(name);

--- a/crates/pkg_cloner/src/cloner/workspace.rs
+++ b/crates/pkg_cloner/src/cloner/workspace.rs
@@ -16,20 +16,24 @@ impl Package {
     }
 }
 
-/// Finds all packages (directories) in the workspaces directory
+/// Finds all packages (directories containing a package.json) in the workspaces directory.
+///
+/// Filters out build/cache directories (e.g. `.turbo`, `dist`, `node_modules`) that are
+/// plain subdirectories but not real packages, so they never show up as template candidates.
 pub fn find_packages(workspaces: &Path) -> IoResult<Vec<Package>> {
     let entries = fs::read_dir(workspaces).map_err(|e| Error::new(e.kind(), format!("Failed to read workspaces directory {}: {}", workspaces.display(), e)))?;
 
     let packages: Vec<Package> = entries
         .filter_map(Result::ok)
         .filter(|entry| entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .filter(|entry| entry.path().join("package.json").is_file())
         .filter_map(|entry| Package::new(entry.path()))
         .collect();
 
     if packages.is_empty() {
         return Err(Error::new(
             ErrorKind::NotFound,
-            format!("No packages found in workspace directory: {}", workspaces.display()),
+            format!("No packages (directories containing a package.json) found in workspace directory: {}", workspaces.display()),
         ));
     }
 
@@ -79,6 +83,24 @@ fn is_valid_package_name(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_find_packages_ignores_dirs_without_package_json() {
+        let workspaces = tempfile::tempdir().unwrap();
+
+        let real_package = workspaces.path().join("some-real-package");
+        fs::create_dir_all(&real_package).unwrap();
+        fs::write(real_package.join("package.json"), "{}").unwrap();
+
+        // A build/cache dir that happens to sit alongside real packages but isn't one.
+        fs::create_dir_all(workspaces.path().join(".turbo")).unwrap();
+
+        let packages = find_packages(workspaces.path()).unwrap();
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "some-real-package");
+    }
 
     #[test]
     fn test_valid_package_names() {

--- a/crates/pkg_cloner/src/main.rs
+++ b/crates/pkg_cloner/src/main.rs
@@ -21,7 +21,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nUsing template: {}", template_package.name);
 
     let existing_names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
-    let new_package_name = get_new_package_name(&existing_names)?;
+    let new_package_name = get_new_package_name(&existing_names, cli.similarity_threshold)?;
 
     // Show summary and confirm
     println!("\n=== Package Creation Summary ===");

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,137 @@
+# Leaf Workspace Scaffold Convention
+
+> Canonical shape for a new `packages/` (or `packages/ui/`) leaf workspace.
+> Written for UTL-FOUND S3 (#522) so every HOIST workspace this milestone
+> stands up (core-utils, react-hooks, ws, speech, viewport, orchestrator,
+> wasm-loader) is identically configured, instead of each split PR
+> reinventing build config by copy-paste archaeology.
+>
+> This convention only defines _how_ a workspace is scaffolded. It moves no
+> code — see [`SHARED_WORKSPACE_DOCTRINE.md`](./SHARED_WORKSPACE_DOCTRINE.md)
+> for _whether_ an export belongs in a shared workspace at all.
+
+Reference implementations: `packages/utils` (`some-ui-utils`) and
+`packages/ui/shared` (`some-ui-shared`). When in doubt, diff a new package
+against these two rather than an arbitrary sibling — they're the two
+workspaces this convention was extracted from.
+
+## 1. `package.json`
+
+- **Name:** `@some-ui/<x>` (scoped) for new M14 workspaces. (The bare
+  `some-ui-<x>` / `some-ui-shared` naming on older packages predates this
+  convention and is not being renamed retroactively — see Doctrine §2, this
+  is a naming nit, not a de-hoist trigger.)
+- **`peerDependencies` vs `dependencies` discipline:** anything the
+  _consumer's_ React tree must own a single copy of (react, react-dom,
+  framer-motion-style animation libs, anything with module-level state) goes
+  in `peerDependencies`. Anything the package fully owns and bundles goes in
+  `dependencies`. Get this wrong and you get duplicate-React or
+  duplicate-store bugs at the consumer, not at build time.
+- **Scripts** (names matter — see §4 on turbo): `build`, `build:tsc-alias`,
+  `watch:build`, `watch:lint`, `clean`, `clean:build`, `lint`, `lint:js`,
+  `prettier`, `typecheck`. Add `test` if the package ships tests.
+- **`sideEffects`:** `["*.css"]` if the package ships a stylesheet, `false`
+  otherwise — required for consumers' bundlers to tree-shake the package.
+- **`main` / `module` / `types` / `exports`:** point at `./dist/<pkg>.*`,
+  mirroring the four-key `exports["."]` map (`types`/`import`/`require`/
+  `default`) both reference packages use. Add an `./style.css` export entry
+  only if the package ships one.
+- **`files`:** `["dist"]` — never ship `src/` in the published tree.
+
+## 2. TypeScript config
+
+- `tsconfig.json` extends `@some-ui/tsconfig/rollupconfig.json`, sets
+  `composite: true`, `rootDir: "./src"`, `outDir: "./dist"`,
+  `declarationDir: "./"`, and declares the package's **own** internal path
+  alias (e.g. `"@utils/*": ["./src/*"]`) for imports inside the package.
+  `include: ["src"]`, `exclude: ["node_modules", "build", "dist"]`.
+- `tsconfig.build.json` extends `./tsconfig.json`, adds `jsx: "react-jsx"`
+  if the package has components/hooks, and excludes `**/*.test.ts` and
+  `**/*.stories.tsx`.
+
+## 3. Build (`@some-ui/vite-config`)
+
+`vite.config.ts`:
+
+```ts
+import { resolve } from "path"
+import { createViteConfig } from "@some-ui/vite-config"
+
+export default createViteConfig({
+  packageName: "@some-ui/<x>",
+  libraryName: "<PascalCaseLibraryName>",
+  alias: { "@<x>": resolve(__dirname, "src") },
+  tsConfigPaths: { projects: [resolve(__dirname, "tsconfig.build.json")] },
+})
+```
+
+## 4. Barrel + turbo pipeline
+
+- `src/index.ts` re-exports the package's public surface (typically
+  `export * from "./lib"` plus a `./types` barrel — see
+  `packages/utils/src/index.ts`). This barrel is also what the census (S2)
+  treats as the source of truth for "what does this package export."
+- **Turbo needs no per-package registration.** `turbo.json` at the repo
+  root defines tasks by _name_ (`build`, `lint`, `typecheck`, `test`,
+  `clean`, `watch:build`, `watch:lint`, ...) with `dependsOn: ["^build"]`
+  graph edges. Any workspace that defines a same-named script in its
+  `package.json` is automatically picked up — the scaffold only has to
+  match the script names in §1, not touch `turbo.json` itself. Only add a
+  new top-level task there if the workspace needs a genuinely new task
+  _type_ turbo doesn't already know about.
+
+## 5. Registration (the parts that don't auto-discover)
+
+Three places list workspaces explicitly and do **not** pick up a new
+package on their own — a new workspace is invisible to type-checking and
+lint import-resolution until these are updated:
+
+1. **`pnpm-workspace.yaml`** — already globs `packages/*`, `packages/ui/*`,
+   `apps/*`, `extensions/**`, `crates/*`. No edit needed if the new package
+   lives under one of those; only edit this if scaffolding a genuinely new
+   top-level category.
+2. **Root `tsconfig.json`** `compilerOptions.paths` — add
+   `"@<x>/*": ["./packages/<path>/src/"]` so the rest of the monorepo can
+   import the package by its short alias during type-checking. (This map
+   had drifted — `@utils/*` pointed at the non-existent
+   `packages/ui/utils/src/` instead of `packages/utils/src/`; fixed as part
+   of landing this convention.)
+3. **`packages/eslint/tsconfig.workspace-resolve.json`**
+   `compilerOptions.paths` — add `"@some-ui/<x>": ["../<path>/src/index.ts"]`
+   (keyed by the real package _name_, not the short alias) so ESLint's
+   import resolver can follow imports of the bare package name to source
+   instead of the built `dist/`.
+
+## 6. Scaffolding it: `pnpm build:template`
+
+`pnpm build:template` runs the `pkg_cloner` Rust binary
+(`crates/pkg_cloner`), which automates the mechanical parts of §1–2: point
+it at a workspaces directory, pick an existing package as a template, name
+the new one, and it copies `tsconfig*.json`, `package.json` (rewriting the
+`name` field), `*.config.{js,ts}`, lint/prettier/git/editorconfig dotfiles,
+and `jest`/`vitest` configs into a freshly created `<new-package>/src/`
+directory.
+
+It does **not** touch §3–5 — the vite-config call, the barrel content, or
+the three registration points above are still a manual step after running
+it.
+
+As part of this story, `pkg_cloner` was bolstered (it was "too happy
+path" — see #522):
+
+- `find_packages` used to treat _any_ directory under the workspaces path
+  as a template candidate, including non-package directories like
+  `.turbo` or a stray `dist/`. It now requires a `package.json` to be
+  present.
+- The CLI already accepted a `--similarity-threshold` flag and shipped a
+  tested Levenshtein `find_closest_match` helper, but neither was ever
+  wired into the actual run — so a near-duplicate package name (a
+  plural/singular slip, a single-character typo) was accepted silently
+  instead of being flagged. `get_new_package_name` now checks the chosen
+  name against existing package names with `find_closest_match` and asks
+  for confirmation before proceeding on a near-miss.
+
+## Non-goals
+
+This document scaffolds workspaces; it does not decide which concerns get
+hoisted into them (Doctrine + S2 census) and it moves no production code.

--- a/packages/UTILS_CENSUS.md
+++ b/packages/UTILS_CENSUS.md
@@ -1,0 +1,258 @@
+# `some-ui-utils` / `some-ui-shared` Named-Import Consumer Census
+
+> Evidence base for UTL-FOUND S2 (#521). Every hoist/keep/de-hoist decision
+> in this milestone is scored against this table via the
+> [Doctrine](./SHARED_WORKSPACE_DOCTRINE.md) §3 decision matrix — not
+> against `package.json` dependency lists, which overcount (see
+> [Declared-but-unused](#declared-but-unused-dependencies) below).
+>
+> **Method:** every `import {...} from "some-ui-utils"` / `"some-ui-shared"`
+> statement in the repo (single- and multi-line, including `import type`),
+> excluding each package's own source tree, grouped by symbol → consuming
+> workspace → file. Zero-hit symbols were re-checked by hand to distinguish
+> "no consumers" from "internal-only, consumed by another exported hook."
+> Package specifiers confirmed against each package's `package.json` `name`
+> field — note `some-ui-shared` (not `@some-ui/shared`; that scope belongs
+> to the unrelated `@some-ui/styles` package).
+>
+> Zero code moves in this doc. Cleanup items called out below (dead code,
+> unreachable exports, stale deps) are evidence for later stories, not
+> action taken here.
+
+## 1. Pure utils
+
+| Symbol                                      | Real consumers                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Verdict                                           |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `cn` (`lib/cn.ts`)                          | **18 workspaces**: `apps/www`, root `.storybook`, `packages/some-content`, `packages/ui/attributions`, `packages/ui/chat`, `packages/ui/emoji-animations`, `packages/ui/input`, `packages/ui/makjang`, `packages/ui/neon-sign`, `packages/ui/nfl`, `packages/ui/overlays`, `packages/ui/resume`, `packages/ui/searchbar`, `packages/ui/shared` (`components/ui/tatu/index.tsx`), `packages/ui/slideshow`, `packages/ui/stepper`, `packages/ui/umag`, `packages/ui/wireframes` | **hoist** — widest-reaching export in the package |
+| `getAcronymFromString` (`string-utils.ts`)  | 1 workspace: `packages/ui/shared/src/components/ui/with-avatar/index.tsx`                                                                                                                                                                                                                                                                                                                                                                                                     | **de-hoist**                                      |
+| `formatRelativeTime` (`date-utils.ts`)      | 2 workspaces: `apps/www`, `packages/ui/chat`                                                                                                                                                                                                                                                                                                                                                                                                                                  | **borderline → flag for DEHOIST S5**              |
+| `getRandomSubarray` (`array-utils.ts`)      | 2 workspaces: `packages/ui/input` (`use-crossword-wasm`), `packages/ui/slideshow` (`rotating-cube.ts`)                                                                                                                                                                                                                                                                                                                                                                        | **borderline → flag for DEHOIST S5**              |
+| `createSequentialCycler` (`array-utils.ts`) | 1 workspace: `packages/ui/stepper/src/hooks/use-accordion-stepper.ts`                                                                                                                                                                                                                                                                                                                                                                                                         | **de-hoist**                                      |
+
+## 2. Generic hooks (`lib/hooks/*`)
+
+| Symbol                      | Real consumers                                                                                                     | Verdict                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `useLocalStorage`           | 4 workspaces: `packages/ui/chat`, `packages/ui/emoji-animations`, `packages/ui/neon-sign`, `packages/ui/slideshow` | **hoist**                                      |
+| `useMeasureRect`            | 4 workspaces: `packages/ui/chat`, `packages/ui/nfl`, `packages/ui/shared`, `packages/ui/slideshow`                 | **hoist**                                      |
+| `useContainerRect`          | 1 workspace: `packages/ui/slideshow/src/components/cube-geometry/index.tsx`                                        | **de-hoist**                                   |
+| `useEventListener`          | 1 workspace: `packages/ui/searchbar/src/components/searchbar/searchbar.tsx`                                        | **de-hoist**                                   |
+| `useIsomorphicLayoutEffect` | 1 workspace: `packages/ui/searchbar/src/components/searchbar-input/searchbar-input.tsx`                            | **de-hoist**                                   |
+| `useIsMobile`               | 1 workspace: `packages/ui/shared/src/components/ui/sidebar.tsx`                                                    | **de-hoist**                                   |
+| `useResizeObserver`         | 0 external — internal to `useMeasureRect` only                                                                     | **no external consumers** (internal substrate) |
+| `useIsMounted`              | 0 external — internal to `useResizeObserver` only (two layers deep)                                                | **no external consumers** (internal substrate) |
+| `useInterval`               | 0 usages anywhere, including inside `packages/utils`                                                               | **dead code**                                  |
+| `useFetch`                  | 0 usages anywhere, including inside `packages/utils`                                                               | **dead code**                                  |
+
+## 3. Websocket engine (`lib/hooks/websocket/*`)
+
+Not re-exported by `hooks/index.ts` — no `export * from "./websocket"` exists.
+The only importers are internal: `socket-tenants/use-obs-socket.ts`,
+`socket-tenants/use-prompt-utterance.ts`,
+`socket-tenants/use-now-playing-socket.ts`,
+`socket-tenants/orchestrator/use-orchestrator.ts`.
+
+**Verdict: no external consumers — confirmed pure internal substrate** for
+the socket-tenants hooks in §7–8, §14 below. Correctly out of scope for
+hoist/de-hoist; must never be publicly exported.
+
+## 4. Speech / TTS / audio
+
+| Symbol                                                                                                                                  | Real consumers                                                                                                                                                                     | Verdict                              |
+| --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `useAudioTTS`                                                                                                                           | 2 workspaces: `apps/www` (`providers/tts.tsx`), `packages/ui/chat`                                                                                                                 | **borderline → flag for DEHOIST S5** |
+| `useAudioFromStorage`                                                                                                                   | 1 workspace: `packages/ui/umag/src/components/now-playing/audio-player/demo/index.tsx`                                                                                             | **de-hoist**                         |
+| `useSpeechQueue`                                                                                                                        | 3 workspaces: `packages/ui/chat`, `packages/ui/stepper`, `packages/ui/umag`                                                                                                        | **hoist**                            |
+| `initializeSpeechQueue`                                                                                                                 | 1 workspace: `apps/www/src/providers/tts.tsx`                                                                                                                                      | **de-hoist**                         |
+| `useAudioSpeech`                                                                                                                        | 0 external — internal to `useAudioTTS`/`useAudioFromStorage`                                                                                                                       | **no external consumers**            |
+| `useTTSFetch`                                                                                                                           | 0 external — internal to `useAudioTTS`                                                                                                                                             | **no external consumers**            |
+| `getSpeechQueue`, `useSpeechQueueActions`/actions selectors, metrics selectors                                                          | 0 external, 0 internal beyond definition                                                                                                                                           | **dead code**                        |
+| Types `TTSOptions`, `TTSProvider`, `VoiceConfig`, `UseAudioTTSReturn`, `UseAudioTTSOptions`, `UseAudioStorageOptions`, `BUILTIN_VOICES` | span the same 4 workspaces as the hooks above (chat, stepper, umag, www) — **missing from the epic's first-pass list**, tracked here so they move together with any hoist/de-hoist | same tier as cluster verdict         |
+
+**Cluster verdict: hoist** (4 genuinely distinct app/workspace consumers), but
+`useAudioSpeech`, `useTTSFetch`, and the unused queue-action/metric selectors
+are dead weight on the public surface and are cleanup candidates, not
+hoist/de-hoist candidates.
+
+## 5. Viewport / polyhedron (`lib/polyhedron/*`)
+
+| Symbol                                                                        | Real consumers                                                                   | Verdict                                   |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------- |
+| `useViewport`                                                                 | 1 workspace: `packages/ui/slideshow/src/components/viewport-dice-card/index.tsx` | **de-hoist**                              |
+| `useCycleRotationAdapter`                                                     | 0 usages anywhere, including inside `packages/utils`                             | **dead code**                             |
+| `viewport-engine.ts`, `viewport-manager.ts`, `wasm-runtime.ts`, `viewport.ts` | not re-exported by `polyhedron/index.ts`; no deep imports found                  | **internal-only, unreachable externally** |
+
+Note: `packages/ui/input/src/hooks/use-viewport-rotation-wasm/index.ts` is a
+same-sounding but **independent** implementation — it imports only
+`createEventBus` from `some-ui-utils` (§12), nothing from `polyhedron/*`. Not
+part of this cluster.
+
+## 6. Orchestrator / livestream — the first-pass census conflated two unrelated engines
+
+This is the single most important correction from this census: the
+epic's first-pass table names `useLivestreamOchestrator` /
+`useOchestrationStore` as if they were the live implementation. They are
+not — the actually-used orchestrator is a separate file
+(`zustand-store/orchestrator-store.ts`), unrelated to the generic
+`context/ochestra/*` store substrate.
+
+### 6a. `zustand-store/orchestrator-store.ts` — the real, consumed implementation
+
+| Symbol                                                                 | Real consumers                                                                                       | Verdict                                       |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `useOrchestratorStore`                                                 | 2 workspaces: `apps/www`, `packages/ui/slideshow`                                                    | hoist tier                                    |
+| `useSceneLifetimes`                                                    | 4 workspaces: `apps/www`, `packages/some-content`, `packages/ui/slideshow`, `packages/ui/wireframes` | hoist tier                                    |
+| `usePrimaryScene`                                                      | 2 workspaces: `apps/www`, `packages/some-content`                                                    | **borderline** — missing from first-pass list |
+| `useOrchestratorClock`, `useIsRunning`, `useIsPaused`, `useIsTerminal` | 1 workspace each: `apps/www`                                                                         | ships with the store                          |
+| `selectCurrentTime`, `selectTotalDuration`, `selectIsRunning`          | `packages/ui/slideshow`                                                                              | **missing from first-pass list**              |
+| `useMode`, `selectProgress`, `selectConnectionStatus`                  | 0 external                                                                                           | dead code                                     |
+
+Combined distinct consumer workspaces: `apps/www`, `packages/some-content`,
+`packages/ui/slideshow`, `packages/ui/wireframes` (4) → **cluster verdict:
+hoist**. `usePrimaryScene` individually flagged **borderline → DEHOIST S5**.
+
+### 6b. `context/ochestra/*` — generic store substrate, dead
+
+`createStore`, `useStore`, `createLivestreamOrchestrator`,
+`useLivestreamOrchestrator` — **zero external consumers**.
+`createLivestreamOrchestrator` and `useLivestreamOrchestrator` aren't even
+re-exported by `context/index.ts`, so they're unreachable from the public
+`some-ui-utils` surface at all.
+
+**Verdict: dead code / unreachable — cleanup candidate for a follow-up
+story, not a hoist/de-hoist decision.**
+
+### 6c. `hooks/socket-tenants/orchestrator/*` — websocket-driven orchestrator hooks
+
+| Symbol                | Real consumers                                 | Verdict                 |
+| --------------------- | ---------------------------------------------- | ----------------------- |
+| `useOrchestrator`     | root `.storybook` only                         | de-hoist / tooling-only |
+| `useMockOrchestrator` | `apps/www/src/providers/orchestrator.tsx` only | de-hoist                |
+
+`mock-orchestrator-engine.ts` internals are not re-exported — internal only.
+
+## 7. OBS socket / store
+
+| Symbol                                                                                                                                                                                                                                                                                                                                                                | Real consumers                                                                                       | Verdict                              |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `useObsStatusWebSocket`                                                                                                                                                                                                                                                                                                                                               | 2 workspaces: `packages/ui/input`, `packages/ui/overlays`                                            | **borderline → flag for DEHOIST S5** |
+| All `obs-store` zustand selectors (`useObsCommands`, `useIsConnected`, `useIsRecording`, `useIsStreaming`, `useCurrentProfile`, `useSceneInfo`, `useStreamTimecode`, `useRecordTimecode`, `useReplayBufferActive`, `useVirtualCamActive`, `useStudioModeEnabled`, `useActiveFps`, `useCpuUsage`, `useConnectionInfo`, `useCurrentCollection`, `useCurrentTransition`) | 1 workspace, 1 file: `packages/ui/overlays/src/components/youtube/demo/index.tsx` (a demo component) | **de-hoist**                         |
+
+The socket hook and the raw store selectors are tracked separately —
+averaging them would misstate both.
+
+## 8. Now-playing socket / store
+
+| Symbol                                          | Real consumers                                                                        | Verdict      |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- | ------------ |
+| `useLatestNowPlaying`, `useNowPlayingWebSocket` | 1 workspace: `packages/ui/umag/src/components/now-playing/now-playing-card/index.tsx` | **de-hoist** |
+| `useNowPlayingStore`, `pushNowPlaying`          | 0 external                                                                            | dead code    |
+
+## 9. Discovery (`lib/discovery/*`)
+
+| Symbol                                                       | Real consumers                                                      | Verdict      |
+| ------------------------------------------------------------ | ------------------------------------------------------------------- | ------------ |
+| `HttpFileDiscovery`, `HttpJsonLoader`, `useRecursiveLibrary` | 1 workspace: `packages/ui/slideshow/src/hooks/use-scene-library.ts` | **de-hoist** |
+| `hasErrors`, `formatLibraryError`                            | 0 external                                                          | dead code    |
+
+## 10. Registry (`lib/registry/*`)
+
+| Symbol                                                                                                                  | Real consumers                                                                                              | Verdict                                               |
+| ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `preloadRegistryComponents`, `hasRegistryKey`, `lazyWithPreload`, `renderRegistryComponent`, `ComponentEnhancer` (type) | 3 workspaces (1 call site each): `packages/ui/slideshow`, `packages/some-content`, `packages/ui/wireframes` | **hoist** (thin usage, but 3 genuinely distinct apps) |
+
+## 11. Region-rect-store
+
+| Symbol               | Real consumers                                                                       | Verdict      |
+| -------------------- | ------------------------------------------------------------------------------------ | ------------ |
+| `useRegionRectStore` | 1 workspace: `packages/ui/wireframes/src/components/layout-rect-publisher/index.tsx` | **de-hoist** |
+| `useRegionRect`      | 0 external                                                                           | dead code    |
+
+## 12. Event-bus
+
+| Symbol           | Real consumers                                                                                                                                       | Verdict                              |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `createEventBus` | 2 workspaces: `packages/ui/slideshow` (`use-rotating-cube.ts`), `packages/ui/input` (`use-create-crossword-puzzle.ts`, `use-viewport-rotation-wasm`) | **borderline → flag for DEHOIST S5** |
+
+`event-bus.ts` also defines `notificationEvents`, `cartEvents`,
+`taskManager`, `useSubscribeToNotificationEvents`,
+`useHighPriorityTasksFor` — demo/example fixtures, `export *`'d from
+`context/index.ts` but **not** included in the curated re-export list
+`lib/index.ts` takes from `"./context"`, so they are unreachable via
+`import ... from "some-ui-utils"`. (`packages/ui/input`'s own
+`notificationEvents` local const is an unrelated same-named local variable,
+not an import of this fixture — confirmed by reading the call site.)
+
+**Verdict on the fixtures: dead / unreachable — cleanup candidate.**
+
+## 13. String-query-state
+
+| Symbol                                            | Real consumers                                 | Verdict      |
+| ------------------------------------------------- | ---------------------------------------------- | ------------ |
+| `useStringQueryState`, `QueryStateOptions` (type) | 1 workspace: `packages/ui/searchbar` (6 files) | **de-hoist** |
+
+## 14. `use-prompt-utterance`
+
+| Symbol                  | Real consumers                                                      | Verdict      |
+| ----------------------- | ------------------------------------------------------------------- | ------------ |
+| `useUtteranceWebSocket` | 1 workspace: `packages/ui/umag/src/components/prompt-dox/index.tsx` | **de-hoist** |
+
+## 15. `some-ui-shared` non-component exports
+
+| Symbol                        | Real consumers                                                                                                                                                                                                                                                                                             | Verdict                                                                                                                                                                                                                                               |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useToast` (`hooks/index.ts`) | 2 workspaces: `apps/www`, `packages/ui/wireframes`                                                                                                                                                                                                                                                         | **borderline → flag for DEHOIST S5**                                                                                                                                                                                                                  |
+| `cn` (`lib/utils.ts`)         | **Not part of the public barrel.** `src/index.ts` only re-exports `./components` and `./hooks` — `lib/utils.ts` is never re-exported. All internal `some-ui-shared` usages go through the `@shared/lib/utils` path alias, not the package barrel. Zero external files import `cn` from `"some-ui-shared"`. | **no external consumers** — and confirmed to be an independent implementation from `some-ui-utils`'s `cn`, not a re-export or duplicate call path. This resolves the ambiguity in the epic's first-pass table: only `some-ui-utils`'s `cn` is public. |
+
+## Declared-but-unused dependencies
+
+Cross-checking `package.json` deps against actual imports found workspaces
+that declare a dependency but never import a named symbol — pure
+package.json noise, independent of any hoist/de-hoist decision:
+
+| Workspace                     | Declares `some-ui-utils` | Declares `some-ui-shared` | Actual imports                                                                |
+| ----------------------------- | ------------------------ | ------------------------- | ----------------------------------------------------------------------------- |
+| `packages/ui/portfolio-chart` | yes                      | yes                       | none                                                                          |
+| `packages/ui/vidya`           | yes                      | yes                       | none                                                                          |
+| `packages/mdx-generator`      | yes                      | no                        | none                                                                          |
+| `packages/ui/honeycomb`       | yes                      | yes                       | `some-ui-shared` only (real component consumer); zero `some-ui-utils` imports |
+
+No `extensions/*` workspace declares or imports either package — fully out
+of scope for this census.
+
+## Summary
+
+| Concern                                                                                           | Real consumers (excl. utils/shared)                                        | Verdict                                                                  |
+| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `cn` (utils)                                                                                      | 18 workspaces                                                              | hoist                                                                    |
+| string/date/array-utils                                                                           | de-hoist / **borderline** / **borderline** / de-hoist (per-symbol, see §1) | mixed — see §1                                                           |
+| generic hooks: `useLocalStorage`, `useMeasureRect`                                                | 4 workspaces each                                                          | hoist                                                                    |
+| generic hooks: `useContainerRect`, `useEventListener`, `useIsomorphicLayoutEffect`, `useIsMobile` | 1 workspace each                                                           | de-hoist                                                                 |
+| generic hooks: `useResizeObserver`, `useIsMounted`                                                | 0 (internal substrate)                                                     | no external consumers                                                    |
+| generic hooks: `useFetch`, `useInterval`                                                          | 0 (unused anywhere)                                                        | dead code                                                                |
+| websocket engine                                                                                  | 0 (pure substrate for socket-tenants hooks)                                | no external consumers                                                    |
+| speech/tts/audio                                                                                  | 4 workspaces (chat, stepper, umag, www)                                    | hoist (leaf hooks `useAudioSpeech`/`useTTSFetch`/queue-metrics are dead) |
+| viewport/polyhedron                                                                               | 1 workspace (`useViewport`)                                                | de-hoist (`useCycleRotationAdapter` dead)                                |
+| orchestrator — real (`orchestrator-store.ts`)                                                     | 4 workspaces                                                               | hoist (`usePrimaryScene` **borderline**)                                 |
+| orchestrator — generic ("ochestra") substrate                                                     | 0                                                                          | dead code / unreachable                                                  |
+| orchestrator — socket-tenants hooks                                                               | 1 workspace each                                                           | de-hoist                                                                 |
+| obs store selectors                                                                               | 1 workspace (demo only)                                                    | de-hoist                                                                 |
+| obs socket hook                                                                                   | 2 workspaces                                                               | **borderline**                                                           |
+| now-playing socket/store                                                                          | 1 workspace                                                                | de-hoist                                                                 |
+| discovery                                                                                         | 1 workspace                                                                | de-hoist                                                                 |
+| registry                                                                                          | 3 workspaces                                                               | hoist                                                                    |
+| region-rect-store                                                                                 | 1 workspace                                                                | de-hoist                                                                 |
+| event-bus (`createEventBus`)                                                                      | 2 workspaces                                                               | **borderline** (demo fixtures dead/unreachable)                          |
+| string-query-state                                                                                | 1 workspace                                                                | de-hoist                                                                 |
+| use-prompt-utterance                                                                              | 1 workspace                                                                | de-hoist                                                                 |
+| shared `useToast`                                                                                 | 2 workspaces                                                               | **borderline**                                                           |
+| shared `cn`                                                                                       | 0 (never publicly exported)                                                | no external consumers                                                    |
+
+**Borderline (exactly-2-consumer) clusters flagged for DEHOIST S5
+adjudication:** `formatRelativeTime`, `getRandomSubarray`, `useAudioTTS`,
+`usePrimaryScene`, `useObsStatusWebSocket`, `createEventBus`, `useToast`.
+
+## Non-goals
+
+This document is evidence only. It scores no proposed hoist against the
+Doctrine §3 matrix (that's DEHOIST S5's job) and moves no code.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
       "@chat/*": ["./packages/ui/chat/src/"],
       "@calendar/*": ["./packages/ui/calendar/src/"],
       "@input/*": ["./packages/ui/input/src/"],
-      "@utils/*": ["./packages/ui/utils/src/"],
+      "@utils/*": ["./packages/utils/src/"],
       "@searchbar/*": ["./packages/ui/searchbar/src/"],
       "@slideshow/*": ["./packages/ui/slideshow/src/"],
       "@makjang/*": ["./packages/ui/makjang/src/"],


### PR DESCRIPTION
## Description

Lands the two remaining stories of the UTL-FOUND epic (#523), following S1's doctrine doc (#520, already merged):

- **S2 — Concern taxonomy + named-import consumer census** (`packages/UTILS_CENSUS.md`): every `some-ui-utils`/`some-ui-shared` non-component export enumerated with its real named-import consumers (grepped by symbol, not `package.json` deps), grouped into the epic's concern clusters. Corrects the first-pass census's biggest error — the "orchestrator" cluster conflated two unrelated implementations, one of them dead/unreachable — and flags every exactly-2-consumer cluster (`formatRelativeTime`, `getRandomSubarray`, `useAudioTTS`, `usePrimaryScene`, `useObsStatusWebSocket`, `createEventBus`, `useToast`) for DEHOIST S5 adjudication.
- **S3 — Workspace-scaffold convention** (`packages/README.md`): documents the canonical leaf-workspace shape (package.json, tsconfig, vite-config, barrel, turbo, and the three registration points that don't auto-discover a new package) referencing `packages/utils` and `packages/ui/shared` as the reference implementations. Also bolsters `crates/pkg_cloner` per the "too happy path" note on #522 — it now requires a `package.json` to treat a directory as a template candidate (previously any dir, including `.turbo`, counted), and wires the previously-dead `similarity_threshold`/`find_closest_match` Levenshtein check into the new-package-name prompt so a near-duplicate name is flagged instead of silently accepted. Fixed a stale `@utils/*` tsconfig path alias found while documenting the path-alias registration step.

Zero production code moves in either story, per both stories' acceptance criteria.

Closes #521
Closes #522
Closes #523

## Type of Change

- [x] This change requires a documentation update
- [x] Bug fix (non-breaking change which fixes an issue) — `pkg_cloner` robustness fixes, stale tsconfig path alias

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (new `pkg_cloner` unit test for the `package.json`-presence filter)
- [x] New and existing unit tests pass locally with my changes (`cargo test` in `crates/pkg_cloner`)

## Screenshots

N/A — documentation and a Rust CLI tool, no UI surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_0159QGqat6eP1XFzFvFspncx)_