### PR TITLE
test(portfolio-chart): regression tests for Black-Scholes P/L + fix mislabeled put spreads

### DIFF
--- a/packages/ui/portfolio-chart/src/lib/archetypeDetector.test.ts
+++ b/packages/ui/portfolio-chart/src/lib/archetypeDetector.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest"
+
+import type { Leg } from "../types"
+import { detectArchetype } from "./archetypeDetector"
+
+let nextId = 0
+function leg(overrides: Partial<Leg>): Leg {
+  nextId += 1
+  return {
+    id: `leg-${nextId}`,
+    optionType: "call",
+    side: "long",
+    strike: 100,
+    expiry: "2025-01-17",
+    quantity: 1,
+    premium: 1,
+    iv: 0.3,
+    ...overrides,
+  }
+}
+
+describe("detectArchetype — degenerate input", () => {
+  it("returns 'custom' for an empty position", () => {
+    expect(detectArchetype([])).toBe("custom")
+  })
+})
+
+describe("detectArchetype — single leg", () => {
+  it("classifies a lone long call", () => {
+    expect(detectArchetype([leg({ optionType: "call", side: "long" })])).toBe(
+      "long call"
+    )
+  })
+
+  it("classifies a lone short call", () => {
+    expect(detectArchetype([leg({ optionType: "call", side: "short" })])).toBe(
+      "short call"
+    )
+  })
+
+  it("classifies a lone long put", () => {
+    expect(detectArchetype([leg({ optionType: "put", side: "long" })])).toBe(
+      "long put"
+    )
+  })
+
+  it("classifies a lone short put", () => {
+    expect(detectArchetype([leg({ optionType: "put", side: "short" })])).toBe(
+      "short put"
+    )
+  })
+})
+
+describe("detectArchetype — two-leg straddle/strangle", () => {
+  it("classifies same-strike call+put as a straddle, keyed by side", () => {
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 100, side: "long" }),
+        leg({ optionType: "put", strike: 100, side: "long" }),
+      ])
+    ).toBe("long straddle")
+
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 100, side: "short" }),
+        leg({ optionType: "put", strike: 100, side: "short" }),
+      ])
+    ).toBe("short straddle")
+  })
+
+  it("classifies call-strike-above-put-strike as a strangle, keyed by side", () => {
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 110, side: "long" }),
+        leg({ optionType: "put", strike: 90, side: "long" }),
+      ])
+    ).toBe("long strangle")
+
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 110, side: "short" }),
+        leg({ optionType: "put", strike: 90, side: "short" }),
+      ])
+    ).toBe("short strangle")
+  })
+})
+
+describe("detectArchetype — two-leg verticals", () => {
+  it("classifies call verticals by which strike is long vs short", () => {
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 95, side: "long" }),
+        leg({ optionType: "call", strike: 105, side: "short" }),
+      ])
+    ).toBe("bull call spread")
+
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 95, side: "short" }),
+        leg({ optionType: "call", strike: 105, side: "long" }),
+      ])
+    ).toBe("bear call spread")
+  })
+
+  it("classifies put verticals by which strike is long vs short", () => {
+    expect(
+      detectArchetype([
+        leg({ optionType: "put", strike: 95, side: "short" }),
+        leg({ optionType: "put", strike: 105, side: "long" }),
+      ])
+    ).toBe("bear put spread")
+
+    expect(
+      detectArchetype([
+        leg({ optionType: "put", strike: 95, side: "long" }),
+        leg({ optionType: "put", strike: 105, side: "short" }),
+      ])
+    ).toBe("bull put spread")
+  })
+
+  it("falls back to 'custom' when the two legs have different expiries", () => {
+    expect(
+      detectArchetype([
+        leg({
+          optionType: "call",
+          strike: 95,
+          side: "long",
+          expiry: "2025-01-17",
+        }),
+        leg({
+          optionType: "call",
+          strike: 105,
+          side: "short",
+          expiry: "2025-02-21",
+        }),
+      ])
+    ).toBe("custom")
+  })
+})
+
+describe("detectArchetype — three-leg butterfly", () => {
+  it("classifies an equidistant long/short/long same-type triple as a long butterfly", () => {
+    expect(
+      detectArchetype([
+        leg({ strike: 90, side: "long" }),
+        leg({ strike: 100, side: "short" }),
+        leg({ strike: 110, side: "long" }),
+      ])
+    ).toBe("long butterfly")
+  })
+
+  it("falls back to 'custom' when the wings aren't equidistant from the body", () => {
+    expect(
+      detectArchetype([
+        leg({ strike: 90, side: "long" }),
+        leg({ strike: 103, side: "short" }),
+        leg({ strike: 110, side: "long" }),
+      ])
+    ).toBe("custom")
+  })
+})
+
+describe("detectArchetype — four-leg iron condor/butterfly", () => {
+  it("classifies distinct short strikes as an iron condor", () => {
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 110, side: "short" }),
+        leg({ optionType: "call", strike: 120, side: "long" }),
+        leg({ optionType: "put", strike: 90, side: "long" }),
+        leg({ optionType: "put", strike: 100, side: "short" }),
+      ])
+    ).toBe("iron condor")
+  })
+
+  it("classifies coincident short strikes as an iron butterfly", () => {
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 100, side: "short" }),
+        leg({ optionType: "call", strike: 110, side: "long" }),
+        leg({ optionType: "put", strike: 90, side: "long" }),
+        leg({ optionType: "put", strike: 100, side: "short" }),
+      ])
+    ).toBe("iron butterfly")
+  })
+
+  it("falls back to 'custom' when call/put counts aren't balanced 2-and-2", () => {
+    expect(
+      detectArchetype([
+        leg({ optionType: "call", strike: 90, side: "long" }),
+        leg({ optionType: "call", strike: 100, side: "short" }),
+        leg({ optionType: "call", strike: 110, side: "long" }),
+        leg({ optionType: "put", strike: 100, side: "short" }),
+      ])
+    ).toBe("custom")
+  })
+})
+
+describe("detectArchetype — beyond four legs", () => {
+  it("falls back to 'custom' for a five-leg position", () => {
+    const legs = Array.from({ length: 5 }, (_, i) =>
+      leg({ strike: 90 + i * 5, side: i % 2 === 0 ? "long" : "short" })
+    )
+    expect(detectArchetype(legs)).toBe("custom")
+  })
+})

--- a/packages/ui/portfolio-chart/src/lib/archetypeDetector.ts
+++ b/packages/ui/portfolio-chart/src/lib/archetypeDetector.ts
@@ -69,8 +69,8 @@ export function detectArchetype(legs: Array<Leg>): SpreadArchetype {
     if (p.length === 2 && sameExp) {
       const [lo, hi] = [...p].sort((a, b) => a.strike - b.strike)
       if (lo && hi) {
-        if (lo.side === "long" && hi.side === "short") return "bear put spread"
-        if (lo.side === "short" && hi.side === "long") return "bull put spread"
+        if (lo.side === "long" && hi.side === "short") return "bull put spread"
+        if (lo.side === "short" && hi.side === "long") return "bear put spread"
       }
     }
   }

--- a/packages/ui/portfolio-chart/src/lib/blackScholes.test.ts
+++ b/packages/ui/portfolio-chart/src/lib/blackScholes.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest"
+
+import type { Leg, PLPoint } from "../types"
+import {
+  bsPrice,
+  buildPLCurve,
+  computeNetGreeks,
+  computePLMetrics,
+  legPLAtSpot,
+  positionPLAtSpot,
+} from "./blackScholes"
+
+function leg(overrides: Partial<Leg> = {}): Leg {
+  return {
+    id: "leg-1",
+    optionType: "call",
+    side: "long",
+    strike: 100,
+    expiry: "2025-01-17",
+    quantity: 1,
+    premium: 5,
+    iv: 0.3,
+    ...overrides,
+  }
+}
+
+describe("bsPrice", () => {
+  it("returns an all-zero result for non-positive spot/strike/iv (degenerate guard)", () => {
+    const zero = { price: 0, delta: 0, gamma: 0, theta: 0, vega: 0 }
+    expect(bsPrice(0, 100, 30, 0.3, "call")).toEqual(zero)
+    expect(bsPrice(100, 0, 30, 0.3, "call")).toEqual(zero)
+    expect(bsPrice(100, 100, 30, 0, "call")).toEqual(zero)
+  })
+
+  it("honors put-call parity: C - P = S - K*e^(-rT)", () => {
+    const spot = 100
+    const strike = 95
+    const dte = 45
+    const iv = 0.35
+    const r = 0.05
+    const call = bsPrice(spot, strike, dte, iv, "call", r)
+    const put = bsPrice(spot, strike, dte, iv, "put", r)
+    const T = dte / 365
+    const expected = spot - strike * Math.exp(-r * T)
+    expect(call.price - put.price).toBeCloseTo(expected, 6)
+  })
+
+  it("keeps call delta within [0, 1] and put delta within [-1, 0]", () => {
+    const call = bsPrice(100, 100, 30, 0.4, "call")
+    const put = bsPrice(100, 100, 30, 0.4, "put")
+    expect(call.delta).toBeGreaterThanOrEqual(0)
+    expect(call.delta).toBeLessThanOrEqual(1)
+    expect(put.delta).toBeGreaterThanOrEqual(-1)
+    expect(put.delta).toBeLessThanOrEqual(0)
+  })
+
+  it("pushes deep-ITM call delta toward 1 and deep-OTM call delta toward 0", () => {
+    const deepItm = bsPrice(1000, 100, 30, 0.2, "call")
+    const deepOtm = bsPrice(10, 1000, 30, 0.2, "call")
+    expect(deepItm.delta).toBeGreaterThan(0.95)
+    expect(deepOtm.delta).toBeLessThan(0.05)
+  })
+})
+
+describe("legPLAtSpot", () => {
+  it("negates a short leg's P/L relative to the same long leg", () => {
+    const spot = 100
+    const dte = 30
+    const ivShift = 0
+    const longPl = legPLAtSpot(leg({ side: "long" }), spot, dte, ivShift)
+    const shortPl = legPLAtSpot(leg({ side: "short" }), spot, dte, ivShift)
+    expect(shortPl).toBeCloseTo(-longPl, 6)
+  })
+
+  it("scales P/L linearly with quantity", () => {
+    const single = legPLAtSpot(leg({ quantity: 1 }), 110, 30, 0)
+    const tripled = legPLAtSpot(leg({ quantity: 3 }), 110, 30, 0)
+    expect(tripled).toBeCloseTo(single * 3, 6)
+  })
+})
+
+describe("positionPLAtSpot", () => {
+  it("sums each leg's independent P/L", () => {
+    const legs = [
+      leg({ id: "a", side: "long", strike: 95 }),
+      leg({ id: "b", side: "short", strike: 105 }),
+    ]
+    const spot = 100
+    const dte = 30
+    const ivShift = 0
+    const expected =
+      legPLAtSpot(legs[0]!, spot, dte, ivShift) +
+      legPLAtSpot(legs[1]!, spot, dte, ivShift)
+    expect(positionPLAtSpot(legs, spot, dte, ivShift)).toBeCloseTo(expected, 6)
+  })
+
+  it("returns 0 for an empty position", () => {
+    expect(positionPLAtSpot([], 100, 30, 0)).toBe(0)
+  })
+})
+
+describe("buildPLCurve", () => {
+  it("spans [0.7x, 1.3x] of the center spot across the requested point count", () => {
+    const curve = buildPLCurve([leg()], 100, 30, 0, 10)
+    expect(curve).toHaveLength(10)
+    expect(curve[0]!.spot).toBeCloseTo(70, 6)
+    expect(curve[curve.length - 1]!.spot).toBeCloseTo(130, 6)
+  })
+})
+
+describe("computeNetGreeks", () => {
+  it("nets an equal long/short pair to zero rather than doubling it", () => {
+    const legs = [
+      leg({ id: "a", side: "long", optionType: "call" }),
+      leg({ id: "b", side: "short", optionType: "call" }),
+    ]
+    const greeks = computeNetGreeks(legs, 100, 30, 0)
+    expect(greeks.delta).toBeCloseTo(0, 6)
+    expect(greeks.gamma).toBeCloseTo(0, 6)
+    expect(greeks.vega).toBeCloseTo(0, 6)
+  })
+})
+
+describe("computePLMetrics", () => {
+  it("returns an all-zero result for an empty position or curve", () => {
+    expect(computePLMetrics([], 100, [], 30, 0)).toEqual({
+      plAtSpot: 0,
+      maxProfit: 0,
+      maxLoss: 0,
+      probProfit: 0,
+      breakevens: [],
+    })
+  })
+
+  it("interpolates breakevens where the curve crosses zero, from a synthetic curve", () => {
+    const curve: Array<PLPoint> = [
+      { spot: 90, pl: -10 },
+      { spot: 100, pl: 10 },
+      { spot: 110, pl: 10 },
+      { spot: 120, pl: -20 },
+    ]
+    const metrics = computePLMetrics(curve, 100, [leg()], 30, 0)
+    expect(metrics.breakevens).toHaveLength(2)
+    expect(metrics.breakevens[0]).toBeCloseTo(95, 6)
+    expect(metrics.breakevens[1]).toBeCloseTo(113.33, 1)
+    expect(metrics.maxProfit).toBe(10)
+    expect(metrics.maxLoss).toBe(-20)
+    expect(metrics.probProfit).toBeCloseTo(0.5, 6)
+  })
+})


### PR DESCRIPTION
## Description

Borrowing the judgment behind the "test harness" milestone (#15, scoped to `packages/ui/input`) and applying it monorepo-wide: recon'd `./packages` for workspaces that are **already** eslint/tsc debt-free (no `--no-verify` needed), since those are the only ones where new test debt can't silently accumulate lint debt alongside it.

`pnpm turbo run lint` across all of `packages/ui/*` + `packages/utils` + the remaining top-level `packages/*` tooling workspaces: **`@some-ui/portfolio` (`packages/ui/portfolio-chart`) was the only workspace in `packages/ui` that passed clean.** It already has a `test` script wired to vitest, but zero test files.

Its `src/lib` holds real, non-trivial logic a trader-facing UI renders directly:
- `blackScholes.ts` — option pricing, Greeks, and P&L curve math.
- `archetypeDetector.ts` — a 16-way decision table classifying a leg set into a named options strategy (iron condor, bull put spread, etc.) for display.

This is exactly the kind of invariant worth pinning (a silent sign flip changes the P&L a user sees; a silent branch swap mislabels their strategy's risk) as opposed to padding coverage on trivial presentational components — I did not add tests elsewhere in this workspace (components, stories) since there's no comparable invariant at stake there.

**Writing the archetype test caught a real, pre-existing bug**: the two put-vertical-spread branches were swapped — a net-debit, long-higher/short-lower put position (a textbook *bear* put spread) was labeled `"bull put spread"`, and vice versa. This is backwards from both the file's own `ARCHETYPE_DESCRIPTIONS` (credit vs. debit) and the correctly-implemented call-spread branch immediately above it. Fixed alongside the regression suite that now pins the whole decision table so this class of mislabeling can't regress silently.

## Recon notes (no orphaned issues found)

- Checked milestone 14 ("separate utils workspaces"): all 18 open issues target packages (`core-utils`, `react-hooks`, `speech`, `viewport`, `orchestrator`, `wasm-loader`, `ws`) that don't exist in the tree yet — none already landed.
- Checked milestone 15 ("test harness"): S8/S9/S10 (#557–#559) target `packages/ui/input` mathlingo/payload-editor/timeline-editor tests and e2e flows — confirmed still genuinely missing, not orphaned.
- This PR's changes don't correspond to an existing tracked issue, so there's nothing to close here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires no documentation update

## Checklist

- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (`pnpm --filter @some-ui/portfolio test`)
- [x] `pnpm --filter @some-ui/portfolio lint` (eslint + prettier + tsc) passes clean — no `--no-verify` used, touched files are debt-free


---
_Generated by [Claude Code](https://claude.ai/code/session_01YbZdbeTubRQprMmxBkKHEQ)_