### PR TITLE
Refactor docker-compose into modular includes with REPO_ROOT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,12 @@
 ENV="development"
+
+# Absolute path to this repo's checkout. docker-compose.yml pulls in
+# infra/compose/*.yml via `include:`, which resolves relative paths against
+# each included file's own directory rather than the repo root — so bind
+# mounts (nginx.conf, certs, apps/www/Dockerfile build context) rely on this
+# being an absolute path, not the "." default in the compose files.
+REPO_ROOT="/absolute/path/to/some-ui"
+
 API_KEY=your_dummy_api_key_here # This can be any string, it's not a real API key for Edge TTS
 PORT=5050
 DEFAULT_VOICE=en-US-AvaNeural # You can change this to any Edge TTS voice
@@ -9,3 +17,8 @@ REQUIRE_API_KEY=False # Set to True if you want to enforce the API_KEY
 REMOVE_FILTER=False
 EXPAND_API=True # Set to True to enable ElevenLabs and Azure API endpoints (beta)
 INSTALL_FFMPEG_ARG=true # Recommended if you want all audio format options
+
+# infra/compose/www.yml (apps/www, served via nginx)
+TAG=latest
+WWW_HTTP_PORT=8080
+WWW_HTTPS_PORT=8443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,6 @@
-services:
-  openai-edge-tts:
-    image: travisvn/openai-edge-tts:latest-ffmpeg
-    container_name: openai-edge-tts
-    # Remove external port mapping - only accessible through nginx
-    expose:
-      - "5050"
-    env_file:
-      - .env
-    environment:
-      API_KEY: ${API_KEY}
-      PORT: 5050
-      REQUIRE_API_KEY: ${REQUIRE_API_KEY:-false}
-      EXPAND_API: ${EXPAND_API:-true}
-      REMOVE_FILTER: ${REMOVE_FILTER:-false}
-      DEFAULT_VOICE: ${DEFAULT_VOICE:-en-US-DavisNeural}
-      DEFAULT_RESPONSE_FORMAT: ${DEFAULT_RESPONSE_FORMAT:-wav}
-      DEFAULT_SPEED: ${DEFAULT_SPEED:-1.0}
-      DEFAULT_LANGUAGE: ${DEFAULT_LANGUAGE:-en-US}
-    restart: unless-stopped
-  nginx:
-    image: nginx:alpine
-    container_name: openai-edge-tts-proxy
-    ports:
-      - "${PORT:-5050}:80" # Expose nginx on your desired port
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-    depends_on:
-      - openai-edge-tts
-    restart: unless-stopped
+x-environment: &root-env
+  REPO_ROOT: ${REPO_ROOT:-.} # default to current directory if not set externally
+include:
+  - path: ./infra/compose/base.yml
+  - path: ./infra/compose/tts.yml
+  - path: ./infra/compose/www.yml

--- a/infra/compose/base.yml
+++ b/infra/compose/base.yml
@@ -1,0 +1,3 @@
+networks:
+  some-ui-network:
+    driver: bridge

--- a/infra/compose/tts.yml
+++ b/infra/compose/tts.yml
@@ -1,0 +1,34 @@
+services:
+  openai-edge-tts:
+    image: travisvn/openai-edge-tts:latest-ffmpeg
+    container_name: openai-edge-tts
+    # Remove external port mapping - only accessible through nginx
+    expose:
+      - "5050"
+    env_file:
+      - ${REPO_ROOT:-.}/.env
+    environment:
+      API_KEY: ${API_KEY}
+      PORT: 5050
+      REQUIRE_API_KEY: ${REQUIRE_API_KEY:-false}
+      EXPAND_API: ${EXPAND_API:-true}
+      REMOVE_FILTER: ${REMOVE_FILTER:-false}
+      DEFAULT_VOICE: ${DEFAULT_VOICE:-en-US-DavisNeural}
+      DEFAULT_RESPONSE_FORMAT: ${DEFAULT_RESPONSE_FORMAT:-wav}
+      DEFAULT_SPEED: ${DEFAULT_SPEED:-1.0}
+      DEFAULT_LANGUAGE: ${DEFAULT_LANGUAGE:-en-US}
+    networks:
+      - some-ui-network
+    restart: unless-stopped
+  nginx:
+    image: nginx:alpine
+    container_name: openai-edge-tts-proxy
+    ports:
+      - "${PORT:-5050}:80" # Expose nginx on your desired port
+    volumes:
+      - ${REPO_ROOT:-.}/nginx.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - some-ui-network
+    depends_on:
+      - openai-edge-tts
+    restart: unless-stopped

--- a/infra/compose/www.yml
+++ b/infra/compose/www.yml
@@ -3,18 +3,18 @@
 # interview app) sees a secure context. HTTP stays available on 8080 for
 # plain local checks.
 #
-# Requires local mkcert certs at ./certs (gitignored, machine-local) — the
-# same ones apps/www/vite.config.ts already looks for:
+# Requires local mkcert certs at ${REPO_ROOT}/certs (gitignored, machine-local)
+# — the same ones apps/www/vite.config.ts already looks for:
 #   mkcert -install
 #   mkcert -cert-file certs/nixos.local+3.pem \
 #          -key-file certs/nixos.local+3-key.pem \
 #          nixos.local localhost 127.0.0.1 ::1
 #
-# Usage: docker compose -f docker-compose.www.yml up --build
+# Usage: docker compose up www   (from repo root, via root docker-compose.yml)
 services:
   www:
     build:
-      context: .
+      context: ${REPO_ROOT:-.}
       dockerfile: apps/www/Dockerfile
     image: paulgsc/www:${TAG:-latest}
     container_name: some-ui-www
@@ -22,8 +22,13 @@ services:
       - "${WWW_HTTP_PORT:-8080}:80"
       - "${WWW_HTTPS_PORT:-8443}:443"
     volumes:
-      - ./apps/www/nginx.https.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./certs:/etc/nginx/certs:ro
+      - ${REPO_ROOT:-.}/apps/www/nginx.https.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${REPO_ROOT:-.}/certs:/etc/nginx/certs:ro
+    networks:
+      - some-ui-network
+    # Dockerfile bakes in the same wget-spider HEALTHCHECK as a baseline for
+    # bare `docker run`; redeclared here so compose can tune it without a
+    # rebuild (matches the pattern used by infra/compose/*.yml in server).
     healthcheck:
       test:
         [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,6 +1028,9 @@ importers:
       '@some-ui/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@some-ui/vite-config':
+        specifier: workspace:*
+        version: link:../some-vite-config
       '@types/node-fetch':
         specifier: ^2.6.11
         version: 2.6.13


### PR DESCRIPTION
## Description

This PR refactors the monolithic `docker-compose.yml` into a modular structure using Docker Compose's `include:` feature. The changes improve maintainability and enable better separation of concerns across multiple services.

### Key Changes:
- **Modularized compose files**: Split `docker-compose.yml` into three included files:
  - `infra/compose/base.yml`: Shared network definition (`some-ui-network`)
  - `infra/compose/tts.yml`: OpenAI Edge TTS and nginx services (moved from root)
  - `infra/compose/www.yml`: Web app service (renamed from `docker-compose.www.yml`)

- **Added REPO_ROOT environment variable**: Introduced `REPO_ROOT` to handle relative path resolution in included compose files. Docker Compose resolves relative paths in included files against their own directory, not the repo root, so bind mounts and build contexts now use `${REPO_ROOT:-.}` to ensure correct paths.

- **Network connectivity**: All services now explicitly connect to the `some-ui-network` bridge network for inter-service communication.

- **Updated .env.example**: Added documentation and new configuration variables (`REPO_ROOT`, `TAG`, `WWW_HTTP_PORT`, `WWW_HTTPS_PORT`).

- **Improved www.yml**: Updated paths to use `REPO_ROOT`, added explicit network configuration, and updated usage documentation.

## Type of Change

- [x] New feature (modular compose structure)
- [ ] Bug fix
- [ ] Breaking change
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.env.example)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Test Plan

Verify the refactored compose setup works correctly:
1. Set `REPO_ROOT` to the absolute path of the repository in `.env`
2. Run `docker compose up` from the repo root and confirm all services start (openai-edge-tts, nginx, www)
3. Verify services can communicate via the `some-ui-network` bridge network
4. Confirm nginx proxy correctly routes to the TTS service
5. Verify the www service is accessible on the configured ports

https://claude.ai/code/session_01SkQ3MUu6RzrxY3X2PJEp75