### PR TITLE
feat(styles): single-pass Tailwind determinism — www migration, per-package cleanup, wasm types

### DIFF
--- a/apps/www/src/index.css
+++ b/apps/www/src/index.css
@@ -1,11 +1,11 @@
+/* The shared design layer, compiled in a single pass over www's declared graph
+ * (style.context.ts + createStylePlugins in vite.config.ts): utilities + the
+ * shared layer are generated exactly once, from an explicit @source set.
+ *
+ * The per-package `@import "<pkg>/style.css"` lines were removed — each pulled a
+ * package's pre-compiled dist CSS, which carried its OWN copy of the shared
+ * Tailwind layer, and concatenating N of them let module-graph merge order
+ * decide the cascade (the non-determinism behind #636). Authored component CSS
+ * (plain keyframes/selectors, not utilities) is now loaded from package source
+ * in main.tsx. */
 @import "@some-ui/styles/tailwind.css";
-@import "@some-ui/honeycomb/style.css";
-@import "some-ui-input/style.css";
-@import "@some-ui/stepper/style.css";
-@import "@some-ui/chat/style.css";
-@import "@some-ui/slideshow/style.css";
-@import "some-ui-shared/style.css";
-@import "some-ui-neon-sign/style.css";
-@import "@some-ui/umag/style.css";
-@import "@some-ui/overlays/style.css";
-@import "wireframes/style.css";

--- a/apps/www/src/main.tsx
+++ b/apps/www/src/main.tsx
@@ -10,6 +10,21 @@ import "./index.css"
 
 import reportWebVitals from "./reportWebVitals.ts"
 
+// Authored component CSS (plain keyframes/selectors — not Tailwind utilities)
+// lives in each package's source next to its component. The single Tailwind
+// pass (index.css) regenerates every utility from scanned source but does not
+// carry this authored CSS, so pull it straight from package source here, the
+// way .storybook/preview.tsx already does. The root `<pkg>/src/index.css`
+// entries are excluded: they only `@import` the shared layer that index.css
+// already provides.
+import.meta.glob(
+  [
+    "../../../packages/ui/**/src/**/*.css",
+    "!../../../packages/ui/**/src/index.css",
+  ],
+  { eager: true }
+)
+
 // Create a new router instance
 const router = createRouter({
   routeTree,

--- a/apps/www/style.context.ts
+++ b/apps/www/style.context.ts
@@ -1,0 +1,46 @@
+import type { StyleContext } from "@some-ui/styles/styles-build"
+
+/**
+ * www's declared style graph: its own source plus every in-graph ui package's
+ * source. The single `some-styles-build` / dev-server pass scans exactly this
+ * union once — so utilities and the shared design layer are generated one time,
+ * deterministically, instead of once per package (the source of the Docker
+ * static-build drift in #636).
+ *
+ * This is www's dependency closure that renders UI. Pure build/util packages
+ * (vite-config, tsconfig, wasm-loader, fetch-kit, ws, types, *-utils) author no
+ * class candidates, so they're omitted; add one here if it ever ships a
+ * component.
+ */
+const uiPackages = [
+  "calendar",
+  "chat",
+  "dice-card",
+  "emoji-animations",
+  "honeycomb",
+  "input",
+  "makjang",
+  "neon-sign",
+  "nfl",
+  "overlays",
+  "portfolio-chart",
+  "resume",
+  "shared",
+  "slideshow",
+  "stepper",
+  "umag",
+  "wireframes",
+]
+
+const context: StyleContext = {
+  default: {
+    content: [
+      "src/**/*.{ts,tsx}",
+      "../../packages/some-content/src/**/*.{ts,tsx,mdx}",
+      ...uiPackages.map((p) => `../../packages/ui/${p}/src/**/*.{ts,tsx}`),
+    ],
+    outFile: "dist/styles.css",
+  },
+}
+
+export default context

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs"
 import { resolve } from "node:path"
-import tailwindcss from "@tailwindcss/vite"
+import { createStylePlugins } from "@some-ui/styles/styles-build/dev-config"
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite"
 import viteReact from "@vitejs/plugin-react"
 import { defineConfig, type UserConfig } from "vite"
+
+import styleContext from "./style.context"
 
 const certPath = resolve(__dirname, "../../certs/nixos.local+3.pem")
 const keyPath = resolve(__dirname, "../../certs/nixos.local+3-key.pem")
@@ -34,7 +36,10 @@ export default defineConfig(
         : {}),
     },
     plugins: [
-      tailwindcss(),
+      // Single Tailwind pass over www's declared graph (style.context.ts):
+      // utilities + the shared design layer are generated exactly once, from an
+      // explicit @source set, instead of once per package. See #636.
+      ...createStylePlugins(styleContext),
       TanStackRouterVite({ autoCodeSplitting: true }),
       viteReact(),
     ],

--- a/crates/leetype_wasm/package.json
+++ b/crates/leetype_wasm/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.3",
   "main": "dist/leetype_wasm.js",
   "module": "dist/leetype_wasm.js",
-  "types": "index.d.ts",
+  "types": "dist/leetype_wasm.d.ts",
   "type": "module",
   "scripts": {
     "build": "pnpm wasm:dev",

--- a/crates/some-crossword/package.json
+++ b/crates/some-crossword/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.3",
   "main": "dist/some_crossword.js",
   "module": "dist/some_crossword.js",
-  "types": "index.d.ts",
+  "types": "dist/some_crossword.d.ts",
   "type": "module",
   "scripts": {
     "build": "wasm-pack build --target web --release --out-dir dist",

--- a/crates/viewport-rotation/package.json
+++ b/crates/viewport-rotation/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.3",
   "main": "dist/viewport_rotation.js",
   "module": "dist/viewport_rotation.js",
-  "types": "index.d.ts",
+  "types": "dist/viewport_rotation.d.ts",
   "type": "module",
   "scripts": {
     "build": "wasm-pack build --target web --release --out-dir dist",

--- a/packages/some-styles/styles-build/dev-config.ts
+++ b/packages/some-styles/styles-build/dev-config.ts
@@ -2,31 +2,46 @@ import { isAbsolute, resolve } from "node:path"
 import tailwindcss from "@tailwindcss/vite"
 import { defineConfig, type Plugin, type UserConfig } from "vite"
 
-import { buildSourceInjection } from "./resolve-context.mjs"
+import { injectSourcesForCssId } from "./resolve-context.mjs"
 import type { StyleContext } from "./types.js"
 
 /**
- * Dev/build-server counterpart to styles-build/run.mjs, the styles analogue of
- * extensions/common/ext-build/dev-config.ts. A workspace's vite.config.ts is a
- * one-line wrapper around this, fed the SAME style.context.ts the production
- * `some-styles-build` pass reads — so the dev server and the static build scan
- * an identical source set and can't diverge.
- *
- * It returns the shared `@tailwindcss/vite` plugin plus a small transform that
- * appends the context's `@source` directives onto the Tailwind entry, so the
- * declared graph — not vite's cwd auto-detection — decides what is scanned.
+ * The shared `@tailwindcss/vite` plugin plus a transform that appends the
+ * declared context's `@source` directives onto the Tailwind entry — so the
+ * declared graph, not vite's cwd auto-detection, decides what a single pass
+ * scans. Return the array so a workspace with an existing vite config (e.g.
+ * apps/www, with its router/react plugins and build options) can spread these
+ * into its own `plugins` instead of replacing the whole config.
  */
-export function createStyleConfig(
+export function createStylePlugins(
   context: StyleContext,
   target = "default"
-): UserConfig {
+): Array<Plugin> {
   const ctx = context[target] ?? context.default
   const root = process.cwd()
   const content = (ctx?.content ?? []).map((glob) =>
     isAbsolute(glob) ? glob : resolve(root, glob)
   )
+  // The injector must transform the Tailwind entry BEFORE @tailwindcss/vite
+  // reads it, so it comes first. `tailwindcss()` returns several plugins;
+  // flatten so the caller gets one uniform array.
+  return [sourceInjector(content), tailwindcss()].flat()
+}
+
+/**
+ * Dev/build-server counterpart to styles-build/run.mjs, the styles analogue of
+ * extensions/common/ext-build/dev-config.ts. A workspace whose vite.config.ts
+ * needs nothing but the style pipeline uses this one-liner; a workspace with a
+ * richer config spreads {@link createStylePlugins} instead. Either way it reads
+ * the SAME style.context.ts the production `some-styles-build` pass reads, so
+ * the dev server and the static build scan an identical source set.
+ */
+export function createStyleConfig(
+  context: StyleContext,
+  target = "default"
+): UserConfig {
   return defineConfig({
-    plugins: [tailwindcss(), sourceInjector(content)],
+    plugins: createStylePlugins(context, target),
   })
 }
 
@@ -35,8 +50,7 @@ function sourceInjector(contentAbs: Array<string>): Plugin {
     name: "some-ui-styles:source-injector",
     enforce: "pre",
     transform(code, id): string | undefined {
-      if (!id.endsWith(".css")) return undefined
-      return buildSourceInjection(code, contentAbs) ?? undefined
+      return injectSourcesForCssId(code, id, contentAbs) ?? undefined
     },
   }
 }

--- a/packages/some-styles/styles-build/resolve-context.d.mts
+++ b/packages/some-styles/styles-build/resolve-context.d.mts
@@ -33,3 +33,13 @@ export declare function buildSourceInjection(
   code: string,
   contentAbs: Array<string>
 ): string | null
+
+/**
+ * The dev source-injector's per-module decision: inject the `@source` block
+ * only into CSS modules, matching on the path before any `?query` suffix.
+ */
+export declare function injectSourcesForCssId(
+  code: string,
+  id: string,
+  contentAbs: Array<string>
+): string | null

--- a/packages/some-styles/styles-build/resolve-context.mjs
+++ b/packages/some-styles/styles-build/resolve-context.mjs
@@ -81,3 +81,19 @@ export function buildSourceInjection(code, contentAbs) {
   if (!ENTRY_MARKERS.some((marker) => code.includes(marker))) return null
   return `${code}\n${SOURCE_SENTINEL}\n${toSourceDirectives(contentAbs)}\n`
 }
+
+/**
+ * The dev source-injector's per-module decision (see dev-config.ts): inject the
+ * `@source` block only into CSS modules. Vite tags CSS ids with query suffixes
+ * (e.g. `index.css?used`), so match on the path before the query.
+ *
+ * @param {string} code           Module source.
+ * @param {string} id             Vite module id (may carry a `?query`).
+ * @param {string[]} contentAbs   Absolute content globs.
+ * @returns {string | null}
+ */
+export function injectSourcesForCssId(code, id, contentAbs) {
+  const path = id.split("?")[0] ?? id
+  if (!path.endsWith(".css")) return null
+  return buildSourceInjection(code, contentAbs)
+}

--- a/packages/some-styles/styles-build/tests/compile.test.ts
+++ b/packages/some-styles/styles-build/tests/compile.test.ts
@@ -8,6 +8,7 @@ import exampleContext from "../examples/style.context.js"
 import {
   buildSourceInjection,
   CANONICAL_ENTRY,
+  injectSourcesForCssId,
   resolveContext,
   SOURCE_SENTINEL,
   toSourceDirectives,
@@ -137,6 +138,28 @@ describe("toSourceDirectives / buildSourceInjection", () => {
 
   it("no-ops when there is no declared content", () => {
     expect(buildSourceInjection('@import "tailwindcss";', [])).toBeNull()
+  })
+})
+
+describe("injectSourcesForCssId", () => {
+  const entry = '@import "tailwindcss";'
+
+  it("injects into a .css module id", () => {
+    const out = injectSourcesForCssId(entry, "/app/src/index.css", ["/x/**"])
+    expect(out).toContain('@source "/x/**";')
+  })
+
+  it("injects even when the id carries a ?query suffix (vite tags CSS ids)", () => {
+    const out = injectSourcesForCssId(entry, "/app/src/index.css?used", [
+      "/x/**",
+    ])
+    expect(out).toContain('@source "/x/**";')
+  })
+
+  it("ignores non-CSS module ids", () => {
+    expect(
+      injectSourcesForCssId(entry, "/app/src/main.tsx", ["/x/**"])
+    ).toBeNull()
   })
 })
 

--- a/packages/some-styles/styles-build/tests/dev-config.test.ts
+++ b/packages/some-styles/styles-build/tests/dev-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { createStylePlugins } from "../dev-config.js"
+import type { StyleContext } from "../types.js"
+
+const context: StyleContext = {
+  default: { content: ["src/**/*.tsx"] },
+}
+
+describe("createStylePlugins", () => {
+  it("returns the source-injector BEFORE the Tailwind plugin", () => {
+    // Order matters: the injector must transform the Tailwind entry (append
+    // @source) before @tailwindcss/vite reads it. A regression here silently
+    // drops every out-of-app source from the scan — the app compiles only its
+    // own utilities and every package component renders unstyled.
+    const names = createStylePlugins(context).map((p) => p.name)
+    expect(names[0]).toBe("some-ui-styles:source-injector")
+    expect(names).toContain("@tailwindcss/vite:scan")
+  })
+})

--- a/packages/ui/chat/src/index.css
+++ b/packages/ui/chat/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/chat/src/index.ts
+++ b/packages/ui/chat/src/index.ts
@@ -1,5 +1,3 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./types"
 export { interviewQuestions } from "./data/interview-questions"

--- a/packages/ui/dice-card/src/index.css
+++ b/packages/ui/dice-card/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/dice-card/src/index.ts
+++ b/packages/ui/dice-card/src/index.ts
@@ -1,5 +1,3 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./hooks"
 export * from "./utils"

--- a/packages/ui/honeycomb/src/index.css
+++ b/packages/ui/honeycomb/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/honeycomb/src/index.ts
+++ b/packages/ui/honeycomb/src/index.ts
@@ -1,3 +1,1 @@
-import "./index.css"
-
 export { HangulHexGrid } from "./components"

--- a/packages/ui/input/src/hooks/leetype/use-typing-game-wasm/index.test.ts
+++ b/packages/ui/input/src/hooks/leetype/use-typing-game-wasm/index.test.ts
@@ -139,7 +139,9 @@ beforeEach(async () => {
   instances = []
   resetWasm()
   const wasmStub = await import("@some-ui/leetype-wasm")
-  vi.mocked(wasmStub.default)
+  vi
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the wasm init's InitOutput return is unused; the mock only needs to resolve
+    .mocked(wasmStub.default as unknown as () => Promise<void>)
     .mockReset()
     .mockImplementation(() => Promise.resolve())
 })
@@ -211,7 +213,10 @@ describe("resolve-after-unmount safety (aliveRef guard)", () => {
   it("does not construct a game instance if loadWasm resolves after unmount", async () => {
     const wasmStub = await import("@some-ui/leetype-wasm")
     const gate = deferred<void>()
-    vi.mocked(wasmStub.default).mockImplementation(() => gate.promise)
+    vi
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the wasm init's InitOutput return is unused; the mock only needs to resolve
+      .mocked(wasmStub.default as unknown as () => Promise<void>)
+      .mockImplementation(() => gate.promise)
 
     const { unmount } = renderHook(() => useTypingGame(baseProps()))
 
@@ -234,7 +239,10 @@ describe("resolve-after-unmount safety (aliveRef guard)", () => {
   it("does not surface an error state if loadWasm rejects after unmount", async () => {
     const wasmStub = await import("@some-ui/leetype-wasm")
     const gate = deferred<void>()
-    vi.mocked(wasmStub.default).mockImplementation(() => gate.promise)
+    vi
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the wasm init's InitOutput return is unused; the mock only needs to resolve
+      .mocked(wasmStub.default as unknown as () => Promise<void>)
+      .mockImplementation(() => gate.promise)
 
     const { result, unmount } = renderHook(() => useTypingGame(baseProps()))
     unmount()

--- a/packages/ui/input/src/hooks/use-crossword-wasm/index.test.ts
+++ b/packages/ui/input/src/hooks/use-crossword-wasm/index.test.ts
@@ -51,7 +51,8 @@ beforeEach(async () => {
   generatorInstances = []
   const mod = await import("@some-ui/some-crossword")
   initMock = vi
-    .mocked(mod.default)
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the wasm init's InitOutput return is unused; the mock only needs to resolve
+    .mocked(mod.default as unknown as () => Promise<void>)
     .mockReset()
     .mockImplementation(() => Promise.resolve())
   // vitest 4 types a mocked class constructor as Mock<typeof CrosswordGenerator>,

--- a/packages/ui/input/src/hooks/use-viewport-rotation-wasm/index.test.ts
+++ b/packages/ui/input/src/hooks/use-viewport-rotation-wasm/index.test.ts
@@ -71,7 +71,8 @@ beforeEach(async () => {
 
   const mod = await import("@some-ui/viewport-rotation")
   initMock = vi
-    .mocked(mod.default)
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the wasm init's InitOutput return is unused; the mock only needs to resolve
+    .mocked(mod.default as unknown as () => Promise<void>)
     .mockReset()
     .mockImplementation(() => Promise.resolve())
   // vitest 4 types a mocked class constructor as Mock<typeof ViewportManager>,

--- a/packages/ui/input/src/index.css
+++ b/packages/ui/input/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/input/src/index.ts
+++ b/packages/ui/input/src/index.ts
@@ -1,5 +1,3 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./lib"
 export * from "./types"

--- a/packages/ui/input/src/wasm-shims.d.ts
+++ b/packages/ui/input/src/wasm-shims.d.ts
@@ -1,0 +1,22 @@
+// The published @some-ui/{leetype-wasm,some-crossword,viewport-rotation}@0.0.3
+// ship their wasm-pack `dist/*.d.ts`, but their package.json "types" points at a
+// nonexistent `index.d.ts`, so TypeScript can't find the declarations and every
+// import resolves to `any` (TS7016). The root cause is fixed for future
+// publishes in crates/*/package.json; this re-exports the real, already-shipped
+// declarations so consumers resolve types against the installed 0.0.3 today.
+// Remove once a corrected version is published and adopted.
+//
+// wasm-pack modules have a default export (the `__wbg_init` loader) plus named
+// exports, so both are re-exported.
+declare module "@some-ui/leetype-wasm" {
+  export * from "@some-ui/leetype-wasm/dist/leetype_wasm"
+  export { default } from "@some-ui/leetype-wasm/dist/leetype_wasm"
+}
+declare module "@some-ui/some-crossword" {
+  export * from "@some-ui/some-crossword/dist/some_crossword"
+  export { default } from "@some-ui/some-crossword/dist/some_crossword"
+}
+declare module "@some-ui/viewport-rotation" {
+  export * from "@some-ui/viewport-rotation/dist/viewport_rotation"
+  export { default } from "@some-ui/viewport-rotation/dist/viewport_rotation"
+}

--- a/packages/ui/neon-sign/src/index.css
+++ b/packages/ui/neon-sign/src/index.css
@@ -1,2 +1,0 @@
-@import "@some-ui/styles/tailwind.css";
-@import "some-ui-shared/style.css";

--- a/packages/ui/neon-sign/src/index.ts
+++ b/packages/ui/neon-sign/src/index.ts
@@ -1,4 +1,2 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./hooks"

--- a/packages/ui/overlays/src/index.css
+++ b/packages/ui/overlays/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/overlays/src/index.ts
+++ b/packages/ui/overlays/src/index.ts
@@ -1,4 +1,2 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./hooks"

--- a/packages/ui/shared/src/index.css
+++ b/packages/ui/shared/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/shared/src/index.ts
+++ b/packages/ui/shared/src/index.ts
@@ -1,5 +1,3 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./hooks"
 //

--- a/packages/ui/slideshow/src/index.css
+++ b/packages/ui/slideshow/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/slideshow/src/index.ts
+++ b/packages/ui/slideshow/src/index.ts
@@ -1,5 +1,3 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./types"
 export * from "./hooks"

--- a/packages/ui/stepper/src/index.css
+++ b/packages/ui/stepper/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/stepper/src/index.ts
+++ b/packages/ui/stepper/src/index.ts
@@ -1,4 +1,2 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./types"

--- a/packages/ui/umag/src/index.css
+++ b/packages/ui/umag/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/umag/src/index.ts
+++ b/packages/ui/umag/src/index.ts
@@ -1,4 +1,2 @@
-import "./index.css"
-
 export * from "./components"
 export * from "./hooks"

--- a/packages/ui/wireframes/src/index.css
+++ b/packages/ui/wireframes/src/index.css
@@ -1,1 +1,0 @@
-@import "@some-ui/styles/tailwind.css";

--- a/packages/ui/wireframes/src/index.ts
+++ b/packages/ui/wireframes/src/index.ts
@@ -1,4 +1,2 @@
-import "./index.css"
-
 export * from "@wireframes/components"
 export type { LayoutNode } from "./lib"


### PR DESCRIPTION
## Description

Completes the single-pass Tailwind work behind #636 (styles not building for the tanstack www docker image). Four commits, each a self-contained step:

1. **`feat(styles): add createStylePlugins`** — engine helper so a vite app can run the single pass in-process: returns `[source-injector, @tailwindcss/vite]` (injector first, so it appends the declared `@source` set before Tailwind reads the entry) plus a pure, tested `injectSourcesForCssId()`.

2. **`feat(www): compile styles in one pass over the declared graph`** — www now runs **one** Tailwind pass over its dependency graph instead of importing ten packages' prebuilt `dist/*.css` (each carrying its own copy of the shared layer). `style.context.ts` declares the graph; `index.css` drops the per-package imports; `main.tsx` pulls authored component CSS from package source (as `.storybook/preview.tsx` already does).

3. **`fix(wasm): point package "types" at the shipped declarations`** — the `@some-ui/{leetype-wasm,some-crossword,viewport-rotation}` crates ship their wasm-pack `dist/*.d.ts` but pointed `package.json` "types" at a nonexistent `index.d.ts`, so `some-ui-input`'s `tsc` failed with TS7016 (and blocked any www-graph build). Fixes the crate manifests for future publishes; a re-export shim in input resolves types against the installed `0.0.3` today; input's wasm test mocks are updated to the real `Promise<InitOutput>` init signature.

4. **`refactor(ui): stop compiling the shared Tailwind layer into each package`** — with www reading source, no consumer reads these packages' `dist/*.css`, so each package's framework-only root `src/index.css` was pure duplication. Deletes the 11 of them.

## Verification

Built www end-to-end (`vite build`) after every step and checked the emitted CSS:

| Signal | Before | After |
| --- | --- | --- |
| Copies of the shared Tailwind layer | 11 | **1** |
| Whole-graph utilities (dice-card `transform-3d`, scramble-card `bg-neon`, …) | per-package only | **present** |
| Authored keyframes (border-beam, now-playing, …) | present | **present (64)** |
| Total CSS | ~783 kB (sum of per-package dist) | **~550 kB** |

`some-ui-input` now `tsc`-clean; `@some-ui/styles` typecheck + 20 unit tests green. Verified that component CSS `@theme`/`@custom-variant` directives (e.g. scramble-card's `bg-neon`) are correctly merged into www's single pass, and that deleting the per-package root CSS leaves www byte-identical.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes / follow-ups (out of scope here)

- A few component CSS files still carry a load-bearing `@import "tailwindcss"` for their `@theme`/`@custom-variant`; consolidating those scattered directives into the shared `@some-ui/styles` layer would let their packages emit zero framework CSS (and shave another ~90 kB off www).
- The three wasm test files share module-singleton/timer state and fail when run **together** (pre-existing, independent of the types fix); worth a separate test-isolation pass.
- The `main.tsx` authored-CSS glob matches all `packages/ui/**` source CSS (like storybook's), a slight superset of the exact graph — `import.meta.glob` needs static literal patterns, so it can't derive from `style.context.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)