### PR TITLE
fix(ci): resolve WASM release workflow issues — package name mismatch and self-triggering loop

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -7,6 +7,10 @@ on:
       - "Cargo.lock"
       - ".github/workflows/wasm-release.yml"
   workflow_dispatch:
+env:
+  # Also referenced (as a literal, see the `detect` job's `if:` comment)
+  # by the release-commit guard below - keep both in sync if this changes.
+  RELEASE_COMMIT_MESSAGE: "chore(release): update WASM packages"
 permissions:
   contents: write
   pull-requests: write
@@ -24,11 +28,15 @@ jobs:
   detect:
     name: Detect Changed WASM Crates
     runs-on: ubuntu-latest
-    # The release job's own version-bump commits land under crates/**
-    # (package.json, CHANGELOG.md) and would otherwise re-trigger this
-    # workflow, rebuild every bumped crate, mint fresh changesets, and
-    # spawn another release PR forever. Skip runs whose triggering commit
-    # is that release commit to break the cycle.
+    # Prevent release automation from triggering itself. The release job
+    # commits version bumps under crates/** (package.json, CHANGELOG.md),
+    # which match this workflow's own trigger paths. Without this guard,
+    # that commit would rerun detection, regenerate changesets, and create
+    # an endless release loop. Manual dispatches are always permitted.
+    #
+    # This must be a literal string, not `env.RELEASE_COMMIT_MESSAGE`: the
+    # `env` context isn't available in job-level `if:` conditions (only in
+    # steps). Keep this in sync with that env var by hand.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       !startsWith(github.event.head_commit.message, 'chore(release): update WASM packages')
@@ -211,8 +219,8 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1.4.9
         with:
-          commit: "chore(release): update WASM packages"
-          title: "chore(release): update WASM packages"
+          commit: ${{ env.RELEASE_COMMIT_MESSAGE }}
+          title: ${{ env.RELEASE_COMMIT_MESSAGE }}
           publish: nix develop .#ci --command npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -24,6 +24,14 @@ jobs:
   detect:
     name: Detect Changed WASM Crates
     runs-on: ubuntu-latest
+    # The release job's own version-bump commits land under crates/**
+    # (package.json, CHANGELOG.md) and would otherwise re-trigger this
+    # workflow, rebuild every bumped crate, mint fresh changesets, and
+    # spawn another release PR forever. Skip runs whose triggering commit
+    # is that release commit to break the cycle.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore(release): update WASM packages')
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
       has_changes: ${{ steps.detect.outputs.has_changes }}


### PR DESCRIPTION
## Description

Fixes two critical bugs in the WASM release workflow that were preventing proper CI operation:

1. **Package name mismatch**: The `Create changeset` step hardcoded `@some-ui/<crate_name>`, but `crates/leetype_wasm/package.json` is actually named `@some-ui/leetype-wasm` (hyphen). This caused `changeset version` to fail with "package which is not in the workspace" on every release run.

2. **Self-triggering loop**: Merging a changesets release PR lands version bumps under `crates/*/package.json` and `crates/*/CHANGELOG.md`, which match the workflow's own `crates/**` trigger path. This re-ran the pipeline, minted new changesets, and opened another release PR forever (#644 → #579 → #645 → ...). Now the workflow skips when triggered by its own release commits.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

1. **`.github/workflows/wasm-release.yml` (line 135)**: Read the real package name from each crate's `package.json` instead of assuming it matches the directory name.
2. **`.github/workflows/wasm-release.yml` (lines 24–31)**: Guard the `detect` job to skip the entire workflow when triggered by a `chore(release): update WASM packages` commit — the exact message the `changesets/action` step produces.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_014pz6wpbnuZJo4b9D15CySm)_