### PR TITLE
Mark internal packages as private and fix WASM release workflow

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -37,3 +37,10 @@ pnpm install
 #   this hook). Without --continue, that one failure aborts the whole turbo
 #   run and leaves every other, unrelated package unbuilt too.
 pnpm build:unsafe --filter='!./crates/*' --continue=always || true
+
+# apps/www's build regenerates src/routeTree.gen.ts via
+# @tanstack/router-plugin's codegen, whose output format (quote style,
+# import order) has drifted from what's committed as the plugin version
+# floats on its ^ range. It's fully derived from src/routes/** - discard
+# any diff so the build doesn't leave every session starting dirty.
+git -C "$CLAUDE_PROJECT_DIR" checkout -- apps/www/src/routeTree.gen.ts 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -130,23 +130,36 @@ jobs:
             --out-dir dist \
             "crates/${{ matrix.crate_name }}"
       - name: Create changeset
+        id: changeset
         run: |
           PACKAGE_NAME="@some-ui/${{ matrix.crate_name }}"
           VERSION="${{ matrix.version }}"
           CHANGESET_ID="${{ matrix.crate_name }}-$(date +%s)"
+          CHANGESET_FILE=".changeset/${CHANGESET_ID}.md"
 
-          cat > ".changeset/${CHANGESET_ID}.md" << EOF
+          cat > "$CHANGESET_FILE" << EOF
           ---
           "${PACKAGE_NAME}": patch
           ---
 
           Update WASM package for ${{ matrix.crate_name }} to version ${VERSION}
           EOF
+
+          echo "file=${CHANGESET_FILE}" >> "$GITHUB_OUTPUT"
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
         with:
           name: wasm-dist-${{ matrix.crate_name }}
           path: crates/${{ matrix.crate_name }}/dist
+          if-no-files-found: error
+      # The build job's checkout is a separate, ephemeral working tree from
+      # the release job's - a changeset file written here never reaches
+      # `release` unless it travels as an artifact like the dist output does.
+      - name: Upload changeset
+        uses: actions/upload-artifact@v7
+        with:
+          name: wasm-changeset-${{ matrix.crate_name }}
+          path: ${{ steps.changeset.outputs.file }}
           if-no-files-found: error
   # ── Publish via changesets ───────────────────────────────────────────────
   release:
@@ -166,6 +179,12 @@ jobs:
           pattern: wasm-dist-*
           path: dist/wasm
           merge-multiple: false
+      - name: Download all WASM changesets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: wasm-changeset-*
+          path: .changeset
+          merge-multiple: true
       - name: Restore dist artifacts into each crate directory
         run: |
           set -euo pipefail

--- a/extensions/common/package.json
+++ b/extensions/common/package.json
@@ -40,6 +40,7 @@
     "shared"
   ],
   "name": "@some-extension/common",
+  "private": true,
   "peerDependencies": {
     "vite": "^6.0.7"
   },

--- a/extensions/some-censor/package.json
+++ b/extensions/some-censor/package.json
@@ -38,6 +38,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "@some-extension/censor",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-conveyor/package.json
+++ b/extensions/some-conveyor/package.json
@@ -42,6 +42,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "@some-extension/conveyor",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-cycle/package.json
+++ b/extensions/some-cycle/package.json
@@ -42,6 +42,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "some-cycle",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-cycle/packages/content/package.json
+++ b/extensions/some-cycle/packages/content/package.json
@@ -33,6 +33,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "name": "@some-cycle/content",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-cycle/packages/types/package.json
+++ b/extensions/some-cycle/packages/types/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "main": "./dist/esm/src/index.js",
   "name": "@some-cycle/types",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-filter/package.json
+++ b/extensions/some-filter/package.json
@@ -36,6 +36,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "@some-extension/filter",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-mujik/package.json
+++ b/extensions/some-mujik/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@some-extension/mujik",
+  "private": true,
   "version": "1.0.0",
   "description": "Ambient music visualizer overlay for YouTube/YouTube Music browser extension",
   "type": "module",

--- a/extensions/some-prompt/package.json
+++ b/extensions/some-prompt/package.json
@@ -32,6 +32,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "some-prompt",
+  "private": true,
   "peerDependencies": {},
   "repository": {
     "type": "git",

--- a/extensions/some-schedule/package.json
+++ b/extensions/some-schedule/package.json
@@ -5,6 +5,7 @@
     "@types/firefox-webext-browser": "^120.0.4"
   },
   "name": "@some-extensions/schedule",
+  "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.build.json && vite build",
     "clean": "rimraf .turbo && rimraf node_modules && rimraf .eslintcache && pnpm clean:build",

--- a/extensions/some-scrobbler/package.json
+++ b/extensions/some-scrobbler/package.json
@@ -40,6 +40,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "some-scrobbler",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-streak/package.json
+++ b/extensions/some-streak/package.json
@@ -32,6 +32,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "some-streak",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/some-tab-meta/package.json
+++ b/extensions/some-tab-meta/package.json
@@ -32,6 +32,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "some-tab-meta",
+  "private": true,
   "peerDependencies": {},
   "repository": {
     "type": "git",

--- a/extensions/suspender-ledger/package.json
+++ b/extensions/suspender-ledger/package.json
@@ -16,6 +16,7 @@
   "keywords": [],
   "license": "MPL-2.0 AND MIT",
   "name": "@some-extension/suspender-ledger",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/tab-tracker/package.json
+++ b/extensions/tab-tracker/package.json
@@ -35,6 +35,7 @@
   "main": "./dist/some-ui-utils.umd.js",
   "module": "./dist/esm/some-ui-utils.esm.js",
   "name": "@some-extension/tab-tracker",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/extensions/transport/package.json
+++ b/extensions/transport/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@some-extension/transport",
+  "private": true,
   "version": "0.0.1",
   "description": "Property-agnostic transport kernel implementing dom-state-estimation-canon.typ (§5–§8, §D)",
   "type": "module",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -28,6 +28,7 @@
   "main": "./dist/@some-ui/core-utils.cjs.js",
   "module": "./dist/@some-ui/core-utils.es.js",
   "name": "@some-ui/core-utils",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,5 +1,6 @@
 {
   "name": "maishatu-eslint-kit",
+  "private": true,
   "version": "2.0.0",
   "description": "Strict ESLint flat config kit for some-ui and related repos",
   "type": "module",

--- a/packages/fetch-kit/package.json
+++ b/packages/fetch-kit/package.json
@@ -28,6 +28,7 @@
   "main": "./dist/@some-ui/fetch-kit.cjs.js",
   "module": "./dist/@some-ui/fetch-kit.es.js",
   "name": "@some-ui/fetch-kit",
+  "private": true,
   "peerDependencies": {
     "@tanstack/react-query": "^5.66.11",
     "react": "^19.0.0",

--- a/packages/rollup-config/package.json
+++ b/packages/rollup-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-ui-rollup-config",
+  "private": true,
   "version": "1.0.0",
   "description": "rollup-sconfig for some-ui",
   "files": [

--- a/packages/some-content/package.json
+++ b/packages/some-content/package.json
@@ -44,6 +44,7 @@
     "shared"
   ],
   "name": "@some-ui/content",
+  "private": true,
   "peerDependencies": {
     "vite": "^6.0.7"
   },

--- a/packages/some-styles/package.json
+++ b/packages/some-styles/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@some-ui/styles",
+  "private": true,
   "version": "1.0.0",
   "description": "Shared design system (UnoCSS preset + shadcn tokens/themes) for the some-ui monorepo",
   "type": "module",

--- a/packages/some-vite-config/package.json
+++ b/packages/some-vite-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@some-ui/vite-config",
+  "private": true,
   "version": "1.0.0",
   "description": "Shared Vite configuration for monorepo packages",
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-types-utils",
+  "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/packages/ui/dice-card/package.json
+++ b/packages/ui/dice-card/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@some-ui/dice-card",
+  "private": true,
   "version": "0.0.1",
   "type": "module",
   "scripts": {

--- a/packages/ui/emoji-animations/package.json
+++ b/packages/ui/emoji-animations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-ui-emoji-animations",
+  "private": true,
   "version": "0.0.5",
   "type": "module",
   "scripts": {

--- a/packages/ui/makjang/package.json
+++ b/packages/ui/makjang/package.json
@@ -29,6 +29,7 @@
   "main": "./dist/some-ui-makjang.cjs.js",
   "module": "./dist/some-ui-makjang.es.js",
   "name": "@some-ui/makjang",
+  "private": true,
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/ui/neon-sign/package.json
+++ b/packages/ui/neon-sign/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-ui-neon-sign",
+  "private": true,
   "version": "0.0.5",
   "type": "module",
   "scripts": {

--- a/packages/ui/nfl/package.json
+++ b/packages/ui/nfl/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-ui-nfl",
+  "private": true,
   "version": "0.0.5",
   "type": "module",
   "scripts": {

--- a/packages/ui/overlays/package.json
+++ b/packages/ui/overlays/package.json
@@ -44,6 +44,7 @@
   "main": "./dist/overlays.cjs.js",
   "module": "./dist/overlays.es.js",
   "name": "@some-ui/overlays",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/paulgsc/some-ui"

--- a/packages/ui/portfolio-chart/package.json
+++ b/packages/ui/portfolio-chart/package.json
@@ -36,6 +36,7 @@
   "main": "./dist/some-ui-portfolio-chart.cjs.js",
   "module": "./dist/some-ui-portfolio-chart.es.js",
   "name": "@some-ui/portfolio",
+  "private": true,
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/ui/searchbar/package.json
+++ b/packages/ui/searchbar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-ui-searchbar",
+  "private": true,
   "version": "0.0.5",
   "type": "module",
   "scripts": {

--- a/packages/ui/shared/package.json
+++ b/packages/ui/shared/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-ui-shared",
+  "private": true,
   "version": "0.0.5",
   "type": "module",
   "sideEffects": [

--- a/packages/ui/slideshow/package.json
+++ b/packages/ui/slideshow/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@some-ui/slideshow",
+  "private": true,
   "version": "0.0.5",
   "type": "module",
   "scripts": {

--- a/packages/ui/umag/package.json
+++ b/packages/ui/umag/package.json
@@ -34,6 +34,7 @@
   "main": "./dist/umag.cjs.js",
   "module": "./dist/umag.es.js",
   "name": "@some-ui/umag",
+  "private": true,
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/ui/wireframes/package.json
+++ b/packages/ui/wireframes/package.json
@@ -35,6 +35,7 @@
   "main": "./dist/wireframes.cjs.js",
   "module": "./dist/wireframes.es.js",
   "name": "wireframes",
+  "private": true,
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "some-ui-utils",
+  "private": true,
   "version": "1.1.0",
   "type": "module",
   "scripts": {

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/ws.cjs.js",
   "module": "./dist/ws.es.js",
   "name": "@some-ui/ws",
+  "private": true,
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Description

This PR makes three key changes to improve the monorepo structure and release process:

1. **Mark all internal packages as private**: Added `"private": true` to 30+ package.json files across extensions, packages, and UI components. These packages are internal to the monorepo and should not be published to npm.

2. **Fix WASM release workflow**: Updated the `wasm-release.yml` workflow to properly handle changesets across separate job contexts:
   - Added step ID to the changeset creation step
   - Store changeset file path in GitHub Actions output
   - Upload changesets as artifacts from the build job
   - Download and merge changesets in the release job before publishing
   - Added explanatory comment about ephemeral working trees between jobs

3. **Switch release workflow to manual trigger**: Changed `release.yml` from automatic push-based triggering to `workflow_dispatch` for manual control over release timing.

4. **Fix session startup script**: Added cleanup step in `.claude/hooks/session-start.sh` to discard generated `routeTree.gen.ts` changes that drift from committed state due to plugin version variations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Motivation

- **Private packages**: Prevents accidental npm publication of internal monorepo utilities and prevents namespace pollution
- **WASM workflow fix**: Ensures changesets created during the build job are available in the release job, fixing a critical gap in the automated release pipeline
- **Manual releases**: Provides better control over when releases happen, reducing risk of unintended deployments
- **Session cleanup**: Prevents dirty working tree state from generated files that are not meant to be committed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Changes are consistent across all affected files
- [x] No new warnings generated

https://claude.ai/code/session_015ZBvPWn7wjD6SW1t9cdmsc