### PR TITLE
Fix Vite config and Docker build for HTTPS and Rust toolchain

### DIFF
--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------
 # Stage 0: Base
 # ------------------------------------------------------------
-FROM node:24-alpine AS base
+FROM mirror.gcr.io/library/node:24-alpine AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="${PNPM_HOME}:${PATH}"
@@ -50,9 +50,24 @@ RUN apk add --no-cache \
         curl \
         build-base \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y
+        | sh -s -- -y --default-toolchain stable
 
+#
+# Turborepo's default (strict) env mode strips RUSTUP_HOME/CARGO_HOME from
+# task subprocesses, which breaks rustup's cargo/rustc proxy shims ("rustup
+# could not choose a version of cargo to run"). Point PATH at the real
+# toolchain bin directory instead of the proxies so the build doesn't
+# depend on those env vars surviving into turbo's task processes.
+#
 ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="/root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin:${PATH}"
+
+#
+# Pre-install the wasm target so turbo's parallel per-crate wasm-pack
+# tasks don't race each other downloading it into the same rustup cache
+# (concurrent downloads corrupt the partial-file rename).
+#
+RUN rustup target add wasm32-unknown-unknown
 
 RUN cargo install wasm-pack
 
@@ -68,15 +83,31 @@ COPY --from=deps /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml 
 COPY --from=pruner /app/out/full/ .
 
 #
-# Build only the www application (and everything it depends on)
+# turbo prune only tracks the JS workspace, so it drops the Rust workspace
+# root manifest and any crates not reachable from www's JS dependency
+# graph. cargo needs every member listed in Cargo.toml's [workspace] to
+# exist on disk, so restore the whole crates/ tree from the original
+# build context alongside the root manifest.
+#
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
+
+#
+# Build only the www application (and everything it depends on).
+#
+# --concurrency=1: the wasm crates' `wasm-pack build` steps race each
+# other over shared cargo/rustup state (the rust-std target download,
+# wasm-pack's shared wasm-bindgen-cli cache install dir) when turbo runs
+# them in parallel, corrupting partial downloads/installs. Building
+# serially avoids that whole class of races.
 #
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm turbo build --filter=www...
+    pnpm turbo build --filter=www... --concurrency=1
 
 # ------------------------------------------------------------
 # Stage 4: Runtime
 # ------------------------------------------------------------
-FROM nginx:alpine AS runtime
+FROM mirror.gcr.io/library/nginx:alpine AS runtime
 
 RUN <<'EOF' > /etc/nginx/conf.d/default.conf
 server {

--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------
 # Stage 0: Base
 # ------------------------------------------------------------
-FROM mirror.gcr.io/library/node:24-alpine AS base
+FROM node:24-alpine AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="${PNPM_HOME}:${PATH}"
@@ -74,8 +74,7 @@ RUN cargo install wasm-pack
 #
 # Restore installed dependencies
 #
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+COPY --from=deps /app .
 
 #
 # Copy the complete pruned workspace

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "start": "vite --port 5173",
-    "build:dev": "vite build && tsc",
+    "build": "vite build && tsc",
     "build:analyze": "node scripts/analyze-bundle.js",
     "analyze": "pnpm run build:analyze && open dist/bundle-analysis.html",
     "analyze:ci": "pnpm run build:analyze",

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -2,118 +2,132 @@ import fs from "node:fs"
 import { resolve } from "node:path"
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite"
 import viteReact from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig, type UserConfig } from "vite"
 import tsconfigPaths from "vite-tsconfig-paths"
 
+const certPath = resolve(__dirname, "../../certs/nixos.local+3.pem")
+const keyPath = resolve(__dirname, "../../certs/nixos.local+3-key.pem")
+const hasLocalCerts = fs.existsSync(certPath) && fs.existsSync(keyPath)
+
 // https://vitejs.dev/config/
-export default defineConfig({
-  server: {
-    host: "0.0.0.0",
-    allowedHosts: ["nixos.local"],
-    port: 5173,
-    strictPort: true,
-    https: {
-      cert: fs.readFileSync("../../certs/nixos.local+3.pem"),
-      key: fs.readFileSync("../../certs/nixos.local+3-key.pem"),
+export default defineConfig(
+  ({ command }): UserConfig => ({
+    server: {
+      host: "0.0.0.0",
+      allowedHosts: ["nixos.local"],
+      port: 5173,
+      strictPort: true,
+      // Local mkcert certs are machine-local (gitignored) and only relevant to
+      // `vite dev`/`vite preview` - `vite build` never starts a server, and
+      // CI/Docker builds don't have these certs, so only wire this up when
+      // both apply.
+      ...(command === "serve" && hasLocalCerts
+        ? {
+            https: {
+              cert: fs.readFileSync(certPath),
+              key: fs.readFileSync(keyPath),
+            },
+          }
+        : {}),
     },
-  },
-  plugins: [
-    TanStackRouterVite({ autoCodeSplitting: true }),
-    viteReact(),
-    tsconfigPaths({
-      projects: [
-        "./tsconfig.json",
-        "../../packages/some-content/tsconfig.json",
-      ],
-    }),
-  ],
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "./src"),
-      "@content": resolve(__dirname, "../../packages/some-content/src"),
+    plugins: [
+      TanStackRouterVite({ autoCodeSplitting: true }),
+      viteReact(),
+      tsconfigPaths({
+        projects: [
+          "./tsconfig.json",
+          "../../packages/some-content/tsconfig.json",
+        ],
+      }),
+    ],
+    resolve: {
+      alias: {
+        "@": resolve(__dirname, "./src"),
+        "@content": resolve(__dirname, "../../packages/some-content/src"),
+      },
     },
-  },
-  build: {
-    // Enable rollup bundle analysis
-    rollupOptions: {
-      output: {
-        // Manual chunk splitting for better analysis
-        manualChunks: {
-          // Separate your authored dependencies
-          "authored-deps": ["some-ui-input"], // Add your package names here, e.g., ['@myorg/package1', '@myorg/package2']
-          // Common vendor chunks
-          "react-vendor": ["react", "react-dom"],
-          "router-vendor": ["@tanstack/react-router"],
-          "utils-vendor": ["lodash", "date-fns"], // Add your utility deps
+    build: {
+      // Enable rollup bundle analysis
+      rollupOptions: {
+        output: {
+          // Manual chunk splitting for better analysis
+          manualChunks: {
+            // Separate your authored dependencies
+            "authored-deps": ["some-ui-input"], // Add your package names here, e.g., ['@myorg/package1', '@myorg/package2']
+            // Common vendor chunks
+            "react-vendor": ["react", "react-dom"],
+            "router-vendor": ["@tanstack/react-router"],
+            "utils-vendor": ["lodash", "date-fns"], // Add your utility deps
+          },
+        },
+        // Tree shaking options
+        treeshake: {
+          // Enable aggressive tree shaking
+          moduleSideEffects: false,
+          // Custom tree shaking for your authored packages
+          propertyReadSideEffects: false,
+          tryCatchDeoptimization: false,
+          // Enable pure annotation checking
+          annotations: true,
+        },
+        // External dependencies (won't be bundled)
+        external: (id): boolean => {
+          // Don't externalize your authored packages - we want to analyze them
+          if (id.startsWith("some")) return false
+          // You can add other conditions here
+          return false
         },
       },
-      // Tree shaking options
-      treeshake: {
-        // Enable aggressive tree shaking
-        moduleSideEffects: false,
-        // Custom tree shaking for your authored packages
-        propertyReadSideEffects: false,
-        tryCatchDeoptimization: false,
-        // Enable pure annotation checking
-        annotations: true,
+      // Generate source maps for better analysis
+      sourcemap: true,
+      // Minification settings that preserve tree shaking info
+      minify: "terser",
+      terserOptions: {
+        compress: {
+          // Keep function names for better analysis
+          keep_fnames: true,
+          // Drop console statements in production
+          drop_console: true,
+          // Remove dead code
+          dead_code: true,
+          // Remove unused variables
+          unused: true,
+        },
+        mangle: {
+          // Keep function names for analysis
+          keep_fnames: true,
+        },
       },
-      // External dependencies (won't be bundled)
-      external: (id) => {
-        // Don't externalize your authored packages - we want to analyze them
-        if (id.startsWith("some")) return false
-        // You can add other conditions here
-        return false
-      },
+      // Chunk size warnings
+      chunkSizeWarningLimit: 1000,
+      // Generate detailed build report
+      reportCompressedSize: true,
     },
-    // Generate source maps for better analysis
-    sourcemap: true,
-    // Minification settings that preserve tree shaking info
-    minify: "terser",
-    terserOptions: {
-      compress: {
-        // Keep function names for better analysis
-        keep_fnames: true,
-        // Drop console statements in production
-        drop_console: true,
-        // Remove dead code
-        dead_code: true,
-        // Remove unused variables
-        unused: true,
-      },
-      mangle: {
-        // Keep function names for analysis
-        keep_fnames: true,
-      },
+    // Dependency optimization
+    optimizeDeps: {
+      // Include your authored dependencies for analysis
+      include: [
+        // Add your authored package names here
+        // '@yourorg/package1',
+        // '@yourorg/package2',
+      ],
+      // Exclude packages you want to analyze tree shaking for
+      exclude: [],
     },
-    // Chunk size warnings
-    chunkSizeWarningLimit: 1000,
-    // Generate detailed build report
-    reportCompressedSize: true,
-  },
-  // Dependency optimization
-  optimizeDeps: {
-    // Include your authored dependencies for analysis
-    include: [
-      // Add your authored package names here
-      // '@yourorg/package1',
-      // '@yourorg/package2',
-    ],
-    // Exclude packages you want to analyze tree shaking for
-    exclude: [],
-  },
-  // Define globals for tree shaking analysis
-  define: {
-    // This helps with dead code elimination
-    __DEV__: JSON.stringify(process.env.NODE_ENV !== "production"),
-    // Add feature flags for your packages
-    __FEATURE_A__: JSON.stringify(true),
-    __FEATURE_B__: JSON.stringify(false),
-  },
-  // ESBuild options for tree shaking
-  esbuild: {
-    // Tree shaking of unused imports
-    treeShaking: true,
-    // Keep names for better analysis
-    keepNames: true,
-  },
-})
+    // Define globals for tree shaking analysis
+    define: {
+      // This helps with dead code elimination
+      __DEV__: JSON.stringify(process.env.NODE_ENV !== "production"),
+      // Add feature flags for your packages
+      __FEATURE_A__: JSON.stringify(true),
+      __FEATURE_B__: JSON.stringify(false),
+    },
+    // ESBuild options for tree shaking
+    esbuild: {
+      // Tree shaking of unused imports
+      treeShaking: true,
+      // Keep names for better analysis
+      keepNames: true,
+    },
+  })
+)


### PR DESCRIPTION
## Description

This PR addresses several issues with the development and build setup:

1. **Vite HTTPS Configuration**: Refactored `vite.config.ts` to conditionally enable HTTPS only during `vite dev`/`vite preview` commands when local mkcert certificates are available. This prevents build failures in CI/Docker environments where these machine-local certificates don't exist.

2. **Docker Build Improvements**: 
   - Added explicit Rust stable toolchain installation and PATH configuration to work around Turborepo's strict environment variable stripping
   - Pre-install wasm32 target to prevent race conditions when parallel wasm-pack tasks download it concurrently
   - Restore full Cargo workspace (root manifest and all crates) since `turbo prune` only tracks the JS dependency graph
   - Set `--concurrency=1` for the build step to serialize wasm-pack builds and avoid corrupting shared cargo/rustup state during parallel execution

3. **Package.json**: Renamed `build:dev` script to `build` for consistency with standard npm conventions.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Test Plan

The Vite config changes are backward compatible—HTTPS is only enabled when certificates exist and during dev/preview commands. Docker builds should now succeed in CI environments without local certificates. The Rust toolchain changes ensure wasm-pack builds complete without race conditions or environment variable issues.

https://claude.ai/code/session_018nnN9Xj7Z911wtDWYfLdcN