### PR TITLE
[XPORT] S2: Bootstrap — document-lifetime static install

### DIFF
--- a/extensions/transport/README.md
+++ b/extensions/transport/README.md
@@ -25,8 +25,9 @@ conformance suite with **no business logic** — only a null adapter.
 ```
 src/
   contracts/    Token, Hypothesis, Invariant, Adapter, Action — types only
+  bootstrap/    document-lifetime static install + sentinel (Def D.2, Thm D.1)
 ```
 
-Everything else (`bootstrap/`, `session/`, `sensor/`, `estimator/`,
-`adapter/`, `scheduler/`, `actuator/`, `lifecycle/`) lands story-by-story;
-see the epic for sequencing.
+Everything else (`session/`, `sensor/`, `estimator/`, `adapter/`,
+`scheduler/`, `actuator/`, `lifecycle/`) lands story-by-story; see the epic
+for sequencing.

--- a/extensions/transport/eslint.config.js
+++ b/extensions/transport/eslint.config.js
@@ -33,6 +33,35 @@ const transportConfig = [
       ],
     },
   },
+  {
+    // Bootstrap runs before Session, Sensor, Estimator, Adapter, Scheduler,
+    // Actuator, or Lifecycle exist (Definition D.2) — none of hat(H), Phi,
+    // or Delta have been constructed yet, so none of those stages can be a
+    // dependency of bootstrap/ without contradicting the definition itself.
+    files: ["src/bootstrap/**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/session/*",
+                "**/sensor/*",
+                "**/estimator/*",
+                "**/adapter/*",
+                "**/scheduler/*",
+                "**/actuator/*",
+                "**/lifecycle/*",
+              ],
+              message:
+                "bootstrap/ runs before any other transport stage exists and must not import one (canon Definition D.2).",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]
 
 export default transportConfig

--- a/extensions/transport/src/bootstrap/static.test.ts
+++ b/extensions/transport/src/bootstrap/static.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { install, installedAt, isInstalled } from "./static"
+
+function freshRoot(): Element {
+  return document.implementation.createHTMLDocument("").documentElement
+}
+
+describe("bootstrap/static", () => {
+  it("is not installed until install() runs", () => {
+    const root = freshRoot()
+    expect(isInstalled(root)).toBe(false)
+    expect(installedAt(root)).toBeUndefined()
+  })
+
+  it("installs a sentinel carrying the installation epoch", () => {
+    const root = freshRoot()
+    const now = 1_720_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    const layer = install(root)
+
+    expect(isInstalled(root)).toBe(true)
+    expect(layer.root).toBe(root)
+    expect(layer.installedAt).toBe(now)
+    expect(installedAt(root)).toBe(now)
+
+    vi.restoreAllMocks()
+  })
+
+  it("is idempotent: a second install() within the same L_D is a no-op", () => {
+    const root = freshRoot()
+    vi.spyOn(Date, "now").mockReturnValueOnce(1).mockReturnValueOnce(2)
+
+    const first = install(root)
+    const second = install(root)
+
+    expect(second.installedAt).toBe(first.installedAt)
+    expect(second.root).toBe(first.root)
+
+    vi.restoreAllMocks()
+  })
+
+  it("survives arbitrary DOM mutation of everything except the sentinel", () => {
+    const root = freshRoot()
+    const layer = install(root)
+
+    // Simulate a same-document (SPA) navigation: the router tears down and
+    // rebuilds the entire body subtree, but never touches root's attributes.
+    root.innerHTML = "<body><main>first route</main></body>"
+    root.innerHTML = "<body><main>second route</main></body>"
+    root.removeChild(root.firstElementChild!)
+
+    expect(isInstalled(root)).toBe(true)
+    expect(installedAt(root)).toBe(layer.installedAt)
+  })
+
+  it("treats a fresh document's root as not yet installed (refresh begins a new L_D)", () => {
+    const originalRoot = freshRoot()
+    install(originalRoot)
+
+    const newDocumentRoot = freshRoot()
+
+    expect(isInstalled(newDocumentRoot)).toBe(false)
+    expect(installedAt(newDocumentRoot)).toBeUndefined()
+  })
+
+  it("defaults to document.documentElement when no root is given", () => {
+    expect(isInstalled()).toBe(false)
+
+    const layer = install()
+
+    expect(layer.root).toBe(document.documentElement)
+    expect(isInstalled()).toBe(true)
+
+    document.documentElement.removeAttribute("data-transport-bootstrap")
+  })
+})

--- a/extensions/transport/src/bootstrap/static.ts
+++ b/extensions/transport/src/bootstrap/static.ts
@@ -1,0 +1,48 @@
+/**
+ * Definition D.2 (Bootstrap), Theorem D.1 — canon §D.0.
+ *
+ * Bootstrap owns exactly the mechanism for installing and detecting itself,
+ * scoped to the document lifetime `L_D` rather than the content lifetime
+ * `L_C` (Definition D.1) — nothing about what a pessimistic default *does*,
+ * which is an Adapter's concern (Definition D.3, story S7) once a content
+ * session exists.
+ *
+ * The sentinel lives on `root` (default `document.documentElement`) rather
+ * than in module-scoped memory: a same-document (SPA) navigation leaves
+ * `root` and its attribute untouched, so Bootstrap is not reinstalled
+ * (Theorem D.1(a)); a refresh begins a new `L_D` with a fresh document —
+ * and therefore a fresh `root` with no attribute — so the next `install`
+ * call installs again (Theorem D.1(b)). The attribute's value is the
+ * installation epoch itself, so no separate store is needed to correlate
+ * it with Session's epoch (S3).
+ */
+
+const SENTINEL_ATTR = "data-transport-bootstrap"
+
+export type BootstrapLayer = {
+  readonly root: Element
+  readonly installedAt: number
+}
+
+export function install(
+  root: Element = document.documentElement
+): BootstrapLayer {
+  const existing = root.getAttribute(SENTINEL_ATTR)
+  if (existing !== null) {
+    return { root, installedAt: Number(existing) }
+  }
+  const installedAt = Date.now()
+  root.setAttribute(SENTINEL_ATTR, String(installedAt))
+  return { root, installedAt }
+}
+
+export function isInstalled(root: Element = document.documentElement): boolean {
+  return root.hasAttribute(SENTINEL_ATTR)
+}
+
+export function installedAt(
+  root: Element = document.documentElement
+): number | undefined {
+  const value = root.getAttribute(SENTINEL_ATTR)
+  return value === null ? undefined : Number(value)
+}


### PR DESCRIPTION
## Description

Implements Definition D.2 (Bootstrap) and Theorem D.1 (Bootstrap persistence) from `extensions/docs/dom-state-estimation-canon.typ` §D.0: a document-lifetime (`L_D`) static install mechanism, scoped independently of any content session (`L_C`).

`src/bootstrap/static.ts` adds:

- `install(root?)`: idempotent install of a DOM sentinel on `root` (default `document.documentElement`). The sentinel's attribute value *is* the installation epoch, so no separate store is needed to correlate it with Session's epoch (S3).
- `isInstalled(root?)`: query usable by Lifecycle (S10) to implement Theorem D.1's persistence check.
- `installedAt(root?)`: exposes the recorded epoch.

Because the sentinel lives on the root element rather than in module-scoped memory, a same-document (SPA) navigation — which leaves `root` and its attributes untouched — does not reinstall Bootstrap (Theorem D.1(a)), while a refresh begins a new document with a fresh, sentinel-less root, so the next `install()` call installs again (Theorem D.1(b)).

Per the story's non-goals, no pessimistic per-key masking logic lives here — that's the Business Adapter's job (S7) once a content session exists. `eslint.config.js` gains a rule forbidding `bootstrap/` from importing `session/`, `sensor/`, `estimator/`, `adapter/`, `scheduler/`, `actuator/`, or `lifecycle/`, matching Definition D.2's requirement that Bootstrap runs before any of those exist.

Closes #609
Part of #607

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (README layout)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A — no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_019T4gMqnzTSMX6Aggv3fVtj)_