### PR TITLE
fix(ci): scope wasm-release publish install to the root project only

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -237,17 +237,24 @@ jobs:
             rm -rf "crates/${crate_name}/dist"
             mv "$artifact_dir" "crates/${crate_name}/dist"
           done
-      # --frozen-lockfile is intentionally not used here: on the release
-      # commit, changesets has already bumped consumer package.json files to
-      # pin the crate versions this job publishes, so pnpm-lock.yaml can't be
-      # in sync yet. pnpm resolves those pins against the local crates/*
-      # workspace packages (link-workspace-packages, pnpm's default) rather
-      # than the registry, so this doesn't need the not-yet-published npm
-      # versions to already exist.
+      # This only needs the root project's own devDependencies (changesets
+      # and friends) to run `npx changeset publish` below - nothing here
+      # needs the rest of the workspace installed. That's not just an
+      # optimization: a full install is actually broken at this point in the
+      # pipeline. On the release commit, changesets has already bumped
+      # consumer package.json files (e.g. extensions/some-conveyor pinning
+      # "@some-ui/polyhedron": "0.0.4") to a version that doesn't exist on
+      # npm yet - this job is what's about to publish it. Those are plain
+      # semver pins, not `workspace:`, so pnpm won't link them locally; any
+      # whole-workspace resolution (even with --no-frozen-lockfile, even
+      # just to compute a fresh lockfile) fails with ERR_PNPM_NO_MATCHING_VERSION
+      # before ever reaching the publish step. `--filter .` scopes
+      # resolution to the root package, and `--no-lockfile` skips the
+      # workspace-wide lockfile pnpm would otherwise insist on computing.
       - name: Install dependencies
         run: |
-          nix develop .#ci --command pnpm install \
-            --no-frozen-lockfile \
+          nix develop .#ci --command pnpm --filter . install \
+            --no-lockfile \
             --prefer-offline
         env:
           HUSKY: 0


### PR DESCRIPTION
## Description

Follow-up to #657, which fixed the `build` job but only partially fixed the `release` job. #657 dropped `--frozen-lockfile` from the release job's `pnpm install`, on the assumption pnpm would link the just-bumped wasm crates (e.g. `@some-ui/polyhedron@0.0.4`) locally instead of hitting the npm registry. That assumption was wrong, confirmed by the next real run: https://github.com/paulgsc/some-ui/actions/runs/29333337947/job/87087118649

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @some-ui/hangul-game-core@0.0.4 while fetching it from https://registry.npmjs.org/
```

Downstream consumers (e.g. `extensions/some-conveyor`, `packages/ui/honeycomb`) pin these wasm crates with plain semver (`"0.0.4"`), not the `workspace:` protocol — that's intentional, per the design goal that other environments consume the stable published npm version rather than a local link. But it means pnpm always resolves them from the registry, and that version can't exist yet: publishing it is what this very job is about to do. `--no-frozen-lockfile` didn't help because pnpm still needs to fully resolve the workspace to compute *any* lockfile, frozen or not.

I reproduced this locally by checking out the exact commit CI ran against (`1fb7a2f`) and running `pnpm install` outside CI — same error. Then verified the fix the same way:

```
pnpm --filter . install --no-lockfile --prefer-offline
```

`--filter .` scopes resolution to the root project (where `@changesets/cli` actually lives — the only thing this step needs to make `npx changeset publish` runnable), and `--no-lockfile` skips the workspace-wide lockfile pnpm otherwise insists on computing even under a filter. This installs cleanly in ~10s and never touches the unpublished pins, confirmed against the same commit that failed in CI.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (reproduced the failure and verified the fix locally against the same commit CI failed on; will also validate with a `workflow_dispatch` run before merging)

## Screenshots

N/A — CI workflow change only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ak1J41fpHeCHQYG7MxAC4z)_