### PR TITLE
Fix: Use package.json name field for changeset package name

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Create changeset
         id: changeset
         run: |
-          PACKAGE_NAME="@some-ui/${{ matrix.crate_name }}"
+          PACKAGE_NAME=$(jq -r .name "crates/${{ matrix.crate_name }}/package.json")
           VERSION="${{ matrix.version }}"
           CHANGESET_ID="${{ matrix.crate_name }}-$(date +%s)"
           CHANGESET_FILE=".changeset/${CHANGESET_ID}.md"


### PR DESCRIPTION
## Description

This change updates the WASM release workflow to dynamically read the package name from each crate's `package.json` file instead of using a hardcoded naming pattern. Previously, the workflow assumed all packages followed the `@some-ui/{crate_name}` naming convention, which may not be accurate for all crates.

By using `jq` to extract the `name` field directly from `package.json`, the workflow now respects the actual package name defined in each crate's configuration, making it more flexible and maintainable.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation

The hardcoded package name pattern could cause mismatches between the changeset metadata and the actual published package name, potentially leading to release automation issues. This change ensures the changeset uses the correct package name as defined in each crate's `package.json`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Test Plan

The CI/CD pipeline will validate this change when the workflow runs during the next WASM release. The changeset file will be created with the correct package name extracted from `package.json`.

https://claude.ai/code/session_014pz6wpbnuZJo4b9D15CySm