### PR TITLE
extensions/transport: land S3–S11, completing Epic #607

### DIFF
--- a/extensions/transport/README.md
+++ b/extensions/transport/README.md
@@ -15,10 +15,12 @@ should land first.
 
 ## Status
 
-Tracking [Epic #607](https://github.com/paulgsc/some-ui/issues/607). See that
-issue for the module tree, story sequencing, and the Kernel Independence
-acceptance bar (Theorem D.2): this package must build and pass its full
-conformance suite with **no business logic** — only a null adapter.
+All stories of [Epic #607](https://github.com/paulgsc/some-ui/issues/607)
+(S1–S11) have landed. The package builds (typechecks + lints) and its full
+unit (`pnpm test`) and conformance (`pnpm test:e2e`) suites pass against
+`adapter/null-adapter.ts` alone — the Kernel Independence acceptance bar
+(Theorem D.2). No business logic (theme/censor/redaction or any other
+domain concept) exists anywhere in this tree.
 
 ## Layout
 
@@ -26,8 +28,16 @@ conformance suite with **no business logic** — only a null adapter.
 src/
   contracts/    Token, Hypothesis, Invariant, Adapter, Action — types only
   bootstrap/    document-lifetime static install + sentinel (Def D.2, Thm D.1)
+  session/      epoch counter + reset operator (Def 5.4, D.1)
+  sensor/       hybrid event+poll channel (Def 3.1–3.3) + identity reconciliation (Def 4.1, Cor 4.1.1)
+  estimator/    hypothesis, per-key evidentiary order, monotonic update (Def 5.1–5.3, Thm 5.1), decay (Remark 3.3)
+  adapter/      the Adapter contract + null adapter (Def D.3, Thm D.2)
+  scheduler/    invariant re-evaluation cadence, R-bounded delivery bookkeeping (Def 7.2)
+  actuator/     self-tagged idempotent actuation, structural exclusion (Def 7.3, Thm 7.2, Cor 7.3.1)
+  lifecycle/    refresh-vs-navigation reset semantics, full teardown (Thm D.1)
+tests/e2e/      Playwright conformance suite (S11) — protocol guarantees only, against the null adapter
 ```
 
-Everything else (`session/`, `sensor/`, `estimator/`, `adapter/`,
-`scheduler/`, `actuator/`, `lifecycle/`) lands story-by-story; see the epic
-for sequencing.
+No migration of `some-censor` or `some-filter` onto this package has
+happened yet — that is tracked as follow-on work once a real Adapter
+implementation exists (see the epic's non-goals).

--- a/extensions/transport/eslint.config.js
+++ b/extensions/transport/eslint.config.js
@@ -62,6 +62,192 @@ const transportConfig = [
       ],
     },
   },
+  {
+    // Session (S3) is purely epoch/lifetime bookkeeping (Definition 5.4,
+    // Definition D.1) consumed by the Sensor, Estimator, and Actuator — not
+    // the other way around. A dependency in the reverse direction would
+    // make Session's reset semantics contingent on the very stages it is
+    // meant to be a stable substrate for.
+    files: ["src/session/**/*.ts"],
+    ignores: ["src/session/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/sensor/*", "**/estimator/*", "**/actuator/*"],
+              message:
+                "session/ is estimator-agnostic bookkeeping (canon Definition 5.4) and must not import sensor/, estimator/, or actuator/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Sensor (S4, S5) only produces tokens (Definition 3.2) and reconciles
+    // identity (Definition 4.1) — it has no business folding evidence
+    // (Estimator), deciding (Adapter), scheduling (Scheduler), writing to
+    // G_t (Actuator), or tearing anything down (Lifecycle).
+    files: ["src/sensor/**/*.ts"],
+    ignores: ["src/sensor/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/estimator/*",
+                "**/adapter/*",
+                "**/scheduler/*",
+                "**/actuator/*",
+                "**/lifecycle/*",
+              ],
+              message:
+                "sensor/ only produces tokens and reconciles identity (canon §3–§4) and must not import estimator/, adapter/, scheduler/, actuator/, or lifecycle/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Estimator (S6) folds evidence into a hypothesis (Definition 5.3) and
+    // has no knowledge of *why* a key is being tracked (S6 non-goal): no
+    // invariant evaluation (Adapter), scheduling policy, DOM writes
+    // (Actuator), or teardown wiring belong here.
+    files: ["src/estimator/**/*.ts"],
+    ignores: ["src/estimator/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/adapter/*",
+                "**/scheduler/*",
+                "**/actuator/*",
+                "**/lifecycle/*",
+              ],
+              message:
+                "estimator/ folds evidence into a hypothesis (canon Definition 5.3) and must not import adapter/, scheduler/, actuator/, or lifecycle/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Scheduler (S8) decides only *when* to ask the Adapter, never *what*
+    // (S8 acceptance criterion) — it has no need to import any other
+    // transport stage; it is driven entirely by its own `trigger()`/
+    // `onFire` callback surface.
+    files: ["src/scheduler/**/*.ts"],
+    ignores: ["src/scheduler/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/sensor/*",
+                "**/estimator/*",
+                "**/adapter/*",
+                "**/actuator/*",
+                "**/lifecycle/*",
+              ],
+              message:
+                "scheduler/ decides only when, never what (canon §8) and must not import sensor/, estimator/, adapter/, actuator/, or lifecycle/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Actuator (S9) only realizes a given Fin(A) (§8's (ACT) rule) — it
+    // has no business deciding *what* to apply (that's the Adapter, S7
+    // non-goal), scheduling itself, or reaching into the Sensor/Estimator.
+    files: ["src/actuator/**/*.ts"],
+    ignores: ["src/actuator/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/sensor/*",
+                "**/estimator/*",
+                "**/adapter/*",
+                "**/scheduler/*",
+                "**/lifecycle/*",
+              ],
+              message:
+                "actuator/ only realizes a given Fin(A) (canon §8) and must not import sensor/, estimator/, adapter/, scheduler/, or lifecycle/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Lifecycle (S10) only sequences disposal and Session's reset
+    // (Theorem D.1) against a caller-supplied registry of disposables —
+    // it has no need to import Sensor/Estimator/Adapter/Scheduler/
+    // Actuator directly, only Session and (via a callback, not an import)
+    // Bootstrap's teardown.
+    files: ["src/lifecycle/**/*.ts"],
+    ignores: ["src/lifecycle/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/sensor/*",
+                "**/estimator/*",
+                "**/adapter/*",
+                "**/scheduler/*",
+                "**/actuator/*",
+              ],
+              message:
+                "lifecycle/ only sequences disposal and Session's reset (canon Theorem D.1) and must not import sensor/, estimator/, adapter/, scheduler/, or actuator/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Corollary D.2.1 (the litmus test): no module outside adapter/'s own
+    // package — or this package's own tests, which are allowed to wire a
+    // concrete adapter for exercising the pipeline — may import a concrete
+    // adapter implementation. Everything else depends on the `Adapter` type
+    // from contracts/adapter.ts and receives an implementation only via
+    // injection (Axiom D.1).
+    files: ["src/**/*.ts"],
+    ignores: ["src/adapter/**", "**/*.test.ts", "**/*.spec.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/adapter/null-adapter", "**/adapter/null-adapter.*"],
+              message:
+                "Only adapter/invoke.ts and this package's own tests may reference a concrete adapter implementation (canon Corollary D.2.1). Depend on the Adapter type from contracts/adapter.ts instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]
 
 export default transportConfig

--- a/extensions/transport/package.json
+++ b/extensions/transport/package.json
@@ -23,7 +23,9 @@
   "devDependencies": {
     "@playwright/test": "1.60.0",
     "@some-ui/tsconfig": "workspace:*",
+    "esbuild": "^0.25.0",
     "eslint": "^10.6.0",
+    "fast-check": "^3.23.1",
     "maishatu-eslint-kit": "workspace:*"
   },
   "scripts": {
@@ -33,6 +35,7 @@
     "lint:js": "eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
     "prettier": "prettier \"**/*.{js,mjs,ts,tsx,md,mdx,json,yml,css}\" --ignore-path $(git rev-parse --show-toplevel)/.prettierignore --check --cache",
     "test": "vitest",
+    "test:e2e": "playwright test --config playwright.config.ts",
     "typecheck": "tsc --noEmit"
   }
 }

--- a/extensions/transport/playwright.config.ts
+++ b/extensions/transport/playwright.config.ts
@@ -5,6 +5,9 @@
  * transport *protocol* guarantees (bootstrap persistence, epoch transitions,
  * hypothesis convergence, actuation idempotence) against the null adapter,
  * never a domain-specific property. See canon §8.3 and §D.
+ *
+ * Runtime: 18 specs, ~5s wall clock on a single worker (measured locally
+ * against a pre-provisioned Chromium) — viable per-PR, not just nightly.
  */
 
 import { defineConfig, devices } from "@playwright/test"
@@ -12,6 +15,7 @@ import { defineConfig, devices } from "@playwright/test"
 export default defineConfig({
   testDir: "./tests/e2e",
   testMatch: "**/*.spec.ts",
+  globalSetup: "./tests/e2e/global-setup.ts",
 
   timeout: 15_000,
   retries: 0,

--- a/extensions/transport/src/actuator/apply.test.ts
+++ b/extensions/transport/src/actuator/apply.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+
+import type { Action } from "../contracts/action"
+import { apply, type ActionRealizer } from "./apply"
+import { isSelfTagged, selfTagValue } from "./self-tag"
+
+type MaskAction = Action & { readonly kind: "mask"; readonly key: string }
+
+function maskRealizer(root: Element): ActionRealizer<MaskAction> {
+  return (action) => {
+    const el = root.querySelector<HTMLElement>(`[data-key="${action.key}"]`)
+    if (el === null) {
+      return []
+    }
+    el.setAttribute("data-masked", "true") // idempotent: same value every call
+    return [el]
+  }
+}
+
+describe("actuator/apply — α(Δ)", () => {
+  it("applies each action and self-tags every element it touches", () => {
+    const root = document.createElement("div")
+    root.innerHTML = `<div data-key="k1"></div>`
+    document.body.appendChild(root)
+
+    apply<MaskAction>([{ kind: "mask", key: "k1" }], {
+      realize: maskRealizer(root),
+      tagValue: (action) => action.key,
+    })
+
+    const el = root.querySelector("[data-key='k1']")
+    expect(el?.getAttribute("data-masked")).toBe("true")
+    expect(el !== null && isSelfTagged(el)).toBe(true)
+    expect(el !== null ? selfTagValue(el) : undefined).toBe("k1")
+
+    root.remove()
+  })
+
+  it("is idempotent: applying the same action twice produces identical G_t as applying it once", () => {
+    const root = document.createElement("div")
+    root.innerHTML = `<div data-key="k1"></div>`
+    document.body.appendChild(root)
+
+    const options = {
+      realize: maskRealizer(root),
+      tagValue: (a: MaskAction): string => a.key,
+    }
+
+    apply<MaskAction>([{ kind: "mask", key: "k1" }], options)
+    const afterFirst = root.innerHTML
+
+    apply<MaskAction>([{ kind: "mask", key: "k1" }], options)
+    const afterSecond = root.innerHTML
+
+    expect(afterSecond).toBe(afterFirst)
+
+    root.remove()
+  })
+
+  it("an empty Δ applies nothing", () => {
+    const root = document.createElement("div")
+    root.innerHTML = `<div data-key="k1"></div>`
+    document.body.appendChild(root)
+    const before = root.innerHTML
+
+    apply<MaskAction>([], {
+      realize: maskRealizer(root),
+      tagValue: (a) => a.key,
+    })
+
+    expect(root.innerHTML).toBe(before)
+    root.remove()
+  })
+})

--- a/extensions/transport/src/actuator/apply.ts
+++ b/extensions/transport/src/actuator/apply.ts
@@ -1,0 +1,38 @@
+/**
+ * §8 operational semantics (the (ACT) rule), Definition 7.3 — canon §7–§8.
+ *
+ * Realizes `α(Δ)`: applies every action the Adapter (S7) produced and
+ * self-tags every element it touches (Definition 7.3). This is the *only*
+ * transport stage permitted to write to `G_t`. `realize` — what a given
+ * action `kind` actually does to the DOM — is necessarily domain-specific
+ * and is therefore injected, never hard-coded here; it must itself be
+ * idempotent at the DOM level for Theorem 7.2 to hold.
+ */
+
+import type { Action } from "../contracts/action"
+import { tag } from "./self-tag"
+
+/**
+ * Realizes one action against the DOM, returning every element it wrote
+ * to (to be self-tagged). Idempotent: realizing an action that is already
+ * satisfied must be a no-op on observable `G_t`.
+ */
+export type ActionRealizer<A extends Action> = (action: A) => Iterable<Element>
+
+export type ApplyOptions<A extends Action> = {
+  readonly realize: ActionRealizer<A>
+  /** The self-tag value to stamp on every element the realizer touches for this action. */
+  readonly tagValue: (action: A) => string
+}
+
+export function apply<A extends Action>(
+  actions: ReadonlyArray<A>,
+  options: ApplyOptions<A>
+): void {
+  for (const action of actions) {
+    const value = options.tagValue(action)
+    for (const element of options.realize(action)) {
+      tag(element, value)
+    }
+  }
+}

--- a/extensions/transport/src/actuator/exclude.test.ts
+++ b/extensions/transport/src/actuator/exclude.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+
+import { excludeActuatorSubtree, isWithinActuatorSubtree } from "./exclude"
+import { tag } from "./self-tag"
+
+describe("actuator/exclude — structural exclusion (Corollary 7.3.1)", () => {
+  it("excludes a self-tagged element itself", () => {
+    const el = document.createElement("div")
+    tag(el, "k1")
+    expect(isWithinActuatorSubtree(el)).toBe(true)
+  })
+
+  it("excludes a descendant of a self-tagged ancestor, even though the descendant itself is untagged", () => {
+    const parent = document.createElement("div")
+    const child = document.createElement("span")
+    parent.appendChild(child)
+    tag(parent, "k1")
+
+    expect(isWithinActuatorSubtree(child, parent)).toBe(true)
+  })
+
+  it("does not exclude a node outside any actuator-owned subtree", () => {
+    const vendorNode = document.createElement("div")
+    expect(isWithinActuatorSubtree(vendorNode)).toBe(false)
+  })
+
+  it("excludeActuatorSubtree filters a candidate set down to only vendor-authored nodes", () => {
+    const root = document.createElement("div")
+    const veil = document.createElement("div") // actuator's own overlay
+    const vendorCard = document.createElement("div") // genuine vendor content
+    tag(veil, "veil")
+    root.appendChild(veil)
+    root.appendChild(vendorCard)
+
+    const candidates = [veil, vendorCard]
+    const filtered = excludeActuatorSubtree(candidates, root)
+
+    expect(filtered).toEqual([vendorCard])
+  })
+
+  it("regression (the prepaint corollary, 7.3.1): sampling without structural exclusion reads the actuator's own veil as vendor evidence — proving the helper is load-bearing, not a no-op", () => {
+    const root = document.createElement("div")
+    const veil = document.createElement("div")
+    veil.setAttribute("data-detected-color", "veil-color")
+    tag(veil, "veil")
+    root.appendChild(veil)
+
+    // Without exclusion, a naive detector samples the veil directly.
+    const naiveSample = Array.from(
+      root.querySelectorAll("[data-detected-color]")
+    )
+    expect(naiveSample).toHaveLength(1) // the bug this corollary exists to prevent
+
+    // With structural exclusion applied first, the veil never reaches the
+    // detector's sampling at all.
+    const excluded = excludeActuatorSubtree(naiveSample, root)
+    expect(excluded).toHaveLength(0)
+  })
+})

--- a/extensions/transport/src/actuator/exclude.ts
+++ b/extensions/transport/src/actuator/exclude.ts
@@ -1,0 +1,49 @@
+/**
+ * Corollary 7.3.1 (the prepaint corollary), Proposition 7.3 (measurement
+ * disturbance) — canon §7.
+ *
+ * A subtree-exclusion helper any detector (Sensor, S4) can use to keep
+ * actuator output out of its own sampling. This is *structural*
+ * exclusion — deciding, before a node is ever read, that it lies inside
+ * an actuator-owned subtree — not a post-hoc filter over already-sampled
+ * evidence: Proposition 7.3's proof is exactly that filtering after the
+ * fact cannot repair a violation of Axiom 3.5.
+ */
+
+import { isSelfTagged } from "./self-tag"
+
+/** True if `node`, or any ancestor of it up to and including `root`, is self-tagged (actuator-owned). */
+export function isWithinActuatorSubtree(
+  node: Node,
+  root: Node = document
+): boolean {
+  let current: Node | null = node
+  while (current !== null) {
+    if (current instanceof Element && isSelfTagged(current)) {
+      return true
+    }
+    if (current === root) {
+      break
+    }
+    current = current.parentNode
+  }
+  return false
+}
+
+/**
+ * Filters `nodes` down to those *not* rooted inside an actuator-owned
+ * subtree — the structural exclusion a detector applies before treating a
+ * node as a candidate source of evidence.
+ */
+export function excludeActuatorSubtree<N extends Node>(
+  nodes: Iterable<N>,
+  root: Node = document
+): Array<N> {
+  const result: Array<N> = []
+  for (const node of nodes) {
+    if (!isWithinActuatorSubtree(node, root)) {
+      result.push(node)
+    }
+  }
+  return result
+}

--- a/extensions/transport/src/actuator/exclusivity.test.ts
+++ b/extensions/transport/src/actuator/exclusivity.test.ts
@@ -1,0 +1,86 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+/**
+ * S9 acceptance criterion: "`actuator/` is the only directory in the
+ * package containing a DOM-mutating call (grep-checkable, mirroring S4's
+ * channel-purity check in the opposite direction)."
+ *
+ * `bootstrap/` is a deliberate, canon-declared exception: Definition D.2
+ * says installing Bootstrap's sentinel "is not itself an act of
+ * estimation, planning, or actuation" — it runs before any of Ĥ, Φ, or Δ
+ * exist, at document rather than content granularity (Corollary D.1.1).
+ * Its one `setAttribute` call is therefore excluded here by name, not
+ * silently ignored.
+ */
+
+const ACTUATOR_DIR = dirname(fileURLToPath(import.meta.url))
+const SRC_DIR = join(ACTUATOR_DIR, "..")
+const EXEMPT_DIRS = new Set(["bootstrap"])
+
+const MUTATING_CALL_PATTERNS: ReadonlyArray<RegExp> = [
+  /\.setAttribute\s*\(/,
+  /\.removeAttribute\s*\(/,
+  /\.style\s*[.=]/,
+  /\.appendChild\s*\(/,
+  /\.insertBefore\s*\(/,
+  /\.replaceChild\s*\(/,
+  /\.removeChild\s*\(/,
+  /\.remove\s*\(\s*\)/,
+  /\.innerHTML\s*=/,
+  /\.outerHTML\s*=/,
+  /\.textContent\s*=/,
+  /\.classList\.(add|remove|toggle|replace)\s*\(/,
+]
+
+function allSourceFiles(dir: string): Array<string> {
+  const files: Array<string> = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue
+      files.push(...allSourceFiles(full))
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+function topLevelDir(file: string): string {
+  return relative(SRC_DIR, file).split("/")[0] ?? ""
+}
+
+function containsMutatingCall(contents: string): boolean {
+  return MUTATING_CALL_PATTERNS.some((pattern) => pattern.test(contents))
+}
+
+describe("actuator/ exclusivity — the only DOM-mutating directory (besides bootstrap/'s day-zero exception)", () => {
+  const files = allSourceFiles(SRC_DIR).filter(
+    (file) => !EXEMPT_DIRS.has(topLevelDir(file))
+  )
+
+  for (const file of files) {
+    const rel = relative(SRC_DIR, file)
+    const dir = topLevelDir(file)
+
+    if (dir === "actuator") {
+      continue // actuator/ is expected to mutate the DOM; covered by the sanity check below
+    }
+
+    it(`${rel} contains no DOM-mutating call`, () => {
+      const contents = readFileSync(file, "utf8")
+      expect(containsMutatingCall(contents)).toBe(false)
+    })
+  }
+
+  it("sanity check: actuator/ does contain a DOM-mutating call (the check above is not vacuous)", () => {
+    const actuatorFiles = allSourceFiles(ACTUATOR_DIR)
+    const anyMutating = actuatorFiles.some((file) =>
+      containsMutatingCall(readFileSync(file, "utf8"))
+    )
+    expect(anyMutating).toBe(true)
+  })
+})

--- a/extensions/transport/src/actuator/loop-suppression.test.ts
+++ b/extensions/transport/src/actuator/loop-suppression.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import type { Action } from "../contracts/action"
+import { apply, type ActionRealizer } from "./apply"
+import { isSelfTagged } from "./self-tag"
+
+/**
+ * Theorem 7.2 (Loop suppression) — canon §7, executable.
+ *
+ * Given actuation that is idempotent (Definition 7.3) and self-tagged, a
+ * key whose environment-driven mutation rate is zero over an interval
+ * cannot sustain an infinite sequence of non-empty Δ(k): after the first
+ * repair, every further planner round yields Δ(k) = ∅.
+ *
+ * This is a closed-loop simulation local to this test file — a minimal
+ * φ/decide pair standing in for a real Adapter (S7 ships only the null
+ * adapter) — that exercises the real `apply()`/`tag()`/`isSelfTagged()`
+ * machinery from this package, not a re-statement of the proof in prose.
+ */
+
+type MaskAction = Action & { readonly kind: "mask"; readonly key: string }
+
+describe("actuator — Theorem 7.2 (loop suppression), executable", () => {
+  it("repeated planner rounds against a stable environment never produce a second non-empty Δ(k) after the first repair", () => {
+    const root = document.createElement("div")
+    root.innerHTML = `<div data-key="k1"></div>`
+    document.body.appendChild(root)
+
+    const realize: ActionRealizer<MaskAction> = (action) => {
+      const el = root.querySelector<HTMLElement>(`[data-key="${action.key}"]`)
+      if (el === null) {
+        return []
+      }
+      el.setAttribute("data-masked", "true")
+      return [el]
+    }
+
+    // φ(k, ·): "k" is satisfied once its element is both masked and
+    // self-tagged — self-tagging lets this check distinguish "already
+    // repaired by us" from "genuinely still unsafe," which is exactly what
+    // lets an actuator echo be recognized rather than misread as new
+    // environment-driven evidence.
+    function isSatisfied(key: string): boolean {
+      const el = root.querySelector(`[data-key="${key}"]`)
+      return (
+        el !== null &&
+        el.getAttribute("data-masked") === "true" &&
+        isSelfTagged(el)
+      )
+    }
+
+    // decide(): Definition 6.2's Δ — touches only keys currently failing φ.
+    function decide(keys: ReadonlyArray<string>): ReadonlyArray<MaskAction> {
+      return keys
+        .filter((key) => !isSatisfied(key))
+        .map((key) => ({ kind: "mask", key }))
+    }
+
+    const keys = ["k1"]
+    const deltaSizes: Array<number> = []
+
+    // Ten planner rounds over a zero-environment-mutation-rate interval —
+    // no new vendor evidence is ever introduced between rounds.
+    for (let round = 0; round < 10; round++) {
+      const delta = decide(keys)
+      deltaSizes.push(delta.length)
+      apply<MaskAction>(delta, { realize, tagValue: (a) => a.key })
+    }
+
+    expect(deltaSizes[0]).toBe(1) // the first repair
+    expect(deltaSizes.slice(1)).toEqual(deltaSizes.slice(1).map(() => 0)) // every round after: Δ = ∅
+
+    root.remove()
+  })
+})

--- a/extensions/transport/src/actuator/self-tag.test.ts
+++ b/extensions/transport/src/actuator/self-tag.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isSelfTagged,
+  releaseOwnership,
+  selfTagValue,
+  tag,
+  wasOwned,
+  wasRemovedByUs,
+  wasRemovedByVendor,
+} from "./self-tag"
+
+describe("actuator/self-tag — Definition 7.3", () => {
+  it("tag() marks an element self-tagged and owned", () => {
+    const el = document.createElement("div")
+    tag(el, "k1")
+
+    expect(isSelfTagged(el)).toBe(true)
+    expect(selfTagValue(el)).toBe("k1")
+    expect(wasOwned(el)).toBe(true)
+  })
+
+  it("an untagged element is neither self-tagged nor owned", () => {
+    const el = document.createElement("div")
+    expect(isSelfTagged(el)).toBe(false)
+    expect(wasOwned(el)).toBe(false)
+  })
+
+  it("releaseOwnership() clears both markers", () => {
+    const el = document.createElement("div")
+    tag(el, "k1")
+    releaseOwnership(el)
+
+    expect(isSelfTagged(el)).toBe(false)
+    expect(wasOwned(el)).toBe(false)
+  })
+})
+
+describe("actuator/self-tag — ownership signal distinguishes removal source (Remark 7.2)", () => {
+  it("a vendor-driven removal is distinguishable: the ownership flag survives because releaseOwnership() was never called", () => {
+    const parent = document.createElement("div")
+    const el = document.createElement("div")
+    parent.appendChild(el)
+    document.body.appendChild(parent)
+
+    tag(el, "k1")
+
+    // Simulate a hostile vendor script yanking our node out from under us —
+    // no call to releaseOwnership() precedes this.
+    el.remove()
+
+    expect(wasRemovedByVendor(el)).toBe(true)
+    expect(wasRemovedByUs(el)).toBe(false)
+
+    parent.remove()
+  })
+
+  it("our own intentional teardown is distinguishable: releaseOwnership() precedes removal", () => {
+    const parent = document.createElement("div")
+    const el = document.createElement("div")
+    parent.appendChild(el)
+    document.body.appendChild(parent)
+
+    tag(el, "k1")
+    releaseOwnership(el)
+    el.remove()
+
+    expect(wasRemovedByUs(el)).toBe(true)
+    expect(wasRemovedByVendor(el)).toBe(false)
+
+    parent.remove()
+  })
+
+  it("only the vendor-removal case should trigger a re-assert per Remark 7.2", () => {
+    function shouldReassert(el: Element): boolean {
+      return wasRemovedByVendor(el)
+    }
+
+    const vendorRemoved = document.createElement("div")
+    document.body.appendChild(vendorRemoved)
+    tag(vendorRemoved, "k1")
+    vendorRemoved.remove()
+
+    const ourTeardown = document.createElement("div")
+    document.body.appendChild(ourTeardown)
+    tag(ourTeardown, "k2")
+    releaseOwnership(ourTeardown)
+    ourTeardown.remove()
+
+    expect(shouldReassert(vendorRemoved)).toBe(true)
+    expect(shouldReassert(ourTeardown)).toBe(false)
+  })
+})

--- a/extensions/transport/src/actuator/self-tag.ts
+++ b/extensions/transport/src/actuator/self-tag.ts
@@ -1,0 +1,65 @@
+/**
+ * Definition 7.3 (Self-tag), Remark 7.2 (Bidirectional self-tagging) —
+ * canon §7.
+ *
+ * A channel-visible marker attached to every actuator-authored node,
+ * checked at two points: by any detector sampling the subtree (to exclude
+ * self-authored evidence, Axiom 3.5 / Proposition 7.3), and by the
+ * estimator's own ingestion path (to recognize an echo of its own write,
+ * Theorem 7.2). The *ownership signal* is a second, distinct marker
+ * (Remark 7.2): a self-tag alone answers "did I write this," not "was
+ * this just removed, by me or by the vendor" — the ownership signal,
+ * cleared only by `releaseOwnership()`'s intentional teardown, answers
+ * that.
+ */
+
+const SELF_TAG_ATTR = "data-transport-actuator"
+const OWNERSHIP_ATTR = "data-transport-owned"
+
+/** Self-tags `element` and marks it owned. Idempotent: re-tagging with the same value is a no-op on observable state. */
+export function tag(element: Element, tagValue: string): void {
+  element.setAttribute(SELF_TAG_ATTR, tagValue)
+  element.setAttribute(OWNERSHIP_ATTR, "true")
+}
+
+export function isSelfTagged(element: Element): boolean {
+  return element.hasAttribute(SELF_TAG_ATTR)
+}
+
+export function selfTagValue(element: Element): string | undefined {
+  return element.getAttribute(SELF_TAG_ATTR) ?? undefined
+}
+
+/**
+ * Marks intentional teardown. Must be called *before* an actuator-driven
+ * removal — a later `wasRemovedByVendor`/`wasRemovedByUs` check on the
+ * same (now possibly detached) element reference distinguishes the two
+ * only because this function is the sole way the ownership flag clears.
+ */
+export function releaseOwnership(element: Element): void {
+  element.removeAttribute(OWNERSHIP_ATTR)
+  element.removeAttribute(SELF_TAG_ATTR)
+}
+
+export function wasOwned(element: Element): boolean {
+  return element.hasAttribute(OWNERSHIP_ATTR)
+}
+
+/**
+ * True if a tracked, disconnected element was removed by the vendor's own
+ * process rather than by the actuator's own teardown — the ownership flag
+ * is still present because `releaseOwnership()` was never called before
+ * disconnection. Precondition: `element` was previously tagged via `tag()`.
+ */
+export function wasRemovedByVendor(element: Element): boolean {
+  return !element.isConnected && wasOwned(element)
+}
+
+/**
+ * True if a tracked, disconnected element was removed via the actuator's
+ * own intentional teardown — `releaseOwnership()` cleared the flag before
+ * disconnection. Precondition: `element` was previously tagged via `tag()`.
+ */
+export function wasRemovedByUs(element: Element): boolean {
+  return !element.isConnected && !wasOwned(element)
+}

--- a/extensions/transport/src/adapter/invoke.test.ts
+++ b/extensions/transport/src/adapter/invoke.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+
+import type { Action } from "../contracts/action"
+import type { Adapter } from "../contracts/adapter"
+import type { Hypothesis } from "../contracts/hypothesis"
+import { invoke } from "./invoke"
+import { createNullAdapter } from "./null-adapter"
+
+type Attrs = { readonly seq: number }
+
+function throwingHypothesis<K, Attr>(): Hypothesis<K, Attr> {
+  const target: Hypothesis<K, Attr> = {
+    get: () => undefined,
+    has: () => false,
+    keys: () => [],
+  }
+  return new Proxy(target, {
+    get(_target, prop): never {
+      throw new Error(`invoke() touched Hypothesis.${String(prop)} directly`)
+    },
+  })
+}
+
+describe("adapter/invoke — the sole runtime call site for a concrete adapter", () => {
+  it("forwards the hypothesis to the adapter's decide() and returns its result verbatim", () => {
+    const expected: ReadonlyArray<Action> = [{ kind: "noop" }]
+    const adapter: Adapter<string, Attrs> = {
+      decide: () => expected,
+    }
+    const hypothesis: Hypothesis<string, Attrs> = {
+      get: () => undefined,
+      has: () => false,
+      keys: () => [],
+    }
+
+    const result = invoke(hypothesis, adapter)
+
+    expect(result).toBe(expected)
+  })
+
+  it("never dereferences the hypothesis itself — invoke() only passes the reference through to the adapter", () => {
+    const adapter = createNullAdapter<string, Attrs>()
+    const hypothesis = throwingHypothesis<string, Attrs>()
+
+    expect(() => invoke(hypothesis, adapter)).not.toThrow()
+  })
+
+  it("passes the exact hypothesis reference through — an adapter that does call into it sees the same object", () => {
+    const hypothesis: Hypothesis<string, Attrs> = {
+      get: () => ({ seq: 1 }),
+      has: () => true,
+      keys: () => ["k"],
+    }
+    let seen: Hypothesis<string, Attrs> | undefined
+    const adapter: Adapter<string, Attrs> = {
+      decide: (h) => {
+        seen = h
+        return []
+      },
+    }
+
+    invoke(hypothesis, adapter)
+
+    expect(seen).toBe(hypothesis)
+  })
+})

--- a/extensions/transport/src/adapter/invoke.ts
+++ b/extensions/transport/src/adapter/invoke.ts
@@ -1,0 +1,21 @@
+/**
+ * Definition D.3 (Business Adapter), Axiom D.1 (Adapter purity) — canon §D.1.
+ *
+ * The single call site that hands `Ĥ` to an injected `decide` and returns
+ * `Fin(A)` to the Scheduler/Actuator (S8/S9). This is the only file in the
+ * transport package permitted to hold a reference to a concrete adapter
+ * instance at runtime — every other module is typed against the `Adapter`
+ * interface only (Corollary D.2.1), and receives an implementation solely
+ * via this function's `adapter` parameter, never by importing one.
+ */
+
+import type { Action } from "../contracts/action"
+import type { Adapter } from "../contracts/adapter"
+import type { Hypothesis } from "../contracts/hypothesis"
+
+export function invoke<K, Attr, A extends Action = Action>(
+  hypothesis: Hypothesis<K, Attr>,
+  adapter: Adapter<K, Attr, A>
+): ReadonlyArray<A> {
+  return adapter.decide(hypothesis)
+}

--- a/extensions/transport/src/adapter/kernel-independence.test.ts
+++ b/extensions/transport/src/adapter/kernel-independence.test.ts
@@ -1,0 +1,65 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Theorem D.2 (Kernel independence), S11 acceptance criterion: "The
+ * entire suite runs and passes with `adapter/null-adapter.ts` as the only
+ * adapter in the tree — CI fails the build if any test file imports
+ * anything resembling a concrete domain adapter." Enforced twice: the
+ * eslint `no-restricted-imports` rule (Corollary D.2.1, S7) catches an
+ * import-level violation anywhere in `src/`; this test additionally
+ * asserts, by directory listing, that no second concrete adapter file has
+ * been added to `adapter/` at all.
+ */
+
+const ADAPTER_DIR = dirname(fileURLToPath(import.meta.url))
+const E2E_DIR = join(ADAPTER_DIR, "..", "..", "tests", "e2e")
+
+const ALLOWED_ADAPTER_FILES = new Set([
+  "null-adapter.ts",
+  "null-adapter.test.ts",
+  "invoke.ts",
+  "invoke.test.ts",
+  "kernel-independence.test.ts",
+])
+
+function allTsFiles(dir: string): Array<string> {
+  const files: Array<string> = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === "dist" || entry.name === "node_modules") continue
+      files.push(...allTsFiles(full))
+    } else if (entry.name.endsWith(".ts")) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+describe("adapter/ — Theorem D.2 kernel independence", () => {
+  it("adapter/ contains no file beyond the null adapter and its call site", () => {
+    const actual = readdirSync(ADAPTER_DIR).filter((name) =>
+      name.endsWith(".ts")
+    )
+    for (const name of actual) {
+      expect(ALLOWED_ADAPTER_FILES.has(name)).toBe(true)
+    }
+  })
+
+  it("no e2e test/harness file imports a concrete adapter other than the null adapter", () => {
+    for (const file of allTsFiles(E2E_DIR)) {
+      const contents = readFileSync(file, "utf8")
+      const adapterImports =
+        contents.match(/from\s+["'][^"']*\/adapter\/[^"']+["']/g) ?? []
+      for (const importStatement of adapterImports) {
+        const isAllowed = /\/adapter\/(null-adapter|invoke)["']$/.test(
+          importStatement
+        )
+        expect(isAllowed).toBe(true)
+      }
+    }
+  })
+})

--- a/extensions/transport/src/adapter/null-adapter.test.ts
+++ b/extensions/transport/src/adapter/null-adapter.test.ts
@@ -1,0 +1,41 @@
+import fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import type { Hypothesis } from "../contracts/hypothesis"
+import { createNullAdapter } from "./null-adapter"
+
+type Attrs = { readonly seq: number }
+
+function arbitraryHypothesis(): fc.Arbitrary<Hypothesis<string, Attrs>> {
+  return fc
+    .dictionary(fc.string(), fc.record({ seq: fc.integer() }))
+    .map((entries) => {
+      const map = new Map(Object.entries(entries))
+      return {
+        get: (key: string) => map.get(key),
+        has: (key: string) => map.has(key),
+        keys: () => map.keys(),
+      }
+    })
+}
+
+describe("adapter/null-adapter — Theorem D.2 (Kernel independence)", () => {
+  it("decide_0 invoked against an arbitrary hypothesis always returns ∅", () => {
+    fc.assert(
+      fc.property(arbitraryHypothesis(), (hypothesis) => {
+        const adapter = createNullAdapter<string, Attrs>()
+        expect(adapter.decide(hypothesis)).toEqual([])
+      })
+    )
+  })
+
+  it("returns an empty array even for a hypothesis with entries", () => {
+    const adapter = createNullAdapter<string, Attrs>()
+    const hypothesis: Hypothesis<string, Attrs> = {
+      get: (key) => (key === "k" ? { seq: 1 } : undefined),
+      has: (key) => key === "k",
+      keys: () => ["k"],
+    }
+    expect(adapter.decide(hypothesis)).toEqual([])
+  })
+})

--- a/extensions/transport/src/adapter/null-adapter.ts
+++ b/extensions/transport/src/adapter/null-adapter.ts
@@ -1,0 +1,24 @@
+/**
+ * Theorem D.2 (Kernel Independence) — canon §D.1.
+ *
+ * `decide_0(h) = ∅` for every `h`. This is the reference adapter this
+ * package's own build, lint, and conformance suite (S11) run against —
+ * the transport kernel must type-check, lint, and pass its full suite
+ * with no business logic anywhere in the tree, and this is the trivial
+ * inhabitant of the `Adapter` contract that proves it.
+ */
+
+import type { Action } from "../contracts/action"
+import type { Adapter } from "../contracts/adapter"
+
+export function createNullAdapter<
+  K,
+  Attr,
+  A extends Action = Action,
+>(): Adapter<K, Attr, A> {
+  return {
+    decide(): ReadonlyArray<A> {
+      return []
+    },
+  }
+}

--- a/extensions/transport/src/bootstrap/static.test.ts
+++ b/extensions/transport/src/bootstrap/static.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { install, installedAt, isInstalled } from "./static"
+import { install, installedAt, isInstalled, uninstall } from "./static"
 
 function freshRoot(): Element {
   return document.implementation.createHTMLDocument("").documentElement
@@ -63,6 +63,21 @@ describe("bootstrap/static", () => {
 
     expect(isInstalled(newDocumentRoot)).toBe(false)
     expect(installedAt(newDocumentRoot)).toBeUndefined()
+  })
+
+  it("uninstall() removes the sentinel so a later install() reinstalls fresh (Theorem D.1(b))", () => {
+    const root = freshRoot()
+    vi.spyOn(Date, "now").mockReturnValueOnce(1).mockReturnValueOnce(2)
+
+    const first = install(root)
+    uninstall(root)
+
+    expect(isInstalled(root)).toBe(false)
+
+    const second = install(root)
+    expect(second.installedAt).not.toBe(first.installedAt)
+
+    vi.restoreAllMocks()
   })
 
   it("defaults to document.documentElement when no root is given", () => {

--- a/extensions/transport/src/bootstrap/static.ts
+++ b/extensions/transport/src/bootstrap/static.ts
@@ -46,3 +46,13 @@ export function installedAt(
   const value = root.getAttribute(SENTINEL_ATTR)
   return value === null ? undefined : Number(value)
 }
+
+/**
+ * Removes the sentinel so a subsequent `install()` call reinstalls fresh.
+ * Only Lifecycle's `teardownDocument()` (S10) calls this — it is Theorem
+ * D.1(b)'s "Bootstrap is reinstalled" half, made callable without waiting
+ * for an actual page refresh to supply a new `root`.
+ */
+export function uninstall(root: Element = document.documentElement): void {
+  root.removeAttribute(SENTINEL_ATTR)
+}

--- a/extensions/transport/src/estimator/decay.test.ts
+++ b/extensions/transport/src/estimator/decay.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+
+import { createDecayTracker } from "./decay"
+import { createHypothesis } from "./hypothesis"
+import { createProvenanceStore, update } from "./update"
+
+type Attrs = { readonly seq: number }
+
+function seed(
+  h: ReturnType<typeof createHypothesis<string, Attrs>>,
+  p: ReturnType<typeof createProvenanceStore<string>>,
+  key: string,
+  timestamp: number
+): void {
+  update(h, p, {
+    key,
+    epoch: 0,
+    tier: "full",
+    timestamp,
+    attrs: { seq: timestamp },
+  })
+}
+
+describe("estimator/decay — Remark 3.3", () => {
+  it("does not evict a key on a single brief absence (must never false-positive virtualization)", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    const decay = createDecayTracker<string, Attrs>()
+
+    seed(h, p, "k", 0)
+    decay.touch("k", 0)
+
+    const evicted = decay.sweep(1, 10, h, p) // only 1 tick elapsed, well within the bound
+
+    expect(evicted).toEqual([])
+    expect(h.has("k")).toBe(true)
+  })
+
+  it("evicts a key only after sustained absence exceeds the staleness bound", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    const decay = createDecayTracker<string, Attrs>()
+
+    seed(h, p, "k", 0)
+    decay.touch("k", 0)
+
+    const stillWithinBound = decay.sweep(10, 10, h, p)
+    expect(stillWithinBound).toEqual([])
+    expect(h.has("k")).toBe(true)
+
+    const pastBound = decay.sweep(11, 10, h, p)
+    expect(pastBound).toEqual(["k"])
+    expect(h.has("k")).toBe(false)
+  })
+
+  it("a touch() resets the staleness clock, so continued reinforcement never decays", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    const decay = createDecayTracker<string, Attrs>()
+
+    seed(h, p, "k", 0)
+    decay.touch("k", 0)
+    decay.sweep(5, 10, h, p)
+    decay.touch("k", 5) // reinforced again before the bound
+
+    const evicted = decay.sweep(14, 10, h, p) // 14 - 5 = 9, still within bound
+    expect(evicted).toEqual([])
+    expect(h.has("k")).toBe(true)
+  })
+
+  it("reset() clears all decay bookkeeping — gated to a single epoch", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    const decay = createDecayTracker<string, Attrs>()
+
+    seed(h, p, "k", 0)
+    decay.touch("k", 0)
+    decay.reset()
+
+    // With bookkeeping cleared, a sweep long past any bound finds nothing to evict.
+    const evicted = decay.sweep(1000, 10, h, p)
+    expect(evicted).toEqual([])
+  })
+
+  it("never confuses physical disconnection with logical deletion — sweep only consults its own touch() ticks, not DOM connectivity", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    const decay = createDecayTracker<string, Attrs>()
+
+    seed(h, p, "k", 0)
+    decay.touch("k", 0)
+
+    // No DOM API appears anywhere in this module or test; eviction is purely
+    // a function of elapsed ticks since the last touch().
+    const evicted = decay.sweep(5, 10, h, p)
+    expect(evicted).toEqual([])
+    expect(h.has("k")).toBe(true)
+  })
+})

--- a/extensions/transport/src/estimator/decay.ts
+++ b/extensions/transport/src/estimator/decay.ts
@@ -1,0 +1,61 @@
+/**
+ * Remark 3.3 (Tombstoning versus decay) — canon §3.3.
+ *
+ * Absence of continued evidence is strictly weaker than an explicit
+ * mismatch (Corollary 4.1.1's continuity check, S5): a key briefly
+ * unobserved must not be evicted — that would false-positive on
+ * virtualization (Proposition 4.1) — but a key absent past a declared
+ * staleness bound is evicted by a controlled, gated downward move, the one
+ * sanctioned departure from §5's strict monotonicity. Gating: decay
+ * bookkeeping is scoped to a single epoch (`reset()` clears it, wired to
+ * the same Session reset (S3) that begins a fresh epoch) and it never
+ * substitutes for the continuity check's *immediate* signal — decay only
+ * ever handles "unobserved for a while," never "known to be gone now."
+ */
+
+import type { MutableHypothesis } from "./hypothesis"
+import type { ProvenanceStore } from "./update"
+
+export type DecayTracker<K, Attr> = {
+  /** Records that `key` was reinforced by evidence at local tick `tick`. */
+  touch(key: K, tick: number): void
+  /**
+   * Evicts every key whose most recent reinforcement is more than
+   * `staleBound` ticks before `now`. A single call is one round of
+   * sweeping — repeated, sustained absence, never a single observation,
+   * is what drives an eviction. Returns the evicted keys.
+   */
+  sweep(
+    now: number,
+    staleBound: number,
+    hypothesis: MutableHypothesis<K, Attr>,
+    provenance: ProvenanceStore<K>
+  ): Array<K>
+  /** Clears all decay bookkeeping — call on an epoch reset (Definition 5.4). */
+  reset(): void
+}
+
+export function createDecayTracker<K, Attr>(): DecayTracker<K, Attr> {
+  const lastSeen = new Map<K, number>()
+
+  return {
+    touch(key: K, tick: number): void {
+      lastSeen.set(key, tick)
+    },
+    sweep(now, staleBound, hypothesis, provenance): Array<K> {
+      const evicted: Array<K> = []
+      for (const [key, seenAt] of lastSeen) {
+        if (now - seenAt > staleBound) {
+          hypothesis.delete(key)
+          provenance.delete(key)
+          lastSeen.delete(key)
+          evicted.push(key)
+        }
+      }
+      return evicted
+    },
+    reset(): void {
+      lastSeen.clear()
+    },
+  }
+}

--- a/extensions/transport/src/estimator/epoch-dominance.test.ts
+++ b/extensions/transport/src/estimator/epoch-dominance.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { createHypothesis } from "./hypothesis"
+import { compareTierOnly } from "./order"
+import { createProvenanceStore, update, type Evidence } from "./update"
+
+/**
+ * Lemma 5.2 (Necessity of epoch dominance) — canon §5.4.
+ *
+ * A physical carrier is recycled by the vendor's rendering strategy so
+ * that the logical key it renders changes across a navigation boundary.
+ * A high-tier, user-driven property ("dismissed") was recorded against
+ * the key while it denoted the *old* occupant; after recycling, a fresh,
+ * low-tier ("raw") observation arrives in the *new* epoch for whatever now
+ * occupies that key. Under the shipped, epoch-dominant order
+ * (`compareEvidentiary`), the new epoch's evidence wins regardless of
+ * tier, so the stale "dismissed" value does not leak onto the new
+ * occupant. Under a tier-only order (`compareTierOnly`, Lemma 5.2's
+ * counterexample), the stale high-tier value survives — exactly the
+ * violation the lemma proves.
+ */
+describe("estimator — Lemma 5.2 (epoch dominance)", () => {
+  const staleDismissal: Evidence<string, { dismissed: boolean }> = {
+    key: "k",
+    epoch: 1,
+    tier: "full",
+    timestamp: 100,
+    attrs: { dismissed: true },
+  }
+
+  const freshPostRecycling: Evidence<string, { dismissed: boolean }> = {
+    key: "k",
+    epoch: 2,
+    tier: "raw",
+    timestamp: 5,
+    attrs: { dismissed: false },
+  }
+
+  it("PASSES against the shipped comparator: the new epoch's evidence wins even though its tier is lower", () => {
+    const h = createHypothesis<string, { dismissed: boolean }>()
+    const p = createProvenanceStore<string>()
+
+    update(h, p, staleDismissal)
+    update(h, p, freshPostRecycling)
+
+    expect(h.get("k")).toEqual({ dismissed: false })
+  })
+
+  it("FAILS against the epoch-less, tier-only comparator: the stale high-tier value silently survives (Lemma 5.2's counterexample, reproduced)", () => {
+    const h = createHypothesis<string, { dismissed: boolean }>()
+    const p = createProvenanceStore<string>()
+
+    update(h, p, staleDismissal, compareTierOnly)
+    update(h, p, freshPostRecycling, compareTierOnly)
+
+    // This is the violation Lemma 5.2 proves is reachable without epoch
+    // dominance: the stale "dismissed: true" value from the old occupant
+    // is still recorded against `k` after recycling, in violation of any
+    // invariant Φ distinguishing "reviewed" from "unreviewed" content.
+    expect(h.get("k")).toEqual({ dismissed: true })
+  })
+})

--- a/extensions/transport/src/estimator/hypothesis.test.ts
+++ b/extensions/transport/src/estimator/hypothesis.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { createHypothesis } from "./hypothesis"
+
+type Attrs = { readonly dismissed: boolean }
+
+describe("estimator/hypothesis", () => {
+  it("has() is false and get() is undefined for a key with no evidence yet (⊥)", () => {
+    const h = createHypothesis<string, Attrs>()
+    expect(h.has("k")).toBe(false)
+    expect(h.get("k")).toBeUndefined()
+  })
+
+  it("set() makes has()/get() agree", () => {
+    const h = createHypothesis<string, Attrs>()
+    h.set("k", { dismissed: true })
+    expect(h.has("k")).toBe(true)
+    expect(h.get("k")).toEqual({ dismissed: true })
+  })
+
+  it("delete() restores ⊥", () => {
+    const h = createHypothesis<string, Attrs>()
+    h.set("k", { dismissed: true })
+    h.delete("k")
+    expect(h.has("k")).toBe(false)
+    expect(h.get("k")).toBeUndefined()
+  })
+
+  it("keys() enumerates only keys with evidence", () => {
+    const h = createHypothesis<string, Attrs>()
+    h.set("a", { dismissed: true })
+    h.set("b", { dismissed: false })
+    expect(new Set(h.keys())).toEqual(new Set(["a", "b"]))
+  })
+})

--- a/extensions/transport/src/estimator/hypothesis.ts
+++ b/extensions/transport/src/estimator/hypothesis.ts
@@ -1,0 +1,37 @@
+/**
+ * Definition 5.1 (Hypothesis) — canon §5.1.
+ *
+ * The concrete, mutable realization of `contracts/hypothesis.ts`'s
+ * read-only `Hypothesis<K, Attr>` query surface. `⊥` ("no evidence yet")
+ * is modeled as key-absence — never as a stored `undefined` — so `has()`
+ * and `get()` always agree.
+ */
+
+import type { Hypothesis } from "../contracts/hypothesis"
+
+export type MutableHypothesis<K, Attr> = Hypothesis<K, Attr> & {
+  set(key: K, value: Attr): void
+  delete(key: K): void
+}
+
+export function createHypothesis<K, Attr>(): MutableHypothesis<K, Attr> {
+  const store = new Map<K, Attr>()
+
+  return {
+    get(key: K): Attr | undefined {
+      return store.get(key)
+    },
+    has(key: K): boolean {
+      return store.has(key)
+    },
+    keys(): Iterable<K> {
+      return store.keys()
+    },
+    set(key: K, value: Attr): void {
+      store.set(key, value)
+    },
+    delete(key: K): void {
+      store.delete(key)
+    },
+  }
+}

--- a/extensions/transport/src/estimator/order.test.ts
+++ b/extensions/transport/src/estimator/order.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import { compareEvidentiary, compareTierOnly, type Evidentiary } from "./order"
+
+function ev(
+  epoch: number,
+  tier: Evidentiary["tier"],
+  timestamp: number
+): Evidentiary {
+  return { epoch: epoch, tier, timestamp }
+}
+
+describe("estimator/order — compareEvidentiary (Definition 5.2)", () => {
+  it("epoch dominates tier: a later epoch always wins, regardless of tier", () => {
+    const later = ev(2, "raw", 0)
+    const earlier = ev(1, "full", 1000)
+    expect(compareEvidentiary(later, earlier)).toBeGreaterThan(0)
+  })
+
+  it("within the same epoch, tier dominates timestamp", () => {
+    const higherTier = ev(1, "full", 0)
+    const lowerTierLaterTimestamp = ev(1, "partial", 1000)
+    expect(
+      compareEvidentiary(higherTier, lowerTierLaterTimestamp)
+    ).toBeGreaterThan(0)
+  })
+
+  it("within the same (epoch, tier), timestamp breaks the tie", () => {
+    const later = ev(1, "full", 10)
+    const earlier = ev(1, "full", 5)
+    expect(compareEvidentiary(later, earlier)).toBeGreaterThan(0)
+  })
+
+  it("is total: any two evidentiary tuples are comparable", () => {
+    const a = ev(1, "raw", 0)
+    const b = ev(1, "raw", 0)
+    expect(compareEvidentiary(a, b)).toBe(0)
+  })
+
+  it("is anti-symmetric", () => {
+    const a = ev(2, "full", 5)
+    const b = ev(1, "raw", 999)
+    expect(Math.sign(compareEvidentiary(a, b))).toBe(
+      -Math.sign(compareEvidentiary(b, a))
+    )
+  })
+})
+
+describe("estimator/order — compareTierOnly (Lemma 5.2 counterexample comparator)", () => {
+  it("ignores epoch entirely — a later epoch does not win against a higher tier", () => {
+    const laterEpochLowerTier = ev(2, "raw", 0)
+    const earlierEpochHigherTier = ev(1, "full", 0)
+    expect(
+      compareTierOnly(laterEpochLowerTier, earlierEpochHigherTier)
+    ).toBeLessThan(0)
+  })
+})

--- a/extensions/transport/src/estimator/order.ts
+++ b/extensions/transport/src/estimator/order.ts
@@ -1,0 +1,48 @@
+/**
+ * Definition 5.2 (Per-key evidentiary order) — canon §5.2, Remark 5.1,
+ * Lemma 5.2 (necessity of epoch dominance).
+ *
+ * Tokens about a fixed key are compared by the lexicographic order
+ * `(epoch, tier, timestamp)`: epoch dominates tier dominates timestamp.
+ * Total by construction — a lexicographic product of totally ordered
+ * coordinates the estimator itself controls (Remark 5.1): epoch (S3) and
+ * tier (S5) are the estimator's own bookkeeping; timestamp is the
+ * channel's local clock, immune to cross-machine skew because it is never
+ * compared across two different observer instances.
+ */
+
+import { compareTiers, type ExtractionTier } from "../sensor/identity"
+import type { Epoch } from "../session/epoch"
+
+export type Evidentiary = {
+  readonly epoch: Epoch
+  readonly tier: ExtractionTier
+  readonly timestamp: number
+}
+
+/** `< 0` if `a ≺ b`, `0` if `a ≈ b`, `> 0` if `a ≻ b`. Epoch strictly dominates tier (Lemma 5.2). */
+export function compareEvidentiary(a: Evidentiary, b: Evidentiary): number {
+  if (a.epoch !== b.epoch) {
+    return a.epoch - b.epoch
+  }
+  const tierCmp = compareTiers(a.tier, b.tier)
+  if (tierCmp !== 0) {
+    return tierCmp
+  }
+  return a.timestamp - b.timestamp
+}
+
+/**
+ * Lemma 5.2's counterexample comparator — orders by `(tier, timestamp)`
+ * alone, omitting epoch entirely. Exported *only* for the Lemma 5.2
+ * regression test (`epoch-dominance.test.ts`): never wired into `update()`
+ * for real use. A recycled carrier's stale high-tier value survives under
+ * this comparator, which is exactly what that test observes failing.
+ */
+export function compareTierOnly(a: Evidentiary, b: Evidentiary): number {
+  const tierCmp = compareTiers(a.tier, b.tier)
+  if (tierCmp !== 0) {
+    return tierCmp
+  }
+  return a.timestamp - b.timestamp
+}

--- a/extensions/transport/src/estimator/purity.test.ts
+++ b/extensions/transport/src/estimator/purity.test.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+/**
+ * S6 acceptance criterion: "Estimator performs no mutation of `G_t` (no DOM
+ * writes anywhere in `estimator/`)." The Estimator only folds evidence into
+ * a hypothesis (Definition 5.3); §8 reserves DOM writes for the Actuator
+ * alone.
+ */
+
+const ESTIMATOR_DIR = dirname(fileURLToPath(import.meta.url))
+
+const MUTATING_CALL_PATTERNS: ReadonlyArray<RegExp> = [
+  /\.setAttribute\s*\(/,
+  /\.removeAttribute\s*\(/,
+  /\.style\s*[.=]/,
+  /\.appendChild\s*\(/,
+  /\.insertBefore\s*\(/,
+  /\.replaceChild\s*\(/,
+  /\.removeChild\s*\(/,
+  /\.remove\s*\(\s*\)/,
+  /\.innerHTML\s*=/,
+  /\.outerHTML\s*=/,
+  /\.textContent\s*=/,
+  /\.classList\.(add|remove|toggle|replace)\s*\(/,
+]
+
+function sourceFiles(dir: string): Array<string> {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+}
+
+describe("estimator/ purity — no DOM mutation", () => {
+  for (const file of sourceFiles(ESTIMATOR_DIR)) {
+    it(`${file} contains no DOM-mutating call`, () => {
+      const contents = readFileSync(join(ESTIMATOR_DIR, file), "utf8")
+      for (const pattern of MUTATING_CALL_PATTERNS) {
+        expect(contents).not.toMatch(pattern)
+      }
+    })
+  }
+})

--- a/extensions/transport/src/estimator/update.test.ts
+++ b/extensions/transport/src/estimator/update.test.ts
@@ -1,0 +1,152 @@
+import fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import type { ExtractionTier } from "../sensor/identity"
+import { createHypothesis } from "./hypothesis"
+import { compareEvidentiary, type Evidentiary } from "./order"
+import { createProvenanceStore, update, type Evidence } from "./update"
+
+type Attrs = { readonly seq: number }
+
+describe("estimator/update — U (Definition 5.3)", () => {
+  it("the first evidence for a key is always accepted (⊥ is dominated by anything)", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    update(h, p, {
+      key: "k",
+      epoch: 0,
+      tier: "raw",
+      timestamp: 0,
+      attrs: { seq: 1 },
+    })
+    expect(h.get("k")).toEqual({ seq: 1 })
+  })
+
+  it("higher-ranked evidence replaces lower-ranked evidence for the same key", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    update(h, p, {
+      key: "k",
+      epoch: 0,
+      tier: "raw",
+      timestamp: 0,
+      attrs: { seq: 1 },
+    })
+    update(h, p, {
+      key: "k",
+      epoch: 0,
+      tier: "full",
+      timestamp: 1,
+      attrs: { seq: 2 },
+    })
+    expect(h.get("k")).toEqual({ seq: 2 })
+  })
+
+  it("lower-ranked evidence arriving after does not overwrite a higher-ranked value", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    update(h, p, {
+      key: "k",
+      epoch: 0,
+      tier: "full",
+      timestamp: 10,
+      attrs: { seq: 2 },
+    })
+    update(h, p, {
+      key: "k",
+      epoch: 0,
+      tier: "raw",
+      timestamp: 100,
+      attrs: { seq: 1 },
+    })
+    expect(h.get("k")).toEqual({ seq: 2 })
+  })
+
+  it("performs no I/O and mutates only the hypothesis/provenance passed in", () => {
+    const h = createHypothesis<string, Attrs>()
+    const p = createProvenanceStore<string>()
+    const evidence: Evidence<string, Attrs> = {
+      key: "k",
+      epoch: 0,
+      tier: "full",
+      timestamp: 0,
+      attrs: { seq: 1 },
+    }
+    expect(() => update(h, p, evidence)).not.toThrow()
+    expect(p.get("k")).toEqual({ epoch: 0, tier: "full", timestamp: 0 })
+  })
+})
+
+// Theorem 5.1: fold of U over any permutation/duplication of a finite
+// multiset of tokens about a fixed key is independent of delivery order,
+// and equals max_⪯({Ĥ_0(k)} ∪ M).
+const tierArbitrary: fc.Arbitrary<ExtractionTier> = fc.constantFrom(
+  "raw",
+  "partial",
+  "full"
+)
+
+// `attrs` is a deterministic function of the evidentiary triple, not an
+// independently-random field: two evidences that rank equal under
+// compareEvidentiary must also carry equal attrs, or "the" maximum would be
+// ambiguous among ties, which is not what Theorem 5.1 claims.
+const evidenceArbitrary: fc.Arbitrary<Evidence<string, Attrs>> = fc
+  .record({
+    epoch: fc.integer({ min: 0, max: 4 }),
+    tier: tierArbitrary,
+    timestamp: fc.integer({ min: 0, max: 200 }),
+  })
+  .map(({ epoch, tier, timestamp }) => ({
+    key: "k",
+    epoch: epoch,
+    tier,
+    timestamp,
+    attrs: { seq: timestamp },
+  }))
+
+function maxEvidentiary<T extends Evidentiary>(evs: ReadonlyArray<T>): T {
+  const first = evs[0]
+  if (first === undefined) {
+    throw new Error("empty multiset")
+  }
+  return evs.reduce(
+    (best, e) => (compareEvidentiary(e, best) >= 0 ? e : best),
+    first
+  )
+}
+
+function fold(
+  evidenceList: ReadonlyArray<Evidence<string, Attrs>>
+): Attrs | undefined {
+  const h = createHypothesis<string, Attrs>()
+  const p = createProvenanceStore<string>()
+  for (const e of evidenceList) {
+    update(h, p, e)
+  }
+  return h.get("k")
+}
+
+describe("estimator/update — Theorem 5.1 (order-independence of the estimator)", () => {
+  it("folding U over any permutation or duplication of a finite token multiset yields the same final hypothesis value", () => {
+    fc.assert(
+      fc.property(
+        fc.array(evidenceArbitrary, { minLength: 1, maxLength: 30 }),
+        (evidenceList) => {
+          const expected = maxEvidentiary(evidenceList)
+
+          const forward = fold(evidenceList)
+          const reversed = fold([...evidenceList].reverse())
+          const sorted = fold(
+            [...evidenceList].sort((a, b) => compareEvidentiary(a, b))
+          )
+          const duplicated = fold([...evidenceList, ...evidenceList])
+
+          expect(forward).toEqual(expected.attrs)
+          expect(reversed).toEqual(expected.attrs)
+          expect(sorted).toEqual(expected.attrs)
+          expect(duplicated).toEqual(expected.attrs)
+        }
+      )
+    )
+  })
+})

--- a/extensions/transport/src/estimator/update.ts
+++ b/extensions/transport/src/estimator/update.ts
@@ -1,0 +1,51 @@
+/**
+ * Definition 5.3 (Monotonic update), Theorem 5.1 (order-independence) —
+ * canon §5.3.
+ *
+ * `U(Ĥ, s) = Ĥ with entry k replaced by max_⪯(Ĥ(k), s)`. Pure: no I/O, no
+ * DOM access, no mutation beyond the `MutableHypothesis` and
+ * `ProvenanceStore` passed in.
+ */
+
+import type { MutableHypothesis } from "./hypothesis"
+import { compareEvidentiary, type Evidentiary } from "./order"
+
+export type Evidence<K, Attr> = Evidentiary & {
+  readonly key: K
+  readonly attrs: Attr
+}
+
+/**
+ * Per-key evidentiary provenance — the `(epoch, tier, timestamp)` of
+ * whichever evidence currently wins `Ĥ(k)`. Not part of the public
+ * `Hypothesis` query surface (Definition 5.1 only promises `Attr`); kept
+ * separately so future evidence has something to compare against.
+ */
+export type ProvenanceStore<K> = Map<K, Evidentiary>
+
+export function createProvenanceStore<K>(): ProvenanceStore<K> {
+  return new Map()
+}
+
+/**
+ * `U(Ĥ, s)`: folds one piece of evidence into the hypothesis. `compare`
+ * defaults to `compareEvidentiary` (the shipped, epoch-dominant order); an
+ * injected comparator exists only so the Lemma 5.2 regression test can
+ * exercise the epoch-less counterexample without duplicating this function.
+ */
+export function update<K, Attr>(
+  hypothesis: MutableHypothesis<K, Attr>,
+  provenance: ProvenanceStore<K>,
+  evidence: Evidence<K, Attr>,
+  compare: (a: Evidentiary, b: Evidentiary) => number = compareEvidentiary
+): void {
+  const previous = provenance.get(evidence.key)
+  if (previous === undefined || compare(evidence, previous) >= 0) {
+    provenance.set(evidence.key, {
+      epoch: evidence.epoch,
+      tier: evidence.tier,
+      timestamp: evidence.timestamp,
+    })
+    hypothesis.set(evidence.key, evidence.attrs)
+  }
+}

--- a/extensions/transport/src/lifecycle/teardown.test.ts
+++ b/extensions/transport/src/lifecycle/teardown.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createCoalescer } from "../scheduler/reconcile"
+import { attachMutationObserver, createEventChannel } from "../sensor/observer"
+import { createSessionLifecycle } from "../session/lifecycle"
+import { teardownContent, teardownDocument, type Disposable } from "./teardown"
+
+describe("lifecycle/teardown — teardownContent (Theorem D.1(a))", () => {
+  it("disposes every resource in the registry", () => {
+    const disposeA = vi.fn()
+    const disposeB = vi.fn()
+    const session = createSessionLifecycle()
+
+    teardownContent([disposeA, disposeB], session)
+
+    expect(disposeA).toHaveBeenCalledTimes(1)
+    expect(disposeB).toHaveBeenCalledTimes(1)
+  })
+
+  it("advances the epoch via Session.resetContent(), never touching Bootstrap", () => {
+    const teardownBootstrap = vi.fn()
+    const session = createSessionLifecycle()
+    const before = session.epoch
+
+    teardownContent([], session)
+
+    expect(session.epoch).not.toBe(before)
+    expect(teardownBootstrap).not.toHaveBeenCalled()
+  })
+})
+
+describe("lifecycle/teardown — teardownDocument (Theorem D.1(b))", () => {
+  it("disposes every resource, tears down Bootstrap, and resets via Session.resetDocument()", () => {
+    const dispose = vi.fn()
+    const teardownBootstrap = vi.fn()
+    const session = createSessionLifecycle()
+    const before = session.epoch
+
+    teardownDocument([dispose], session, teardownBootstrap)
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(teardownBootstrap).toHaveBeenCalledTimes(1)
+    expect(session.epoch).not.toBe(before)
+  })
+
+  it("disposes resources before tearing down Bootstrap", () => {
+    const order: Array<string> = []
+    const dispose: Disposable = () => order.push("dispose")
+    const teardownBootstrap = (): void => {
+      order.push("bootstrap")
+    }
+    const session = createSessionLifecycle()
+
+    teardownDocument([dispose], session, teardownBootstrap)
+
+    expect(order).toEqual(["dispose", "bootstrap"])
+  })
+})
+
+describe("lifecycle/teardown — no resource leak across repeated content-only cycles", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("teardownContent() leaves zero dangling MutationObserver/timer registrations from Sensor or Scheduler", async () => {
+    const target = document.createElement("div")
+    document.body.appendChild(target)
+    const session = createSessionLifecycle()
+
+    let ingestedCount = 0
+    const channel = createEventChannel<
+      MutationRecord,
+      string,
+      { text: string }
+    >({
+      toTokens: () => [{ key: "k", attrs: { text: "k" }, timestamp: 0 }],
+      currentEpoch: () => session.epoch,
+      emit: () => {
+        ingestedCount++
+      },
+    })
+    const disconnectObserver = attachMutationObserver(target, channel, {
+      attributes: true,
+    })
+
+    const onFire = vi.fn()
+    const coalescer = createCoalescer({ debounceMs: 50 }, onFire)
+    coalescer.trigger() // a pending, not-yet-fired timer
+
+    const disposables: ReadonlyArray<Disposable> = [
+      disconnectObserver,
+      coalescer.dispose,
+    ]
+
+    teardownContent(disposables, session)
+
+    // The observer is disconnected: further mutation produces no tokens.
+    target.setAttribute("data-x", "1")
+    await Promise.resolve()
+    expect(ingestedCount).toBe(0)
+
+    // The coalescer's pending timer was cancelled: it never fires.
+    vi.advanceTimersByTime(1000)
+    expect(onFire).not.toHaveBeenCalled()
+
+    target.remove()
+  })
+})

--- a/extensions/transport/src/lifecycle/teardown.ts
+++ b/extensions/transport/src/lifecycle/teardown.ts
@@ -1,0 +1,47 @@
+/**
+ * Theorem D.1 (Bootstrap persistence), Corollary D.1.1 — canon §D.0.
+ *
+ * Wires the two reset paths Theorem D.1 distinguishes:
+ *
+ * - `teardownContent()` ends the content lifetime L_C without touching
+ *   Bootstrap — case (a), a same-document (SPA) navigation. Paired with a
+ *   fresh content-session init and Session's `resetContent()` (S3), this
+ *   is the SPA-nav path.
+ * - `teardownDocument()` additionally tears down Bootstrap itself — case
+ *   (b), a refresh. Paired with a Bootstrap reinstall and Session's
+ *   `resetDocument()`, this is the refresh path.
+ *
+ * This module owns no concrete resource itself: `disposables` is a
+ * caller-supplied registry of every disposable a content session created
+ * (MutationObserver disconnects, event-listener removals, Scheduler
+ * timers) — Lifecycle only sequences their disposal against Session's
+ * reset, never reaches into Sensor/Estimator/Scheduler internals directly.
+ */
+
+import type { SessionLifecycle } from "../session/lifecycle"
+
+export type Disposable = () => void
+
+/** Disposes every resource the ending content session owns, then advances the epoch without touching Bootstrap (Theorem D.1(a)). */
+export function teardownContent(
+  disposables: ReadonlyArray<Disposable>,
+  session: SessionLifecycle
+): void {
+  for (const dispose of disposables) {
+    dispose()
+  }
+  session.resetContent()
+}
+
+/** As `teardownContent()`, plus tearing down Bootstrap itself (Theorem D.1(b)). */
+export function teardownDocument(
+  disposables: ReadonlyArray<Disposable>,
+  session: SessionLifecycle,
+  teardownBootstrap: () => void
+): void {
+  for (const dispose of disposables) {
+    dispose()
+  }
+  teardownBootstrap()
+  session.resetDocument()
+}

--- a/extensions/transport/src/lifecycle/theorem-d1.test.ts
+++ b/extensions/transport/src/lifecycle/theorem-d1.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  install,
+  installedAt,
+  isInstalled,
+  uninstall,
+} from "../bootstrap/static"
+import { createSessionLifecycle } from "../session/lifecycle"
+import { teardownContent, teardownDocument } from "./teardown"
+
+function freshRoot(): Element {
+  return document.implementation.createHTMLDocument("").documentElement
+}
+
+describe("lifecycle — Theorem D.1(a): same-document navigation", () => {
+  it("Bootstrap's sentinel is the same installed instance across N consecutive SPA navigations; only epoch changes", () => {
+    const root = freshRoot()
+    vi.spyOn(Date, "now").mockReturnValue(1_000)
+    const bootstrap = install(root)
+    vi.restoreAllMocks()
+
+    const session = createSessionLifecycle()
+    const epochs: Array<number> = [session.epoch]
+
+    for (let i = 0; i < 5; i++) {
+      teardownContent([], session)
+      epochs.push(session.epoch)
+
+      // "new content init" — the SPA-nav path never reinstalls Bootstrap.
+      expect(installedAt(root)).toBe(bootstrap.installedAt)
+      expect(isInstalled(root)).toBe(true)
+    }
+
+    // The epoch strictly advanced on every navigation.
+    let previous = epochs[0]
+    for (const epoch of epochs.slice(1)) {
+      expect(previous).toBeDefined()
+      expect(epoch).toBeGreaterThan(previous ?? -Infinity)
+      previous = epoch
+    }
+  })
+})
+
+describe("lifecycle — Theorem D.1(b): refresh", () => {
+  it("Bootstrap's sentinel is a new installation and the epoch resets alongside it", () => {
+    const root = freshRoot()
+    vi.spyOn(Date, "now").mockReturnValueOnce(1_000)
+    const originalInstall = install(root)
+    vi.restoreAllMocks()
+
+    const session = createSessionLifecycle()
+    teardownContent([], session) // some content-only activity before the refresh
+    const epochBeforeRefresh = session.epoch
+
+    vi.spyOn(Date, "now").mockReturnValueOnce(2_000)
+    teardownDocument([], session, () => uninstall(root))
+    const reinstalled = install(root) // "Bootstrap reinstall" + "new content init" per the refresh path
+    vi.restoreAllMocks()
+
+    expect(reinstalled.installedAt).not.toBe(originalInstall.installedAt)
+    expect(session.epoch).toBeGreaterThan(epochBeforeRefresh)
+  })
+})

--- a/extensions/transport/src/scheduler/backoff.test.ts
+++ b/extensions/transport/src/scheduler/backoff.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  advanceRetry,
+  initialRetryState,
+  isExhausted,
+  nextDelay,
+  type BackoffPolicy,
+} from "./backoff"
+
+const policy: BackoffPolicy = {
+  initialDelayMs: 100,
+  maxDelayMs: 1000,
+  factor: 2,
+  maxAttempts: 5,
+}
+
+describe("scheduler/backoff — nextDelay", () => {
+  it("grows exponentially by the configured factor", () => {
+    expect(nextDelay(policy, 0)).toBe(100)
+    expect(nextDelay(policy, 1)).toBe(200)
+    expect(nextDelay(policy, 2)).toBe(400)
+  })
+
+  it("never exceeds maxDelayMs", () => {
+    expect(nextDelay(policy, 10)).toBe(1000)
+  })
+})
+
+describe("scheduler/backoff — isExhausted / advanceRetry", () => {
+  it("is not exhausted before maxAttempts", () => {
+    expect(isExhausted(policy, 0)).toBe(false)
+    expect(isExhausted(policy, policy.maxAttempts - 1)).toBe(false)
+  })
+
+  it("is exhausted at or past maxAttempts", () => {
+    expect(isExhausted(policy, policy.maxAttempts)).toBe(true)
+  })
+
+  it("the retry sequence terminates — it is never silently infinite without a cap", () => {
+    let state = initialRetryState()
+    let steps = 0
+    for (;;) {
+      const next = advanceRetry(policy, state)
+      if (next === undefined) {
+        break
+      }
+      state = next.state
+      steps++
+      if (steps > policy.maxAttempts + 1) {
+        throw new Error("advanceRetry did not terminate within maxAttempts")
+      }
+    }
+    expect(steps).toBe(policy.maxAttempts)
+  })
+
+  it("each step's delay matches nextDelay for its attempt number", () => {
+    const state = initialRetryState()
+    const step = advanceRetry(policy, state)
+    expect(step?.delayMs).toBe(nextDelay(policy, 0))
+    expect(step?.state.attempt).toBe(1)
+  })
+})

--- a/extensions/transport/src/scheduler/backoff.ts
+++ b/extensions/transport/src/scheduler/backoff.ts
@@ -1,0 +1,51 @@
+/**
+ * Remark 3.2 (poll cadence) — canon §3.3.
+ *
+ * Backoff/retry policy for the Sensor's poll sub-channel (S4). Fully
+ * parameterized: `some-censor`'s 500ms interval is a *consumer's* choice,
+ * not transport's, so no interval is hard-coded here. `maxAttempts` is
+ * mandatory — a retry sequence is always bounded, never silently infinite.
+ */
+
+export type BackoffPolicy = {
+  readonly initialDelayMs: number
+  readonly maxDelayMs: number
+  readonly factor: number
+  readonly maxAttempts: number
+}
+
+export function nextDelay(policy: BackoffPolicy, attempt: number): number {
+  const delay = policy.initialDelayMs * policy.factor ** attempt
+  return Math.min(delay, policy.maxDelayMs)
+}
+
+export function isExhausted(policy: BackoffPolicy, attempt: number): boolean {
+  return attempt >= policy.maxAttempts
+}
+
+export type RetryState = {
+  readonly attempt: number
+}
+
+export function initialRetryState(): RetryState {
+  return { attempt: 0 }
+}
+
+export type RetryStep = {
+  readonly state: RetryState
+  readonly delayMs: number
+}
+
+/** Advances the retry sequence one step, or `undefined` once `maxAttempts` is reached — the bound is enforced here, not left to the caller. */
+export function advanceRetry(
+  policy: BackoffPolicy,
+  state: RetryState
+): RetryStep | undefined {
+  if (isExhausted(policy, state.attempt)) {
+    return undefined
+  }
+  return {
+    state: { attempt: state.attempt + 1 },
+    delayMs: nextDelay(policy, state.attempt),
+  }
+}

--- a/extensions/transport/src/scheduler/config.test.ts
+++ b/extensions/transport/src/scheduler/config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { declaredR, type SchedulerConfig } from "./config"
+
+describe("scheduler/config — declaredR (Definition 7.2's R)", () => {
+  it("is a single, discoverable accessor for the configured bound", () => {
+    const config: SchedulerConfig = {
+      reconcile: { debounceMs: 50 },
+      poll: {
+        initialDelayMs: 500,
+        maxDelayMs: 500,
+        factor: 1,
+        maxAttempts: 100,
+      },
+      boundedDeliveryMs: 2000,
+    }
+    expect(declaredR(config)).toBe(2000)
+  })
+})

--- a/extensions/transport/src/scheduler/config.ts
+++ b/extensions/transport/src/scheduler/config.ts
@@ -1,0 +1,28 @@
+/**
+ * Definition 7.2 (R-bounded delivery), §8.3 conformance checklist —
+ * canon §7.
+ *
+ * `R` must be a single, discoverable configuration value (§8.3's
+ * conformance requirement), not scattered across modules — this is that
+ * one place.
+ */
+
+import type { BackoffPolicy } from "./backoff"
+import type { ReconcilePolicy } from "./reconcile"
+
+export type SchedulerConfig = {
+  readonly reconcile: ReconcilePolicy
+  readonly poll: BackoffPolicy
+  /**
+   * Definition 7.2's R: the driver's declared bound within which every
+   * mutation realized at or before round t0 is guaranteed a delivered
+   * token. Used by the conformance suite (S11) to assert Theorem 7.1's
+   * recovery bound is actually met within it.
+   */
+  readonly boundedDeliveryMs: number
+}
+
+/** The single, discoverable accessor for Definition 7.2's R. */
+export function declaredR(config: SchedulerConfig): number {
+  return config.boundedDeliveryMs
+}

--- a/extensions/transport/src/scheduler/reconcile.test.ts
+++ b/extensions/transport/src/scheduler/reconcile.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createCoalescer } from "./reconcile"
+
+describe("scheduler/reconcile — createCoalescer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("a burst of N triggers within one debounce window fires onFire exactly once", () => {
+    const onFire = vi.fn()
+    const coalescer = createCoalescer({ debounceMs: 50 }, onFire)
+
+    for (let i = 0; i < 10; i++) {
+      coalescer.trigger()
+      vi.advanceTimersByTime(10) // stays within the 50ms window each time
+    }
+
+    expect(onFire).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(50)
+
+    expect(onFire).toHaveBeenCalledTimes(1)
+  })
+
+  it("triggers separated by more than the debounce window fire independently", () => {
+    const onFire = vi.fn()
+    const coalescer = createCoalescer({ debounceMs: 50 }, onFire)
+
+    coalescer.trigger()
+    vi.advanceTimersByTime(60)
+    expect(onFire).toHaveBeenCalledTimes(1)
+
+    coalescer.trigger()
+    vi.advanceTimersByTime(60)
+    expect(onFire).toHaveBeenCalledTimes(2)
+  })
+
+  it("dispose() cancels a pending coalesced invocation", () => {
+    const onFire = vi.fn()
+    const coalescer = createCoalescer({ debounceMs: 50 }, onFire)
+
+    coalescer.trigger()
+    coalescer.dispose()
+    vi.advanceTimersByTime(1000)
+
+    expect(onFire).not.toHaveBeenCalled()
+  })
+
+  it("decides only *when*, never *what* — onFire takes no arguments describing a decision", () => {
+    const onFire = vi.fn()
+    const coalescer = createCoalescer({ debounceMs: 10 }, onFire)
+    coalescer.trigger()
+    vi.advanceTimersByTime(10)
+    expect(onFire).toHaveBeenCalledWith()
+  })
+})

--- a/extensions/transport/src/scheduler/reconcile.ts
+++ b/extensions/transport/src/scheduler/reconcile.ts
@@ -1,0 +1,59 @@
+/**
+ * §8's operational semantics leave "when does (PLAN) run" implicit; this
+ * module is where that cadence actually lives — a trigger coalescer that
+ * batches/debounces ingestion bursts before invoking the Adapter. The
+ * canon takes no position on the "correct" cadence, only that one must be
+ * declared (§8.3's conformance checklist), so no default is hard-coded
+ * here. No decision logic lives in this module — only *when* to ask the
+ * Adapter, never *what* to ask it.
+ */
+
+export type ReconcilePolicy = {
+  /** A burst of triggers within this window (ms) coalesces into one invocation. */
+  readonly debounceMs: number
+}
+
+export type TimerHandle = ReturnType<typeof setTimeout>
+
+export type SchedulerPrimitives = {
+  readonly setTimer: (callback: () => void, delayMs: number) => TimerHandle
+  readonly clearTimer: (handle: TimerHandle) => void
+}
+
+const defaultPrimitives: SchedulerPrimitives = {
+  setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimer: (handle) => clearTimeout(handle),
+}
+
+export type Coalescer = {
+  /** Signals that new evidence arrived; coalesces bursts per the configured policy. */
+  trigger(): void
+  /** Cancels any pending coalesced invocation and releases its timer. */
+  dispose(): void
+}
+
+export function createCoalescer(
+  policy: ReconcilePolicy,
+  onFire: () => void,
+  primitives: SchedulerPrimitives = defaultPrimitives
+): Coalescer {
+  let pending: TimerHandle | undefined
+
+  return {
+    trigger(): void {
+      if (pending !== undefined) {
+        primitives.clearTimer(pending)
+      }
+      pending = primitives.setTimer(() => {
+        pending = undefined
+        onFire()
+      }, policy.debounceMs)
+    },
+    dispose(): void {
+      if (pending !== undefined) {
+        primitives.clearTimer(pending)
+        pending = undefined
+      }
+    },
+  }
+}

--- a/extensions/transport/src/sensor/channel.test.ts
+++ b/extensions/transport/src/sensor/channel.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import { createHybridChannel } from "./channel"
+import type { SensedToken } from "./observer"
+
+type Attrs = { readonly text: string }
+
+function token(
+  key: string,
+  timestamp: number,
+  epoch: number
+): SensedToken<string, Attrs> {
+  return { key, attrs: { text: key }, timestamp, epoch }
+}
+
+describe("sensor/channel — createHybridChannel", () => {
+  it("merges pushes from both sub-channels into one queue (SS = SS_event ∪ SS_poll)", () => {
+    const channel = createHybridChannel<string, Attrs>()
+
+    channel.queue.push(token("from-event", 1, 0))
+    channel.queue.push(token("from-poll", 2, 0))
+
+    expect(channel.queue.length).toBe(2)
+  })
+
+  it("drain() returns tokens in arrival order and empties the queue", () => {
+    const channel = createHybridChannel<string, Attrs>()
+    channel.queue.push(token("a", 1, 0))
+    channel.queue.push(token("b", 2, 0))
+
+    const drained = channel.queue.drain()
+
+    expect(drained.map((t) => t.key)).toEqual(["a", "b"])
+    expect(channel.queue.length).toBe(0)
+  })
+
+  it("makes no attempt to reorder or deduplicate — that is the Estimator's job (§8 stage separation)", () => {
+    const channel = createHybridChannel<string, Attrs>()
+    channel.queue.push(token("k", 5, 0))
+    channel.queue.push(token("k", 1, 0))
+    channel.queue.push(token("k", 5, 0))
+
+    const drained = channel.queue.drain()
+
+    expect(drained.map((t) => t.timestamp)).toEqual([5, 1, 5])
+  })
+})

--- a/extensions/transport/src/sensor/channel.ts
+++ b/extensions/transport/src/sensor/channel.ts
@@ -1,0 +1,40 @@
+/**
+ * Definition 3.3 (Hybrid channel) — canon §3. `SS = SS_event ∪ SS_poll`,
+ * exposed to the Estimator (S6) as a single token queue. This module owns
+ * nothing beyond token production: it never interprets or reorders what it
+ * holds (that ordering is Definition 5.2's job, not this queue's).
+ */
+
+import type { SensedToken } from "./observer"
+
+export type TokenQueue<K, Attr> = {
+  readonly length: number
+  push(token: SensedToken<K, Attr>): void
+  /** Removes and returns every token currently queued, in arrival order. */
+  drain(): Array<SensedToken<K, Attr>>
+}
+
+export function createTokenQueue<K, Attr>(): TokenQueue<K, Attr> {
+  const queue: Array<SensedToken<K, Attr>> = []
+
+  return {
+    get length(): number {
+      return queue.length
+    },
+    push(token: SensedToken<K, Attr>): void {
+      queue.push(token)
+    },
+    drain(): Array<SensedToken<K, Attr>> {
+      return queue.splice(0, queue.length)
+    },
+  }
+}
+
+export type HybridChannel<K, Attr> = {
+  /** The merged `SS_event ∪ SS_poll` token stream. Both sub-channels' `emit` push here. */
+  readonly queue: TokenQueue<K, Attr>
+}
+
+export function createHybridChannel<K, Attr>(): HybridChannel<K, Attr> {
+  return { queue: createTokenQueue<K, Attr>() }
+}

--- a/extensions/transport/src/sensor/fuzz.test.ts
+++ b/extensions/transport/src/sensor/fuzz.test.ts
@@ -1,0 +1,86 @@
+import fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { createEventChannel, type SensedToken } from "./observer"
+
+/**
+ * Theorem 5.1 (order-independence of the estimator) requires only that its
+ * *input* — the channel's output multiset — carry no ordering information
+ * the fold depends on. This file does not re-implement the Estimator (S6);
+ * it proves the Channel's (S4) output shape is fold-compatible: an
+ * unordered, duplication-tolerant sequence of plain tokens, with no attempt
+ * by the channel itself to fix order or drop duplicates (Axioms 3.1–3.3).
+ */
+
+type Attrs = { readonly text: string }
+
+// A local stand-in for Definition 5.3's max_⪯, restricted to the two
+// coordinates the channel controls (epoch, timestamp) — tier (S5) and the
+// full canon order (S6) are out of scope here.
+function maxToken(
+  a: SensedToken<string, Attrs> | undefined,
+  b: SensedToken<string, Attrs>
+): SensedToken<string, Attrs> {
+  if (a === undefined) return b
+  if (a.epoch !== b.epoch) return a.epoch > b.epoch ? a : b
+  return a.timestamp >= b.timestamp ? a : b
+}
+
+function fold(
+  tokens: ReadonlyArray<SensedToken<string, Attrs>>
+): SensedToken<string, Attrs> | undefined {
+  return tokens.reduce<SensedToken<string, Attrs> | undefined>(
+    maxToken,
+    undefined
+  )
+}
+
+function ingestAll(
+  timestamps: ReadonlyArray<number>
+): Array<SensedToken<string, Attrs>> {
+  const emitted: Array<SensedToken<string, Attrs>> = []
+  const channel = createEventChannel<number, string, Attrs>({
+    toTokens: (raw) => [{ key: "k", attrs: { text: "k" }, timestamp: raw }],
+    currentEpoch: () => 0,
+    emit: (token) => emitted.push(token),
+  })
+
+  for (const ts of timestamps) {
+    channel.ingest(ts)
+  }
+  return emitted
+}
+
+describe("sensor — Theorem 5.1 precondition (fuzz)", () => {
+  it("the channel's output folds to the same maximum under any permutation or duplication of an arbitrary delivery multiset", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer({ min: 0, max: 1000 }), {
+          minLength: 1,
+          maxLength: 40,
+        }),
+        (timestamps) => {
+          const emitted = ingestAll(timestamps)
+          const expectedMax = Math.max(...timestamps)
+
+          const forward = fold(emitted)
+          const reversed = fold([...emitted].reverse())
+          const sorted = fold(
+            [...emitted].sort((a, b) => a.timestamp - b.timestamp)
+          )
+          const duplicated = fold([...emitted, ...emitted])
+
+          expect(forward?.timestamp).toBe(expectedMax)
+          expect(reversed?.timestamp).toBe(expectedMax)
+          expect(sorted?.timestamp).toBe(expectedMax)
+          expect(duplicated?.timestamp).toBe(expectedMax)
+        }
+      )
+    )
+  })
+
+  it("emits lossy/duplicate/reordered deliveries verbatim, attempting no fix-up of its own (§8 stage separation)", () => {
+    const emitted = ingestAll([5, 1, 5, 3])
+    expect(emitted.map((t) => t.timestamp)).toEqual([5, 1, 5, 3])
+  })
+})

--- a/extensions/transport/src/sensor/identity.test.ts
+++ b/extensions/transport/src/sensor/identity.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  compareTiers,
+  createContinuityCheck,
+  identify,
+  type Extractor,
+} from "./identity"
+
+type Attrs = { readonly videoId?: string }
+
+describe("sensor/identity — tier order (Definition 4.1)", () => {
+  it("is total: raw ≺ partial ≺ full", () => {
+    expect(compareTiers("raw", "partial")).toBeLessThan(0)
+    expect(compareTiers("partial", "full")).toBeLessThan(0)
+    expect(compareTiers("raw", "full")).toBeLessThan(0)
+  })
+
+  it("is reflexive under equality", () => {
+    expect(compareTiers("raw", "raw")).toBe(0)
+    expect(compareTiers("partial", "partial")).toBe(0)
+    expect(compareTiers("full", "full")).toBe(0)
+  })
+
+  it("is anti-symmetric (comparator flips sign when arguments swap)", () => {
+    expect(compareTiers("full", "raw")).toBeGreaterThan(0)
+    expect(compareTiers("partial", "raw")).toBeGreaterThan(0)
+  })
+})
+
+describe("sensor/identity — continuity check (Corollary 4.1.1)", () => {
+  it("emits no implicit deletion the first time a carrier is seen", () => {
+    const continuity = createContinuityCheck<string, string>()
+    expect(continuity.observe("node1", "vidA")).toBeUndefined()
+  })
+
+  it("emits no implicit deletion when the same key is re-observed", () => {
+    const continuity = createContinuityCheck<string, string>()
+    continuity.observe("node1", "vidA")
+    expect(continuity.observe("node1", "vidA")).toBeUndefined()
+  })
+
+  it("does not treat absence of a fresh key as deletion (Axiom 3.4)", () => {
+    const continuity = createContinuityCheck<string, string>()
+    continuity.observe("node1", "vidA")
+    expect(continuity.observe("node1", undefined)).toBeUndefined()
+  })
+
+  it("a carrier recycled mid-stream (same physical identity, new logical key) triggers the implicit-deletion signal exactly once", () => {
+    const continuity = createContinuityCheck<string, string>()
+
+    continuity.observe("node1", "vidA")
+    const deletion = continuity.observe("node1", "vidB")
+    const again = continuity.observe("node1", "vidB")
+
+    expect(deletion).toEqual({ carrier: "node1", staleKey: "vidA" })
+    expect(again).toBeUndefined() // no explicit removal token ever existed for vidA
+  })
+
+  it("forget() drops bookkeeping so a later re-observation is treated as fresh", () => {
+    const continuity = createContinuityCheck<string, string>()
+    continuity.observe("node1", "vidA")
+    continuity.forget("node1")
+    expect(continuity.observe("node1", "vidB")).toBeUndefined()
+  })
+})
+
+describe("sensor/identity — identify() (Definition 4.1 + Corollary 4.1.1 combined)", () => {
+  const fullExtractor: Extractor<string, string, Attrs> = (
+    _carrier,
+    observed
+  ) =>
+    observed.videoId === undefined
+      ? { tier: "raw" }
+      : { tier: "full", key: observed.videoId, attrs: observed }
+
+  it("re-derives extraction fresh on every call — no caching across rounds", () => {
+    const continuity = createContinuityCheck<string, string>()
+    let calls = 0
+    const countingExtractor: Extractor<string, string, Attrs> = (c, o) => {
+      calls++
+      return fullExtractor(c, o)
+    }
+
+    identify("node1", { videoId: "vidA" }, countingExtractor, continuity)
+    identify("node1", { videoId: "vidA" }, countingExtractor, continuity)
+
+    expect(calls).toBe(2)
+  })
+
+  it("runs the continuity check on every ingestion, even when extraction is 'raw' (nothing actionable)", () => {
+    const continuity = createContinuityCheck<string, string>()
+    let observeCalls = 0
+    const spyContinuity = {
+      observe: (
+        carrier: string,
+        key: string | undefined
+      ): ReturnType<typeof continuity.observe> => {
+        observeCalls++
+        return continuity.observe(carrier, key)
+      },
+      forget: continuity.forget,
+    }
+
+    identify("node1", {}, fullExtractor, spyContinuity)
+
+    expect(observeCalls).toBe(1)
+  })
+
+  it("mirrors Proposition 4.1's proof: recycling a carrier surfaces an implicit deletion with no explicit removal token", () => {
+    const continuity = createContinuityCheck<string, string>()
+
+    const first = identify(
+      "node1",
+      { videoId: "vidA" },
+      fullExtractor,
+      continuity
+    )
+    expect(first.extraction).toEqual({
+      tier: "full",
+      key: "vidA",
+      attrs: { videoId: "vidA" },
+    })
+    expect(first.implicitDeletion).toBeUndefined()
+
+    const second = identify(
+      "node1",
+      { videoId: "vidB" },
+      fullExtractor,
+      continuity
+    )
+    expect(second.implicitDeletion).toEqual({
+      carrier: "node1",
+      staleKey: "vidA",
+    })
+  })
+})

--- a/extensions/transport/src/sensor/identity.ts
+++ b/extensions/transport/src/sensor/identity.ts
@@ -1,0 +1,112 @@
+/**
+ * Definition 4.1 (Identity resolution), Proposition 4.1 (Identity
+ * non-permanence), Corollary 4.1.1 (continuity check) — canon §4.
+ *
+ * Even when a token is delivered, the observer must determine which
+ * logical key it is evidence *for* — a distinct problem from ordering
+ * evidence about an already-known key (§5, S6). `ξ` is applied fresh at
+ * every ingestion, never cached across rounds without re-validation
+ * (Definition 4.1), and every ingestion re-derives it and compares against
+ * the key previously associated with the same physical carrier
+ * (Corollary 4.1.1) — a mismatch is an *implicit deletion*: Axiom 3.4
+ * guarantees no explicit removal token will ever announce it.
+ */
+
+export type ExtractionTier = "raw" | "partial" | "full"
+
+const TIER_RANK: Readonly<Record<ExtractionTier, number>> = {
+  raw: 0,
+  partial: 1,
+  full: 2,
+}
+
+/** Total order `raw ≺ partial ≺ full` (Definition 4.1), exposed for the Estimator's per-key order (S6, Definition 5.2). */
+export function compareTiers(a: ExtractionTier, b: ExtractionTier): number {
+  return TIER_RANK[a] - TIER_RANK[b]
+}
+
+export type ExtractionResult<K, Attr> =
+  | { readonly tier: "raw" }
+  | { readonly tier: "partial"; readonly key: K }
+  | { readonly tier: "full"; readonly key: K; readonly attrs: Readonly<Attr> }
+
+/**
+ * `ξ: Node × Attr -> {("full", k, a), ("partial", k), ("raw")}` (Definition
+ * 4.1). Necessarily domain-specific (e.g. "read a video ID"), so it is
+ * injected — never hard-coded here.
+ */
+export type Extractor<Carrier, K, Attr> = (
+  carrier: Carrier,
+  observed: Readonly<Attr>
+) => ExtractionResult<K, Attr>
+
+export type ImplicitDeletion<Carrier, K> = {
+  readonly carrier: Carrier
+  readonly staleKey: K
+}
+
+export type ContinuityCheck<Carrier, K> = {
+  /**
+   * Compares `key` (the freshly extracted key for `carrier`, or `undefined`
+   * if extraction did not reach at least "partial") against whatever key
+   * was previously recorded for the same carrier. Returns an implicit
+   * deletion when they differ. Absence of a fresh key (Axiom 3.4) is never
+   * itself read as deletion — only a genuine mismatch between two known
+   * keys is (Proposition 4.1's recycling case).
+   */
+  observe(
+    carrier: Carrier,
+    key: K | undefined
+  ): ImplicitDeletion<Carrier, K> | undefined
+  /** Drops bookkeeping for a carrier the caller knows is gone for good (e.g. GC'd). */
+  forget(carrier: Carrier): void
+}
+
+export function createContinuityCheck<Carrier, K>(): ContinuityCheck<
+  Carrier,
+  K
+> {
+  const previouslySeen = new Map<Carrier, K>()
+
+  return {
+    observe(carrier, key): ImplicitDeletion<Carrier, K> | undefined {
+      if (key === undefined) {
+        return undefined
+      }
+      const previous = previouslySeen.get(carrier)
+      previouslySeen.set(carrier, key)
+      if (previous !== undefined && previous !== key) {
+        return { carrier, staleKey: previous }
+      }
+      return undefined
+    },
+    forget(carrier): void {
+      previouslySeen.delete(carrier)
+    },
+  }
+}
+
+export type IdentifyResult<Carrier, K, Attr> = {
+  readonly extraction: ExtractionResult<K, Attr>
+  readonly implicitDeletion?: ImplicitDeletion<Carrier, K>
+}
+
+/**
+ * Runs `ξ` fresh against `carrier`/`observed`, then the continuity check —
+ * unconditionally, on every call, regardless of whether extraction reached
+ * "partial" or "full" (Corollary 4.1.1's requirement: the check runs on
+ * *every* ingestion, not just a subset of code paths).
+ */
+export function identify<Carrier, K, Attr>(
+  carrier: Carrier,
+  observed: Readonly<Attr>,
+  extractor: Extractor<Carrier, K, Attr>,
+  continuity: ContinuityCheck<Carrier, K>
+): IdentifyResult<Carrier, K, Attr> {
+  const extraction = extractor(carrier, observed)
+  const key = extraction.tier === "raw" ? undefined : extraction.key
+  const implicitDeletion = continuity.observe(carrier, key)
+  return implicitDeletion === undefined
+    ? { extraction }
+    : { extraction, implicitDeletion }
+}

--- a/extensions/transport/src/sensor/observer.test.ts
+++ b/extensions/transport/src/sensor/observer.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+
+import type { Token } from "../contracts/token"
+import {
+  attachDomEventListener,
+  attachMutationObserver,
+  createEventChannel,
+  type SensedToken,
+} from "./observer"
+
+type Attrs = { readonly text: string }
+
+describe("sensor/observer — createEventChannel", () => {
+  it("emits tokens tagged with the current epoch", () => {
+    const emitted: Array<SensedToken<string, Attrs>> = []
+    const channel = createEventChannel<string, string, Attrs>({
+      toTokens: (raw) => [{ key: raw, attrs: { text: raw }, timestamp: 1 }],
+      currentEpoch: () => 7,
+      emit: (token) => emitted.push(token),
+    })
+
+    channel.ingest("k1")
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]?.epoch).toBe(7)
+    expect(emitted[0]?.key).toBe("k1")
+  })
+
+  it("excludes self-authored payloads before producing any token (Axiom 3.5)", () => {
+    const emitted: Array<SensedToken<string, Attrs>> = []
+    const channel = createEventChannel<string, string, Attrs>({
+      toTokens: (raw) => [{ key: raw, attrs: { text: raw }, timestamp: 1 }],
+      currentEpoch: () => 0,
+      isSelfAuthored: (raw) => raw.startsWith("self:"),
+      emit: (token) => emitted.push(token),
+    })
+
+    channel.ingest("self:k1")
+    channel.ingest("vendor:k1")
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]?.key).toBe("vendor:k1")
+  })
+
+  it("does not interpret token content — a raw payload producing zero tokens emits nothing", () => {
+    const emitted: Array<SensedToken<string, Attrs>> = []
+    const channel = createEventChannel<string, string, Attrs>({
+      toTokens: () => [],
+      currentEpoch: () => 0,
+      emit: (token) => emitted.push(token),
+    })
+
+    channel.ingest("anything")
+
+    expect(emitted).toHaveLength(0)
+  })
+
+  it("a single raw payload may fan out into multiple tokens, all tagged with the same epoch", () => {
+    const emitted: Array<SensedToken<string, Attrs>> = []
+    const tokens: Array<Token<string, Attrs>> = [
+      { key: "a", attrs: { text: "a" }, timestamp: 1 },
+      { key: "b", attrs: { text: "b" }, timestamp: 2 },
+    ]
+    const channel = createEventChannel<string, string, Attrs>({
+      toTokens: () => tokens,
+      currentEpoch: () => 3,
+      emit: (token) => emitted.push(token),
+    })
+
+    channel.ingest("batch")
+
+    expect(emitted).toHaveLength(2)
+    expect(emitted.every((t) => t.epoch === 3)).toBe(true)
+  })
+})
+
+describe("sensor/observer — DOM wiring", () => {
+  it("attachMutationObserver feeds MutationRecords into the channel and disconnects on dispose", async () => {
+    const target = document.createElement("div")
+    document.body.appendChild(target)
+
+    const ingested: Array<MutationRecord> = []
+    const channel = {
+      ingest: (raw: MutationRecord): void => {
+        ingested.push(raw)
+      },
+    }
+
+    const dispose = attachMutationObserver(target, channel, {
+      attributes: true,
+    })
+
+    target.setAttribute("data-x", "1")
+    await Promise.resolve() // MutationObserver callbacks are microtask-scheduled
+    await new Promise((resolve) => queueMicrotask(() => resolve(undefined)))
+
+    expect(ingested.length).toBeGreaterThan(0)
+
+    dispose()
+    target.remove()
+  })
+
+  it("attachDomEventListener feeds events into the channel and removes the listener on dispose", () => {
+    const target = document.createElement("div")
+    const ingested: Array<Event> = []
+    const channel = {
+      ingest: (raw: Event): void => {
+        ingested.push(raw)
+      },
+    }
+
+    const dispose = attachDomEventListener(target, "click", channel)
+
+    target.dispatchEvent(new Event("click"))
+    expect(ingested).toHaveLength(1)
+
+    dispose()
+    target.dispatchEvent(new Event("click"))
+    expect(ingested).toHaveLength(1)
+  })
+})

--- a/extensions/transport/src/sensor/observer.ts
+++ b/extensions/transport/src/sensor/observer.ts
@@ -1,0 +1,93 @@
+/**
+ * Definition 3.1 (Token), Definition 3.2 (Observation channel), Axioms
+ * 3.1–3.5 — canon §3. Realizes S_event, the event sub-channel of the
+ * hybrid channel (Definition 3.3).
+ *
+ * Wraps `MutationObserver`/DOM events into epoch-tagged Tokens. This module
+ * performs no interpretation of token content — no identity extraction
+ * (that is S5, `identity.ts`) — and no DOM mutation. It only produces
+ * tokens; the Estimator (S6) decides what they mean.
+ */
+
+import type { Token } from "../contracts/token"
+import type { Epoch } from "../session/epoch"
+
+export type SensedToken<K, Attr> = Token<K, Attr> & { readonly epoch: Epoch }
+
+/**
+ * Maps a raw event-channel payload (a `MutationRecord`, a DOM `Event`, or
+ * any vendor-agnostic equivalent) to zero or more Tokens. Injected rather
+ * than hard-coded: this module has no opinion on what a payload means.
+ */
+export type TokenProducer<Raw, K, Attr> = (
+  raw: Raw
+) => ReadonlyArray<Token<K, Attr>>
+
+/**
+ * Axiom 3.5 (Actuator re-entrance): a predicate excluding actuator-authored
+ * mutations from producing tokens in the first place. This module defines
+ * no tag scheme of its own — the predicate is supplied by whatever
+ * Adapter/Actuator pairing (S9) uses this channel.
+ */
+export type SelfAuthoredPredicate<Raw> = (raw: Raw) => boolean
+
+export type EventChannelOptions<Raw, K, Attr> = {
+  readonly toTokens: TokenProducer<Raw, K, Attr>
+  readonly currentEpoch: () => Epoch
+  readonly isSelfAuthored?: SelfAuthoredPredicate<Raw>
+  readonly emit: (token: SensedToken<K, Attr>) => void
+}
+
+export type EventChannel<Raw> = {
+  ingest(raw: Raw): void
+}
+
+export function createEventChannel<Raw, K, Attr>(
+  options: EventChannelOptions<Raw, K, Attr>
+): EventChannel<Raw> {
+  const { toTokens, currentEpoch, isSelfAuthored, emit } = options
+
+  return {
+    ingest(raw: Raw): void {
+      if (isSelfAuthored?.(raw) === true) {
+        return
+      }
+      const epoch = currentEpoch()
+      for (const token of toTokens(raw)) {
+        emit({ ...token, epoch })
+      }
+    },
+  }
+}
+
+/** Attaches a `MutationObserver` to `target`, feeding every record into `channel`. */
+export function attachMutationObserver(
+  target: Node,
+  channel: EventChannel<MutationRecord>,
+  observerOptions: MutationObserverInit
+): () => void {
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      channel.ingest(record)
+    }
+  })
+  observer.observe(target, observerOptions)
+  return () => observer.disconnect()
+}
+
+/**
+ * Attaches a DOM event listener to `target`, feeding every event into
+ * `channel`. `channel` is typed over the base `Event` — a caller needing a
+ * more specific event shape narrows it (e.g. `instanceof`) inside its own
+ * `toTokens`, rather than this module asserting a type it cannot verify.
+ */
+export function attachDomEventListener(
+  target: EventTarget,
+  type: string,
+  channel: EventChannel<Event>,
+  listenerOptions?: AddEventListenerOptions
+): () => void {
+  const listener = (event: Event): void => channel.ingest(event)
+  target.addEventListener(type, listener, listenerOptions)
+  return () => target.removeEventListener(type, listener, listenerOptions)
+}

--- a/extensions/transport/src/sensor/polling.test.ts
+++ b/extensions/transport/src/sensor/polling.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+
+import type { SensedToken } from "./observer"
+import { createPollChannel } from "./polling"
+
+type Attrs = { readonly text: string }
+
+describe("sensor/polling — createPollChannel", () => {
+  it("re-samples every key in the holding set and emits epoch-tagged tokens", () => {
+    const emitted: Array<SensedToken<string, Attrs>> = []
+    const channel = createPollChannel<string, Attrs>({
+      holdingSet: () => ["a", "b"],
+      resample: (key) => ({ key, attrs: { text: key }, timestamp: 1 }),
+      currentEpoch: () => 2,
+      emit: (token) => emitted.push(token),
+    })
+
+    const count = channel.poll()
+
+    expect(count).toBe(2)
+    expect(emitted).toHaveLength(2)
+    expect(emitted.every((t) => t.epoch === 2)).toBe(true)
+  })
+
+  it("skips keys the resampler has nothing new for", () => {
+    const emitted: Array<SensedToken<string, Attrs>> = []
+    const channel = createPollChannel<string, Attrs>({
+      holdingSet: () => ["a", "b"],
+      resample: (key) =>
+        key === "a" ? { key, attrs: { text: key }, timestamp: 1 } : undefined,
+      currentEpoch: () => 0,
+      emit: (token) => emitted.push(token),
+    })
+
+    const count = channel.poll()
+
+    expect(count).toBe(1)
+    expect(emitted[0]?.key).toBe("a")
+  })
+
+  it("re-derives the holding set fresh on every poll() call", () => {
+    let generation = 0
+    const emitted: Array<SensedToken<string, Attrs>> = []
+    const channel = createPollChannel<string, Attrs>({
+      holdingSet: () => {
+        generation++
+        return generation === 1 ? ["a"] : ["a", "b"]
+      },
+      resample: (key) => ({ key, attrs: { text: key }, timestamp: 1 }),
+      currentEpoch: () => 0,
+      emit: (token) => emitted.push(token),
+    })
+
+    channel.poll()
+    channel.poll()
+
+    expect(emitted).toHaveLength(3)
+  })
+
+  it("hard-codes no cadence — poll() only runs when called, never on a timer of its own", () => {
+    let calls = 0
+    const channel = createPollChannel<string, Attrs>({
+      holdingSet: () => [],
+      resample: () => undefined,
+      currentEpoch: () => {
+        calls++
+        return 0
+      },
+      emit: () => {},
+    })
+
+    expect(calls).toBe(0)
+    channel.poll()
+    expect(calls).toBe(1)
+  })
+})

--- a/extensions/transport/src/sensor/polling.ts
+++ b/extensions/transport/src/sensor/polling.ts
@@ -1,0 +1,51 @@
+/**
+ * Definition 3.3 (Hybrid channel), Remark 3.2 — canon §3. Realizes S_poll,
+ * the poll sub-channel of the hybrid channel.
+ *
+ * Re-samples a caller-supplied "holding set" of keys the event channel has
+ * not yet resolved. Cadence *tuning* — when to call `poll()` — is the
+ * Scheduler's concern (S8); this module only executes a re-sample when
+ * told to, and hard-codes no interval of its own.
+ */
+
+import type { Token } from "../contracts/token"
+import type { Epoch } from "../session/epoch"
+import type { SensedToken } from "./observer"
+
+export type HoldingSet<K> = Iterable<K>
+
+/** Re-samples a single held key. Returns `undefined` if there is nothing new. */
+export type Resampler<K, Attr> = (key: K) => Token<K, Attr> | undefined
+
+export type PollChannelOptions<K, Attr> = {
+  readonly holdingSet: () => HoldingSet<K>
+  readonly resample: Resampler<K, Attr>
+  readonly currentEpoch: () => Epoch
+  readonly emit: (token: SensedToken<K, Attr>) => void
+}
+
+export type PollChannel = {
+  /** Executes one re-sampling round; returns the number of tokens emitted. */
+  poll(): number
+}
+
+export function createPollChannel<K, Attr>(
+  options: PollChannelOptions<K, Attr>
+): PollChannel {
+  const { holdingSet, resample, currentEpoch, emit } = options
+
+  return {
+    poll(): number {
+      const epoch = currentEpoch()
+      let emitted = 0
+      for (const key of holdingSet()) {
+        const token = resample(key)
+        if (token !== undefined) {
+          emit({ ...token, epoch })
+          emitted++
+        }
+      }
+      return emitted
+    },
+  }
+}

--- a/extensions/transport/src/sensor/purity.test.ts
+++ b/extensions/transport/src/sensor/purity.test.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+/**
+ * S4 acceptance criterion: "The channel never mutates the DOM (grep-
+ * checkable: no `.style`, `.setAttribute`, `.remove()`, `.appendChild` etc.
+ * in `sensor/`)." Enforced here as an executable test rather than only a CI
+ * grep, so a violation fails `pnpm test` locally, not just in CI.
+ */
+
+const SENSOR_DIR = dirname(fileURLToPath(import.meta.url))
+
+const MUTATING_CALL_PATTERNS: ReadonlyArray<RegExp> = [
+  /\.setAttribute\s*\(/,
+  /\.removeAttribute\s*\(/,
+  /\.style\s*[.=]/,
+  /\.appendChild\s*\(/,
+  /\.insertBefore\s*\(/,
+  /\.replaceChild\s*\(/,
+  /\.removeChild\s*\(/,
+  /\.remove\s*\(\s*\)/,
+  /\.innerHTML\s*=/,
+  /\.outerHTML\s*=/,
+  /\.textContent\s*=/,
+  /\.classList\.(add|remove|toggle|replace)\s*\(/,
+]
+
+function sourceFiles(dir: string): Array<string> {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+}
+
+describe("sensor/ purity — no DOM mutation", () => {
+  for (const file of sourceFiles(SENSOR_DIR)) {
+    it(`${file} contains no DOM-mutating call`, () => {
+      const contents = readFileSync(join(SENSOR_DIR, file), "utf8")
+      for (const pattern of MUTATING_CALL_PATTERNS) {
+        expect(contents).not.toMatch(pattern)
+      }
+    })
+  }
+})

--- a/extensions/transport/src/session/epoch.test.ts
+++ b/extensions/transport/src/session/epoch.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { createEpochCounter, initialEpoch } from "./epoch"
+
+describe("session/epoch", () => {
+  it("starts at the initial epoch", () => {
+    const counter = createEpochCounter()
+    expect(counter.current).toBe(initialEpoch())
+  })
+
+  it("reset() strictly increases the epoch", () => {
+    const counter = createEpochCounter()
+    const first = counter.reset()
+    const second = counter.reset()
+
+    expect(second).toBeGreaterThan(first)
+    expect(counter.current).toBe(second)
+  })
+
+  it("two resets called back-to-back (same tick) never collide", () => {
+    const counter = createEpochCounter()
+    const seen = new Set<number>()
+    for (let i = 0; i < 100; i++) {
+      seen.add(counter.reset())
+    }
+    expect(seen.size).toBe(100)
+  })
+
+  it("current has no public setter — the type only exposes a getter", () => {
+    const counter = createEpochCounter()
+    const descriptor = Object.getOwnPropertyDescriptor(counter, "current")
+    expect(descriptor?.set).toBeUndefined()
+    expect(typeof descriptor?.get).toBe("function")
+  })
+
+  it("can be seeded from an explicit initial value", () => {
+    const counter = createEpochCounter(initialEpoch())
+    expect(counter.current).toBe(initialEpoch())
+    counter.reset()
+    expect(counter.current).not.toBe(initialEpoch())
+  })
+})

--- a/extensions/transport/src/session/epoch.ts
+++ b/extensions/transport/src/session/epoch.ts
@@ -1,0 +1,34 @@
+/**
+ * Definition 5.4 (Epoch) — canon §5.4.
+ *
+ * An epoch is a monotonically increasing counter, advanced only by a
+ * distinguished reset operator (⊥_ε per Definition 5.4) that begins a fresh
+ * epoch. There is no public setter: `reset()` is the only exported mutator,
+ * and `EpochCounter.current` is a read-only accessor.
+ */
+
+export type Epoch = number
+
+export function initialEpoch(): Epoch {
+  return 0
+}
+
+export type EpochCounter = {
+  readonly current: Epoch
+  reset(): Epoch
+}
+
+export function createEpochCounter(
+  initial: Epoch = initialEpoch()
+): EpochCounter {
+  let value = initial
+  return {
+    get current(): Epoch {
+      return value
+    },
+    reset(): Epoch {
+      value = value + 1
+      return value
+    },
+  }
+}

--- a/extensions/transport/src/session/lifecycle.test.ts
+++ b/extensions/transport/src/session/lifecycle.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { initialEpoch } from "./epoch"
+import { createSessionLifecycle, type SessionResetEvent } from "./lifecycle"
+
+describe("session/lifecycle", () => {
+  it("starts at the initial epoch with no reset yet performed", () => {
+    const session = createSessionLifecycle()
+    expect(session.epoch).toBe(initialEpoch())
+  })
+
+  it("resetContent() advances the epoch and reports kind 'content'", () => {
+    const session = createSessionLifecycle()
+    const event = session.resetContent()
+
+    expect(event.kind).toBe("content")
+    expect(event.epoch).toBe(session.epoch)
+    expect(session.epoch).not.toBe(initialEpoch())
+  })
+
+  it("resetDocument() advances the epoch and reports kind 'document'", () => {
+    const session = createSessionLifecycle()
+    const event = session.resetDocument()
+
+    expect(event.kind).toBe("document")
+    expect(event.epoch).toBe(session.epoch)
+  })
+
+  it("both reset paths advance the same underlying epoch counter", () => {
+    const session = createSessionLifecycle()
+    const content = session.resetContent()
+    const document = session.resetDocument()
+
+    expect(document.epoch).toBeGreaterThan(content.epoch)
+  })
+
+  it("invokes the injected onReset callback for both reset paths, never touching Estimator internals directly", () => {
+    const events: Array<SessionResetEvent> = []
+    const session = createSessionLifecycle({
+      onReset: (event) => events.push(event),
+    })
+
+    session.resetContent()
+    session.resetDocument()
+
+    expect(events).toHaveLength(2)
+    expect(events[0]?.kind).toBe("content")
+    expect(events[1]?.kind).toBe("document")
+  })
+
+  it("has no navigation-detection heuristic of its own — callers drive resets explicitly", () => {
+    const onReset = vi.fn()
+    const session = createSessionLifecycle({ onReset })
+
+    expect(onReset).not.toHaveBeenCalled()
+    expect(session.epoch).toBe(initialEpoch())
+  })
+})

--- a/extensions/transport/src/session/lifecycle.ts
+++ b/extensions/transport/src/session/lifecycle.ts
@@ -1,0 +1,67 @@
+/**
+ * SessionLifecycle — canon §5.4 (Definition 5.4), §D.0 (Definition D.1,
+ * Theorem D.1).
+ *
+ * Distinguishes the two reset paths Theorem D.1 names: "content-only reset"
+ * (case (a) — a same-document navigation ends the content lifetime L_C and
+ * begins a new L_C' while the document lifetime L_D, and Bootstrap with it,
+ * persists) from "full reset" (case (b) — a refresh ends L_D itself, which
+ * re-triggers Bootstrap per S2/S10). Both paths advance the epoch exactly
+ * once via the same underlying counter, so there is a single source of
+ * truth for both of Theorem D.1's cases.
+ *
+ * This module has no opinion on *when* either path fires — no History API
+ * patching, no vendor navigation event, no MutationObserver. A caller wires
+ * whatever navigation-detection heuristic it needs and calls `resetContent`
+ * or `resetDocument` directly; that is the entire injection surface
+ * (Remark 1.4: nothing here may depend on a specific vendor).
+ *
+ * `onReset` lets the Estimator (S6) clear whatever per-epoch state it
+ * attaches, without Session importing anything from `estimator/`.
+ */
+
+import { createEpochCounter, type Epoch, type EpochCounter } from "./epoch"
+
+export type ResetKind = "content" | "document"
+
+export type SessionResetEvent = {
+  readonly kind: ResetKind
+  readonly epoch: Epoch
+}
+
+export type SessionLifecycle = {
+  readonly epoch: Epoch
+  resetContent(): SessionResetEvent
+  resetDocument(): SessionResetEvent
+}
+
+export type CreateSessionLifecycleOptions = {
+  readonly onReset?: (event: SessionResetEvent) => void
+  readonly counter?: EpochCounter
+}
+
+export function createSessionLifecycle(
+  options: CreateSessionLifecycleOptions = {}
+): SessionLifecycle {
+  const counter = options.counter ?? createEpochCounter()
+  const onReset = options.onReset
+
+  function performReset(kind: ResetKind): SessionResetEvent {
+    const epoch = counter.reset()
+    const event: SessionResetEvent = { kind, epoch }
+    onReset?.(event)
+    return event
+  }
+
+  return {
+    get epoch(): Epoch {
+      return counter.current
+    },
+    resetContent(): SessionResetEvent {
+      return performReset("content")
+    },
+    resetDocument(): SessionResetEvent {
+      return performReset("document")
+    },
+  }
+}

--- a/extensions/transport/tests/e2e/fixtures/hostile-page.ts
+++ b/extensions/transport/tests/e2e/fixtures/hostile-page.ts
@@ -1,0 +1,165 @@
+/**
+ * Hostile-page fixture (S11) — a synthetic page and a parameterized churn
+ * script exercising the sequence the epic names: blank → theme flips →
+ * body/head replacement → style removal/addition → SPA navigation → root
+ * replacement → virtualized recycling → extension-DOM removal → sustained
+ * mutation. No assertion in this file: it only drives the page. Every
+ * churn step is agnostic to any property `P` — none of them touch CSS or
+ * a domain concept.
+ */
+
+import type { Page } from "@playwright/test"
+
+export function hostilePageHtml(): string {
+  return `<!doctype html>
+<html>
+<head><title>hostile</title></head>
+<body>
+  <div id="content-root"></div>
+</body>
+</html>`
+}
+
+export const churn = {
+  async blank(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      document.body.innerHTML = ""
+    })
+  },
+
+  async themeFlip(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      document.documentElement.classList.toggle("dark")
+      document.documentElement.classList.toggle("light")
+    })
+  },
+
+  async bodyHeadReplace(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      const newHead = document.createElement("head")
+      const newBody = document.createElement("body")
+      newBody.innerHTML = '<div id="content-root"></div>'
+      document.documentElement.replaceChild(newHead, document.head)
+      document.documentElement.replaceChild(newBody, document.body)
+    })
+  },
+
+  async styleChurn(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      const style = document.createElement("style")
+      style.textContent = "body { background: black; }"
+      document.head.appendChild(style)
+      style.remove()
+    })
+  },
+
+  async spaNavigate(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      try {
+        // A real content-script origin (http/https) permits this; the
+        // synthetic `about:blank` origin `page.setContent()` loads into
+        // does not (a null-origin History API restriction, not anything
+        // transport cares about — Session has no navigation-detection
+        // heuristic of its own either way, S3). The `popstate` dispatch
+        // below is the actually-observable signal a router-detection
+        // heuristic would key on, and always fires regardless.
+        history.pushState({}, "", "/route-2")
+      } catch {
+        // ignored — see above
+      }
+      window.dispatchEvent(new PopStateEvent("popstate"))
+    })
+  },
+
+  async rootReplace(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      const newRoot = document.createElement("html")
+      newRoot.innerHTML = document.documentElement.innerHTML
+      // Hostile scripts occasionally clone/replace the entire tree; here we
+      // simulate by wholesale-replacing documentElement's children, since a
+      // literal `document.replaceChild` on `<html>` is not observable the
+      // same way across engines.
+      while (document.documentElement.firstChild !== null) {
+        document.documentElement.removeChild(
+          document.documentElement.firstChild
+        )
+      }
+      while (newRoot.firstChild !== null) {
+        document.documentElement.appendChild(newRoot.firstChild)
+      }
+    })
+  },
+
+  async virtualizedRecycle(
+    page: Page,
+    selector: string,
+    key: string,
+    value: number
+  ): Promise<void> {
+    await page.evaluate(
+      ({ selector, key, value }) => {
+        const root = document.querySelector(selector)
+        if (root === null) return
+        // A virtualized list recycles the *same* physical node to a new
+        // logical key with no removal token (Proposition 4.1) — simulated
+        // by mutating the same element's data-key/data-value in place.
+        let el = root.querySelector("[data-recycled-node]")
+        if (el === null) {
+          el = document.createElement("div")
+          el.setAttribute("data-recycled-node", "")
+          root.appendChild(el)
+        }
+        el.setAttribute("data-key", key)
+        el.setAttribute("data-value", String(value))
+      },
+      { selector, key, value }
+    )
+  },
+
+  async extensionDomRemoval(page: Page, selector: string): Promise<void> {
+    await page.evaluate((selector) => {
+      // A hostile script removing anything it finds, including
+      // extension-authored nodes it has no way of knowing are "ours".
+      for (const el of Array.from(document.querySelectorAll(selector))) {
+        el.remove()
+      }
+    }, selector)
+  },
+
+  async sustainedMutation(
+    page: Page,
+    durationMs: number,
+    targetRate = 1000
+  ): Promise<void> {
+    await page.evaluate(
+      ({ durationMs, targetRate }) => {
+        return new Promise<void>((resolve) => {
+          const root = document.querySelector("#content-root") ?? document.body
+          const start = performance.now()
+          let count = 0
+          const perTick = Math.max(1, Math.round(targetRate / 100)) // ~100 ticks/sec budget
+          function tick(): void {
+            for (let i = 0; i < perTick; i++) {
+              const el = document.createElement("div")
+              el.setAttribute("data-key", `churn-${count % 20}`)
+              el.setAttribute("data-value", String(count))
+              root.appendChild(el)
+              const oldest = root.firstElementChild
+              if (root.children.length > 50 && oldest !== null) {
+                root.removeChild(oldest)
+              }
+              count++
+            }
+            if (performance.now() - start < durationMs) {
+              setTimeout(tick, 10)
+            } else {
+              resolve()
+            }
+          }
+          tick()
+        })
+      },
+      { durationMs, targetRate }
+    )
+  },
+}

--- a/extensions/transport/tests/e2e/global-setup.ts
+++ b/extensions/transport/tests/e2e/global-setup.ts
@@ -1,0 +1,21 @@
+/**
+ * Bundles the S11 harness (`harness/entry.ts`) with esbuild before the
+ * suite runs. Transport ships raw `.ts` source with no build step of its
+ * own (S1/S7) — this bundling is scoped entirely to the test harness, a
+ * fixture, not a build artifact of the package itself.
+ */
+
+import { build } from "esbuild"
+
+export default async function globalSetup(): Promise<void> {
+  await build({
+    entryPoints: ["tests/e2e/harness/entry.ts"],
+    outfile: "tests/e2e/harness/dist/entry.js",
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "chrome110",
+    sourcemap: "inline",
+    logLevel: "warning",
+  })
+}

--- a/extensions/transport/tests/e2e/harness/entry.ts
+++ b/extensions/transport/tests/e2e/harness/entry.ts
@@ -1,0 +1,265 @@
+/**
+ * S11 conformance-suite harness.
+ *
+ * This file is a *test fixture*, not part of the transport package — it is
+ * bundled (via esbuild, see `global-setup.ts`) and injected into a real
+ * browser page so Playwright can exercise the actual transport modules
+ * under real DOM/MutationObserver/timing behavior, not jsdom.
+ *
+ * It wires the real four-stage pipeline (channel → estimator → adapter →
+ * actuator) against `adapter/null-adapter.ts` — the only adapter this
+ * suite imports — plus Bootstrap, Session, and Lifecycle. The one place
+ * this file goes beyond the null adapter is `restoreOwnership()`, which
+ * demonstrates Remark 7.2's ownership-signal path using only
+ * `actuator/self-tag.ts` and `actuator/apply.ts` primitives — no `decide`
+ * function, no invariant, no domain concept of any kind. It is exactly as
+ * "business-logic-free" as a consumer wiring this package would be
+ * required to keep everything *except* their own Adapter.
+ */
+
+import { apply, type ActionRealizer } from "../../../src/actuator/apply"
+import {
+  isSelfTagged,
+  releaseOwnership,
+  wasRemovedByVendor,
+} from "../../../src/actuator/self-tag"
+import { invoke } from "../../../src/adapter/invoke"
+import { createNullAdapter } from "../../../src/adapter/null-adapter"
+import * as bootstrap from "../../../src/bootstrap/static"
+import type { Action } from "../../../src/contracts/action"
+import { createDecayTracker } from "../../../src/estimator/decay"
+import {
+  createHypothesis,
+  type MutableHypothesis,
+} from "../../../src/estimator/hypothesis"
+import {
+  createProvenanceStore,
+  update,
+  type Evidence,
+  type ProvenanceStore,
+} from "../../../src/estimator/update"
+import {
+  teardownContent,
+  teardownDocument,
+  type Disposable,
+} from "../../../src/lifecycle/teardown"
+import {
+  createCoalescer,
+  type Coalescer,
+} from "../../../src/scheduler/reconcile"
+import {
+  createContinuityCheck,
+  identify,
+  type ExtractionResult,
+} from "../../../src/sensor/identity"
+import { attachMutationObserver } from "../../../src/sensor/observer"
+import {
+  createSessionLifecycle,
+  type SessionLifecycle,
+} from "../../../src/session/lifecycle"
+
+type Attrs = { readonly seq: number }
+
+const hypothesis: MutableHypothesis<string, Attrs> = createHypothesis<
+  string,
+  Attrs
+>()
+const provenance: ProvenanceStore<string> = createProvenanceStore<string>()
+const decay = createDecayTracker<string, Attrs>()
+const continuity = createContinuityCheck<Element, string>()
+const nullAdapter = createNullAdapter<string, Attrs>()
+const session: SessionLifecycle = createSessionLifecycle({
+  onReset: () => decay.reset(),
+})
+
+let tick = 0
+function nextTick(): number {
+  tick += 1
+  return tick
+}
+
+let reconcileCount = 0
+const coalescer: Coalescer = createCoalescer({ debounceMs: 20 }, () => {
+  reconcileCount += 1
+  invoke(hypothesis, nullAdapter) // always ∅ — Theorem D.2
+})
+
+function extractor(el: Element): ExtractionResult<string, Attrs> {
+  const key = el.getAttribute("data-key")
+  if (key === null) {
+    return { tier: "raw" }
+  }
+  const valueAttr = el.getAttribute("data-value")
+  if (valueAttr === null) {
+    return { tier: "partial", key }
+  }
+  return { tier: "full", key, attrs: { seq: Number(valueAttr) } }
+}
+
+const ingestChannel = {
+  ingest(record: MutationRecord): void {
+    const el = record.target
+    if (!(el instanceof Element) || isSelfTagged(el)) {
+      return // Axiom 3.5 self-exclusion
+    }
+    // The harness's extractor reads attributes directly off `el` and
+    // ignores `observed`; this placeholder only satisfies the (shared)
+    // Attr shape identify() requires for its second parameter.
+    const result = identify(el, { seq: 0 }, () => extractor(el), continuity)
+    if (result.extraction.tier === "raw") {
+      return
+    }
+    const key = result.extraction.key
+    const attrs: Attrs =
+      result.extraction.tier === "full" ? result.extraction.attrs : { seq: -1 }
+    const evidence: Evidence<string, Attrs> = {
+      key,
+      epoch: session.epoch,
+      tier: result.extraction.tier,
+      timestamp: nextTick(),
+      attrs,
+    }
+    update(hypothesis, provenance, evidence)
+    decay.touch(key, evidence.timestamp)
+    coalescer.trigger()
+  },
+}
+
+let disposeObserver: Disposable | undefined
+
+function startSensing(rootSelector: string): void {
+  const root = document.querySelector(rootSelector)
+  if (root === null) {
+    throw new Error(`content root ${rootSelector} not found`)
+  }
+  disposeObserver = attachMutationObserver(root, ingestChannel, {
+    attributes: true,
+    childList: true,
+    subtree: true,
+  })
+}
+
+function currentDisposables(): ReadonlyArray<Disposable> {
+  const list: Array<Disposable> = [coalescer.dispose]
+  if (disposeObserver !== undefined) {
+    list.push(disposeObserver)
+  }
+  return list
+}
+
+type PresenceAction = Action & {
+  readonly kind: "e2e-presence"
+  readonly key: string
+}
+
+const ownedElements = new Map<string, Element>()
+
+const presenceRealizer: ActionRealizer<PresenceAction> = (action) => {
+  const el = document.createElement("div")
+  el.setAttribute("data-presence-marker", action.key)
+  document.body.appendChild(el)
+  ownedElements.set(action.key, el)
+  return [el]
+}
+
+/** Demonstrates Remark 7.2's ownership-signal path using only self-tag + apply() — no adapter, no invariant. */
+function markPresence(key: string): void {
+  apply<PresenceAction>([{ kind: "e2e-presence", key }], {
+    realize: presenceRealizer,
+    tagValue: () => key,
+  })
+}
+
+function intentionallyRemove(key: string): void {
+  const el = ownedElements.get(key)
+  if (el === undefined) return
+  releaseOwnership(el)
+  el.remove()
+}
+
+function hostileRemove(key: string): void {
+  const el = ownedElements.get(key)
+  if (el === undefined) return
+  el.remove() // no releaseOwnership() — simulates a vendor script yanking our node
+}
+
+function reassertIfRemovedByVendor(key: string): boolean {
+  const el = ownedElements.get(key)
+  if (el === undefined || !wasRemovedByVendor(el)) {
+    return false
+  }
+  ownedElements.delete(key)
+  markPresence(key)
+  return true
+}
+
+function isPresent(key: string): boolean {
+  return document.querySelector(`[data-presence-marker="${key}"]`) !== null
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- TS global augmentation requires `interface`, not `type`
+  interface Window {
+    __transport: {
+      installBootstrap(): { installedAt: number }
+      isBootstrapInstalled(): boolean
+      bootstrapInstalledAt(): number | undefined
+      uninstallBootstrap(): void
+      getEpoch(): number
+      startSensing(rootSelector: string): void
+      hypothesisSnapshot(): Record<string, Attrs>
+      reconcileCount(): number
+      teardownContentSession(): void
+      teardownDocumentSession(): void
+      markPresence(key: string): void
+      intentionallyRemove(key: string): void
+      hostileRemove(key: string): void
+      reassertIfRemovedByVendor(key: string): boolean
+      isPresent(key: string): boolean
+      pendingTimerFired(): Promise<boolean>
+    }
+  }
+}
+
+window.__transport = {
+  installBootstrap: (): { installedAt: number } => bootstrap.install(),
+  isBootstrapInstalled: (): boolean => bootstrap.isInstalled(),
+  bootstrapInstalledAt: (): number | undefined => bootstrap.installedAt(),
+  uninstallBootstrap: (): void => bootstrap.uninstall(),
+  getEpoch: (): number => session.epoch,
+  startSensing,
+  hypothesisSnapshot: (): Record<string, Attrs> => {
+    const snapshot: Record<string, Attrs> = {}
+    for (const key of hypothesis.keys()) {
+      const value = hypothesis.get(key)
+      if (value !== undefined) {
+        snapshot[key] = value
+      }
+    }
+    return snapshot
+  },
+  reconcileCount: (): number => reconcileCount,
+  teardownContentSession: (): void => {
+    teardownContent(currentDisposables(), session)
+    disposeObserver = undefined
+  },
+  teardownDocumentSession: (): void => {
+    teardownDocument(currentDisposables(), session, () => bootstrap.uninstall())
+    disposeObserver = undefined
+  },
+  markPresence,
+  intentionallyRemove,
+  hostileRemove,
+  reassertIfRemovedByVendor,
+  isPresent,
+  pendingTimerFired: (): Promise<boolean> =>
+    new Promise((resolve) => {
+      const before = reconcileCount
+      setTimeout(() => resolve(reconcileCount > before), 50)
+    }),
+}
+
+// Bootstrap installs the moment this bundle executes — the earliest hook
+// available to a page-injected script, standing in for `document_start`
+// (Definition D.2).
+bootstrap.install()

--- a/extensions/transport/tests/e2e/specs/actuator-and-teardown.spec.ts
+++ b/extensions/transport/tests/e2e/specs/actuator-and-teardown.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test"
+
+import { churn, hostilePageHtml } from "../fixtures/hostile-page"
+
+const HARNESS_BUNDLE = "tests/e2e/harness/dist/entry.js"
+
+test.beforeEach(async ({ page }) => {
+  await page.setContent(hostilePageHtml())
+  await page.addScriptTag({ path: HARNESS_BUNDLE })
+})
+
+test.describe("Hostile removal of actuator-owned DOM (Remark 7.2's ownership-signal path)", () => {
+  test("a vendor script removing an owned node is distinguished from our own teardown, and only the former re-asserts", async ({
+    page,
+  }) => {
+    await page.evaluate(() => window.__transport.markPresence("k1"))
+    expect(await page.evaluate(() => window.__transport.isPresent("k1"))).toBe(
+      true
+    )
+
+    await page.evaluate(() => window.__transport.hostileRemove("k1"))
+    expect(await page.evaluate(() => window.__transport.isPresent("k1"))).toBe(
+      false
+    )
+
+    const reasserted = await page.evaluate(() =>
+      window.__transport.reassertIfRemovedByVendor("k1")
+    )
+    expect(reasserted).toBe(true)
+    expect(await page.evaluate(() => window.__transport.isPresent("k1"))).toBe(
+      true
+    )
+  })
+
+  test("our own intentional removal does not trigger a re-assert", async ({
+    page,
+  }) => {
+    await page.evaluate(() => window.__transport.markPresence("k2"))
+    await page.evaluate(() => window.__transport.intentionallyRemove("k2"))
+    expect(await page.evaluate(() => window.__transport.isPresent("k2"))).toBe(
+      false
+    )
+
+    const reasserted = await page.evaluate(() =>
+      window.__transport.reassertIfRemovedByVendor("k2")
+    )
+    expect(reasserted).toBe(false)
+    expect(await page.evaluate(() => window.__transport.isPresent("k2"))).toBe(
+      false
+    )
+  })
+})
+
+test.describe("Full teardown", () => {
+  test("no dangling listeners/observers/timers after teardownContentSession()", async ({
+    page,
+  }) => {
+    await page.addScriptTag({ path: HARNESS_BUNDLE })
+    await page.evaluate(
+      (selector) => window.__transport.startSensing(selector),
+      "#content-root"
+    )
+
+    // Generate a burst of evidence to schedule a pending reconcile timer.
+    await churn.virtualizedRecycle(page, "#content-root", "k1", 1)
+
+    await page.evaluate(() => window.__transport.teardownContentSession())
+
+    const reconcileCountBefore = await page.evaluate(() =>
+      window.__transport.reconcileCount()
+    )
+
+    // Further mutation after teardown must produce no further evidence —
+    // the MutationObserver was disconnected, not merely paused.
+    await churn.virtualizedRecycle(page, "#content-root", "k1", 2)
+    await page.waitForTimeout(100)
+
+    const reconcileCountAfter = await page.evaluate(() =>
+      window.__transport.reconcileCount()
+    )
+    expect(reconcileCountAfter).toBe(reconcileCountBefore)
+
+    // No pending coalescer timer survives teardown.
+    const fired = await page.evaluate(() =>
+      window.__transport.pendingTimerFired()
+    )
+    expect(fired).toBe(false)
+  })
+
+  test("page unload leaves no uncaught exception from any live handle", async ({
+    page,
+  }) => {
+    await page.addScriptTag({ path: HARNESS_BUNDLE })
+    await page.evaluate(
+      (selector) => window.__transport.startSensing(selector),
+      "#content-root"
+    )
+
+    const pageErrors: Array<string> = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await page.evaluate(() => window.__transport.teardownDocumentSession())
+    await page.goto("about:blank")
+
+    expect(pageErrors).toEqual([])
+  })
+})

--- a/extensions/transport/tests/e2e/specs/bootstrap-persistence.spec.ts
+++ b/extensions/transport/tests/e2e/specs/bootstrap-persistence.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test, type Page } from "@playwright/test"
+
+import { churn, hostilePageHtml } from "../fixtures/hostile-page"
+
+const HARNESS_BUNDLE = "tests/e2e/harness/dist/entry.js"
+
+test.describe("Bootstrap persistence (Theorem D.1) and day-zero pessimism (Corollary D.1.1)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setContent(hostilePageHtml())
+    await page.addScriptTag({ path: HARNESS_BUNDLE })
+  })
+
+  test("sentinel is present the moment the bundle executes — before any content session exists", async ({
+    page,
+  }) => {
+    const installed = await page.evaluate(() =>
+      window.__transport.isBootstrapInstalled()
+    )
+    expect(installed).toBe(true)
+  })
+
+  const churnSteps: ReadonlyArray<{
+    readonly name: string
+    readonly run: (page: Page) => Promise<void>
+  }> = [
+    { name: "blank", run: churn.blank },
+    { name: "themeFlip", run: churn.themeFlip },
+    { name: "bodyHeadReplace", run: churn.bodyHeadReplace },
+    { name: "styleChurn", run: churn.styleChurn },
+    { name: "spaNavigate", run: churn.spaNavigate },
+    {
+      name: "virtualizedRecycle",
+      run: (page) => churn.virtualizedRecycle(page, "#content-root", "k1", 1),
+    },
+    // No actuator output has been produced yet in this test, so removing
+    // anything matching this selector is harmless by construction — the
+    // point is that Bootstrap survives regardless.
+    {
+      name: "extensionDomRemoval",
+      run: (page) => churn.extensionDomRemoval(page, "[data-nonexistent]"),
+    },
+  ]
+
+  for (const { name, run } of churnSteps) {
+    test(`Bootstrap survives churn step: ${name}`, async ({ page }) => {
+      const before = await page.evaluate(() =>
+        window.__transport.bootstrapInstalledAt()
+      )
+
+      await run(page)
+
+      const installed = await page.evaluate(() =>
+        window.__transport.isBootstrapInstalled()
+      )
+      const after = await page.evaluate(() =>
+        window.__transport.bootstrapInstalledAt()
+      )
+
+      expect(installed).toBe(true)
+      expect(after).toBe(before)
+    })
+  }
+
+  test("root replacement: sentinel survives because Bootstrap re-reads document.documentElement, which itself is never replaced", async ({
+    page,
+  }) => {
+    const before = await page.evaluate(() =>
+      window.__transport.bootstrapInstalledAt()
+    )
+    await churn.rootReplace(page)
+    const installed = await page.evaluate(() =>
+      window.__transport.isBootstrapInstalled()
+    )
+    const after = await page.evaluate(() =>
+      window.__transport.bootstrapInstalledAt()
+    )
+
+    expect(installed).toBe(true)
+    expect(after).toBe(before)
+  })
+})
+
+test.describe("Theorem D.1(a): same-document (SPA) navigation", () => {
+  test("content session is recreated, Bootstrap is untouched, epoch advances with no gap in custody", async ({
+    page,
+  }) => {
+    await page.setContent(hostilePageHtml())
+    await page.addScriptTag({ path: HARNESS_BUNDLE })
+
+    const before = await page.evaluate(() => ({
+      bootstrapAt: window.__transport.bootstrapInstalledAt(),
+      epoch: window.__transport.getEpoch(),
+    }))
+
+    await churn.spaNavigate(page)
+    await page.evaluate(() => window.__transport.teardownContentSession())
+    // "new content init" — the SPA-nav path never reinstalls Bootstrap.
+    await page.evaluate(
+      (selector) => window.__transport.startSensing(selector),
+      "#content-root"
+    )
+
+    const after = await page.evaluate(() => ({
+      bootstrapAt: window.__transport.bootstrapInstalledAt(),
+      installed: window.__transport.isBootstrapInstalled(),
+      epoch: window.__transport.getEpoch(),
+    }))
+
+    expect(after.installed).toBe(true)
+    expect(after.bootstrapAt).toBe(before.bootstrapAt)
+    expect(after.epoch).toBeGreaterThan(before.epoch)
+  })
+})
+
+test.describe("Theorem D.1(b): refresh", () => {
+  test("both Bootstrap and the content session are recreated", async ({
+    page,
+  }) => {
+    await page.setContent(hostilePageHtml())
+    await page.addScriptTag({ path: HARNESS_BUNDLE })
+
+    const before = await page.evaluate(() => ({
+      bootstrapAt: window.__transport.bootstrapInstalledAt(),
+      epoch: window.__transport.getEpoch(),
+    }))
+
+    await page.evaluate(() => window.__transport.teardownDocumentSession())
+    // "Bootstrap reinstall" + "new content init" — the refresh path.
+    await page.evaluate(() => window.__transport.installBootstrap())
+    await page.evaluate(
+      (selector) => window.__transport.startSensing(selector),
+      "#content-root"
+    )
+
+    const after = await page.evaluate(() => ({
+      bootstrapAt: window.__transport.bootstrapInstalledAt(),
+      epoch: window.__transport.getEpoch(),
+    }))
+
+    expect(after.bootstrapAt).not.toBe(before.bootstrapAt)
+    expect(after.epoch).toBeGreaterThan(before.epoch)
+  })
+})

--- a/extensions/transport/tests/e2e/specs/estimator-convergence.spec.ts
+++ b/extensions/transport/tests/e2e/specs/estimator-convergence.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test"
+
+import { churn, hostilePageHtml } from "../fixtures/hostile-page"
+
+const HARNESS_BUNDLE = "tests/e2e/harness/dist/entry.js"
+
+test.beforeEach(async ({ page }) => {
+  await page.setContent(hostilePageHtml())
+  await page.addScriptTag({ path: HARNESS_BUNDLE })
+  await page.evaluate(
+    (selector) => window.__transport.startSensing(selector),
+    "#content-root"
+  )
+})
+
+test.describe("Evidence-driven convergence (Theorem 5.1, integration-level)", () => {
+  test("the hypothesis converges to the injected ground truth regardless of how many times evidence is re-observed", async ({
+    page,
+  }) => {
+    // Duplicate/reordered delivery at the protocol level (Axioms 3.1–3.3)
+    // is exercised at the unit level (src/sensor/fuzz.test.ts,
+    // src/estimator/update.test.ts); here the same key is repeatedly
+    // recycled to different values via a real MutationObserver over a
+    // real browser DOM, proving the integration converges to the last
+    // written ground truth.
+    for (let value = 1; value <= 5; value++) {
+      await churn.virtualizedRecycle(page, "#content-root", "video-1", value)
+    }
+
+    await page.waitForFunction(() => {
+      const snapshot = window.__transport.hypothesisSnapshot()
+      return snapshot["video-1"]?.seq === 5
+    })
+
+    const snapshot = await page.evaluate(() =>
+      window.__transport.hypothesisSnapshot()
+    )
+    expect(snapshot["video-1"]).toEqual({ seq: 5 })
+  })
+
+  test("recycling a physical carrier to a different logical key converges each key to its own ground truth", async ({
+    page,
+  }) => {
+    await churn.virtualizedRecycle(page, "#content-root", "k1", 10)
+    await page.waitForFunction(
+      () => window.__transport.hypothesisSnapshot()["k1"]?.seq === 10
+    )
+
+    await churn.virtualizedRecycle(page, "#content-root", "k2", 20)
+    await page.waitForFunction(
+      () => window.__transport.hypothesisSnapshot()["k2"]?.seq === 20
+    )
+
+    const snapshot = await page.evaluate(() =>
+      window.__transport.hypothesisSnapshot()
+    )
+    expect(snapshot["k1"]).toEqual({ seq: 10 }) // k1's prior value is untouched by k2's recycling
+    expect(snapshot["k2"]).toEqual({ seq: 20 })
+  })
+})
+
+test.describe("Sustained high-frequency mutation (Theorem 7.1)", () => {
+  test("no uncaught exception, exactly one Bootstrap installation, hypothesis reaches quiescence once churn stops", async ({
+    page,
+  }) => {
+    const pageErrors: Array<string> = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await churn.sustainedMutation(page, 500, 1000)
+
+    // Quiescence: no further evidence means no further reconciler
+    // invocation (Theorem 7.1's t0-quiescent case).
+    const fired = await page.evaluate(() =>
+      window.__transport.pendingTimerFired()
+    )
+    expect(fired).toBe(false)
+
+    const installed = await page.evaluate(() =>
+      window.__transport.isBootstrapInstalled()
+    )
+    expect(installed).toBe(true)
+
+    expect(pageErrors).toEqual([])
+  })
+})

--- a/extensions/transport/tsconfig.json
+++ b/extensions/transport/tsconfig.json
@@ -15,6 +15,11 @@
       "@transport/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "vitest.config.ts", "playwright.config.ts"],
+  "include": [
+    "src/**/*.ts",
+    "tests/e2e/**/*.ts",
+    "vitest.config.ts",
+    "playwright.config.ts"
+  ],
   "exclude": ["node_modules", "dist", "build"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,9 +726,15 @@ importers:
       '@some-ui/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
+      fast-check:
+        specifier: ^3.23.1
+        version: 3.23.2
       maishatu-eslint-kit:
         specifier: workspace:*
         version: link:../../packages/eslint
@@ -2400,12 +2406,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -2414,12 +2414,6 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2436,12 +2430,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.28.1':
     resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
@@ -2450,12 +2438,6 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2472,12 +2454,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
@@ -2486,12 +2462,6 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2508,12 +2478,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
@@ -2522,12 +2486,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2544,12 +2502,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
@@ -2558,12 +2510,6 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2580,12 +2526,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
@@ -2594,12 +2534,6 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2616,12 +2550,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
@@ -2630,12 +2558,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2652,12 +2574,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
@@ -2666,12 +2582,6 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2688,12 +2598,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
@@ -2702,12 +2606,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2724,12 +2622,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -2738,12 +2630,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2760,12 +2646,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.28.1':
     resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
@@ -2774,12 +2654,6 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2796,12 +2670,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
@@ -2810,12 +2678,6 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2832,12 +2694,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
@@ -2846,12 +2702,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -7447,11 +7297,6 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -13415,16 +13260,10 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
@@ -13433,16 +13272,10 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
@@ -13451,16 +13284,10 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
@@ -13469,16 +13296,10 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -13487,16 +13308,10 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
@@ -13505,16 +13320,10 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
@@ -13523,16 +13332,10 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -13541,16 +13344,10 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
@@ -13559,16 +13356,10 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
@@ -13577,16 +13368,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
@@ -13595,16 +13380,10 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
@@ -13613,16 +13392,10 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
@@ -13631,16 +13404,10 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -18537,35 +18304,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-
   esbuild@0.28.1:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.1
@@ -23343,7 +23081,7 @@ snapshots:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
-      esbuild: 0.27.7
+      esbuild: 0.25.12
       open: 10.2.0
       recast: 0.23.12
       semver: 7.8.5
@@ -23365,7 +23103,7 @@ snapshots:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
-      esbuild: 0.27.7
+      esbuild: 0.25.12
       open: 10.2.0
       recast: 0.23.12
       semver: 7.8.5


### PR DESCRIPTION
## Description

Lands the remaining open issues in milestone 16 ("metamathematics."): all nine stories (S3–S11) of the `extensions/transport` epic, plus the epic itself.

`extensions/transport` implements the four-stage observe/estimate/plan/act architecture derived in `extensions/docs/dom-state-estimation-canon.typ` (§5–§8, §D). S1 (contracts) and S2 (bootstrap) had already landed in #619 and #624. This PR lands the rest:

- **S3** `session/`: epoch counter + reset operator (Definition 5.4, Theorem D.1)
- **S4** `sensor/`: hybrid event+poll observation channel (Definitions 3.1–3.3, Axioms 3.1–3.5)
- **S5** `sensor/identity`: extraction tiers + continuity check (Definition 4.1, Corollary 4.1.1)
- **S6** `estimator/`: hypothesis, evidentiary order, monotonic update (Theorem 5.1 confluence, Lemma 5.2 epoch dominance)
- **S7** `adapter/`: Business Adapter contract + the null adapter (Definition D.3, Theorem D.2 kernel independence)
- **S8** `scheduler/`: reconcile cadence + R-bounded delivery bookkeeping (Definition 7.2)
- **S9** `actuator/`: self-tagged idempotent actuation (Definition 7.3, Theorem 7.2 loop suppression, Corollary 7.3.1)
- **S10** `lifecycle/`: refresh vs. SPA-navigation reset semantics + teardown (Theorem D.1)
- **S11** `tests/e2e/`: a Playwright conformance suite bundled via esbuild and run against real Chromium, exercising the actual transport modules (not jsdom) against the null adapter

Every stage's directory boundaries are enforced by `eslint`'s `no-restricted-imports`, mirroring the existing `contracts/`/`bootstrap/` rules already in the package. Corollary D.2.1 (no module outside `adapter/` may reference a concrete adapter implementation) is enforced twice: by lint, and by a directory-listing test — both verified to actually catch a deliberate violation during development.

Closes #607
Closes #610 
Closes #611
Closes #612
Closes #613
Closes #614
Closes #615
Closes #616
Closes #617
Closes #618.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (every module cites the canon Definition/Axiom/Theorem it realizes)
- [x] My changes generate no new warnings (`pnpm lint` — eslint + prettier + typecheck — is clean)
- [x] I have added tests that prove my fix is effective or that my feature works (136 unit/property tests via vitest, 18 e2e tests via Playwright against real Chromium)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (n/a — no other package depends on `extensions/transport` yet)

## Screenshots

N/A — no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NR2DCcZXWtcBpH15m7ithb)_