### PR TITLE
fix(ci): stop wasm-release pnpm install from breaking on the release commit

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -149,16 +149,13 @@ jobs:
       - uses: ./.github/actions/cargo-cache
         with:
           key-suffix: wasm-${{ matrix.crate_name }}
-      - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
-      - name: Install dependencies
-        run: |
-          nix develop .#ci --command pnpm install \
-            --frozen-lockfile \
-            --prefer-offline
-        env:
-          HUSKY: 0
+      # No pnpm install here on purpose: wasm-pack build below only needs
+      # the Rust/cargo toolchain from the nix devshell, and nothing later in
+      # this job touches node_modules. A workspace-wide pnpm install would
+      # also be broken on the release commit itself - changesets has just
+      # bumped consumer package.json files (e.g. packages/ui/input) to pin
+      # the crate version this job is about to build, and pnpm-lock.yaml
+      # can't reflect that until it's regenerated.
       # Each crate's own package.json wraps this same invocation under
       # different script names (wasm:prod, build, ...) - calling wasm-pack
       # directly here keeps the matrix build uniform regardless of which
@@ -240,10 +237,17 @@ jobs:
             rm -rf "crates/${crate_name}/dist"
             mv "$artifact_dir" "crates/${crate_name}/dist"
           done
+      # --frozen-lockfile is intentionally not used here: on the release
+      # commit, changesets has already bumped consumer package.json files to
+      # pin the crate versions this job publishes, so pnpm-lock.yaml can't be
+      # in sync yet. pnpm resolves those pins against the local crates/*
+      # workspace packages (link-workspace-packages, pnpm's default) rather
+      # than the registry, so this doesn't need the not-yet-published npm
+      # versions to already exist.
       - name: Install dependencies
         run: |
           nix develop .#ci --command pnpm install \
-            --frozen-lockfile \
+            --no-frozen-lockfile \
             --prefer-offline
         env:
           HUSKY: 0


### PR DESCRIPTION
## Description

`.github/workflows/wasm-release.yml`'s `build` job ran a workspace-wide `pnpm install --frozen-lockfile` step before building the wasm crate, even though the actual build step already calls `wasm-pack build` directly and touches no `node_modules`. On the release commit itself (e.g. the commit produced by merging a Version Packages PR like this one), changesets bumps downstream consumer `package.json` files — e.g. `packages/ui/input` pinning `@some-ui/leetype-wasm` to the new version — before `pnpm-lock.yaml` can be regenerated to match. `--frozen-lockfile` then fails immediately with `ERR_PNPM_OUTDATED_LOCKFILE`, before wasm-pack ever runs: https://github.com/paulgsc/some-ui/actions/runs/29306795611/job/87001667354

Fix:
- **`build` job**: drop the `pnpm-cache` + `pnpm install --frozen-lockfile` steps entirely. Nothing in this job needs `node_modules` — `wasm-pack build` runs directly via the nix devshell (as it already did), and changeset/artifact creation is plain bash/jq.
- **`release` job**: still needs a pnpm install (for `changesets/action`'s `npx changeset publish`), but drop `--frozen-lockfile` there too, since the lockfile is expected to be behind the just-bumped manifests at this point in the pipeline. pnpm resolves those version pins against the local `crates/*` workspace packages (`link-workspace-packages`, pnpm's default) rather than the npm registry, so this doesn't depend on the not-yet-published npm versions existing yet.

This targets `changeset-release/main` directly (rather than `main`) so the fix is in place before this release PR is merged and re-triggers the publish workflow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective (this is a CI workflow change; validated by re-running the WASM Release workflow after merge)

## Screenshots

N/A — CI workflow change only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ak1J41fpHeCHQYG7MxAC4z)_