### PR TITLE
fix(www): CSP wasm-unsafe-eval fix + Docker Hub release CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,6 +122,24 @@ jobs:
             --filter='!./extensions/**' \
             --concurrency=100%
 
+      # Scoped to the CSP/nginx config surface actually touched by this PR -
+      # this is a config invariant (apps/www/nginx.security-headers.conf),
+      # not a per-package build/test, so turbo's dep-graph filter doesn't
+      # apply the way it does to the steps above. Regression coverage for
+      # #660 (www's CSP header blocked WebAssembly instantiation).
+      - name: E2E — CSP regression (www)
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR HEAD^1 -- \
+            'apps/www/Dockerfile' \
+            'apps/www/nginx*.conf' \
+            'apps/www/tests/csp/**' \
+            'apps/www/playwright.config.ts' || true)
+          if [ -n "$files" ]; then
+            nix develop .#ci-playwright --command pnpm --filter www test:e2e
+          else
+            echo "No CSP-relevant www files changed."
+          fi
+
   # ── Dependency license audit ────────────────────────────────────────────
   deny:
     name: Deny Checks

--- a/.github/workflows/www-docker-release.yml
+++ b/.github/workflows/www-docker-release.yml
@@ -1,0 +1,225 @@
+name: WWW Docker Release
+# Publishes the tanstack `www` app's Docker image to Docker Hub
+# (paulgsc/www — see infra/compose/www.yml).
+#
+# apps/www sits at the wide end of this monorepo's dependency graph: nearly
+# every workspace package (and, transitively through some-ui-input, several
+# wasm crates) can end up in its build. A workspace dependency bumping its
+# own version is a poor publish trigger on its own — it very often carries
+# no user-visible change to www at all. So this workflow doesn't build+push
+# straight off a green build. It mirrors the changesets idiom already used
+# elsewhere in this repo (release.yml, wasm-release.yml): detect a change
+# reachable from www, accumulate it into a standing release PR, and only
+# build+push the image once a human merges that PR. The merge is the
+# judgment call detection can't make on its own.
+#
+# Deliberately NOT changesets/action for the PR step: release.yml and
+# wasm-release.yml already point changesets/action at the same
+# `changeset-release/main` branch (that coupling is exactly what
+# wasm-release.yml's cascading-bump workarounds exist to patch around — see
+# #657-#659). A third consumer of that shared branch would mix an unrelated
+# Docker-publish decision into the same PR as npm version bumps. This
+# workflow drives `@changesets/cli` directly and opens its own PR on its own
+# branch instead, so review here is scoped to "does this diff warrant a new
+# image" and nothing else.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/www/**"
+      - "packages/**"
+      - "crates/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/www-docker-release.yml"
+  workflow_dispatch:
+    inputs:
+      publish_only:
+        description: "Skip detection/PR and build+push straight from the current apps/www package.json version (use to retry a publish that failed after the release PR merged)"
+        type: boolean
+        default: false
+env:
+  RELEASE_COMMIT_MESSAGE: "chore(release): publish www docker image"
+  RELEASE_BRANCH: "changeset-release/www-docker"
+  DOCKERHUB_IMAGE: "paulgsc/www"
+permissions:
+  contents: read
+concurrency:
+  group: www-docker-release-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  # ── Detect whether www's build graph actually changed ───────────────────
+  # Patterned after wasm-release.yml's detect job (bash + explicit outputs)
+  # rather than dorny/paths-filter: paths-filter isn't dependency-graph-aware
+  # (see pr.yml), and a plain `apps/www/**` filter would miss the transitive
+  # workspace-dependency bumps that are the whole reason this workflow opens
+  # a PR instead of publishing directly. No strategy.matrix here, unlike
+  # wasm-release.yml's per-crate matrix — there's exactly one image to build.
+  detect:
+    name: Detect www Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+      is_release_commit: ${{ steps.detect.outputs.is_release_commit }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/nix-setup
+      - uses: ./.github/actions/pnpm-cache
+        with:
+          shell: ci
+      - name: Install dependencies
+        run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
+        env:
+          HUSKY: 0
+      - name: Detect changes reachable from www
+        id: detect
+        run: |
+          set -euo pipefail
+
+          # Is this push *the* release commit (the PR above just got
+          # merged), rather than an ordinary source change? That commit only
+          # touches apps/www/package.json + CHANGELOG.md, which still match
+          # this workflow's trigger paths — it must still run, but skip
+          # re-opening/updating the PR (see release-pr job) or it would loop
+          # forever re-detecting its own version bump as "www changed".
+          is_release_commit=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_only }}" = "true" ]; then
+            is_release_commit=true
+          elif [ "${{ github.event_name }}" = "push" ] && [[ "${{ github.event.head_commit.message }}" == "${{ env.RELEASE_COMMIT_MESSAGE }}"* ]]; then
+            is_release_commit=true
+          fi
+          echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
+
+          if [ "$is_release_commit" = "true" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            has_changes=true
+          else
+            BASE="${{ github.event.before }}"
+            if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+              # First push to main we've seen (or history was rewritten) -
+              # no prior state to diff against, so treat as changed.
+              has_changes=true
+            else
+              # `www...[from...to]` = www and everything it depends on,
+              # scoped to what actually changed in that range. An empty
+              # task list means nothing reachable from www moved.
+              nix develop .#ci --command pnpm turbo run build \
+                --filter="www...[${BASE}...${{ github.sha }}]" \
+                --dry=json > /tmp/www-detect.json
+              task_count=$(sed -n '/^{/,$p' /tmp/www-detect.json | jq '.tasks | length')
+              if [ "$task_count" -gt 0 ]; then
+                has_changes=true
+              else
+                has_changes=false
+              fi
+            fi
+          fi
+          echo "has_changes=${has_changes}" >> "$GITHUB_OUTPUT"
+
+  # ── Open/update the release PR ──────────────────────────────────────────
+  # Runs `@changesets/cli` directly (not changesets/action - see header) to
+  # bump apps/www's version + CHANGELOG, then opens a PR on a dedicated
+  # branch. Re-running this on a later push updates the same PR/branch, so
+  # multiple dependency bumps before a maintainer gets to it collapse into
+  # one review instead of one PR each.
+  release-pr:
+    name: Open/Update www Release PR
+    needs: detect
+    if: needs.detect.outputs.has_changes == 'true' && needs.detect.outputs.is_release_commit != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/nix-setup
+      - uses: ./.github/actions/pnpm-cache
+        with:
+          shell: ci
+      - name: Install dependencies
+        run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
+        env:
+          HUSKY: 0
+      - name: Write changeset
+        run: |
+          cat > ".changeset/www-docker-$(date +%s).md" << 'EOF'
+          ---
+          "www": patch
+          ---
+
+          www's build graph changed - the app itself or one of its workspace
+          dependencies was touched since the last Docker publish. Most
+          dependency bumps don't change www's actual behaviour, so this
+          needs a human read of the diff: merge (squash) this PR to build
+          and push an updated `paulgsc/www` image to Docker Hub, or close it
+          if the change doesn't warrant a new image.
+          EOF
+      # `changeset version` consumes every pending changeset in .changeset/,
+      # not just the one written above - left alone, it would also sweep up
+      # (and delete) any changeset still awaiting release.yml or
+      # wasm-release.yml's own runs, silently absorbing an unrelated npm
+      # package or wasm crate bump into this Docker-only PR. Move everything
+      # else aside first and restore it after, so this release track only
+      # ever touches www's own changeset.
+      - name: Apply version bump and changelog
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/other-changesets
+          find .changeset -maxdepth 1 -name '*.md' ! -name 'www-docker-*.md' \
+            -exec mv {} /tmp/other-changesets/ \;
+
+          nix develop .#ci --command npx changeset version
+
+          shopt -s nullglob
+          other_changesets=(/tmp/other-changesets/*.md)
+          if [ "${#other_changesets[@]}" -gt 0 ]; then
+            mv "${other_changesets[@]}" .changeset/
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Open release PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ${{ env.RELEASE_BRANCH }}
+          base: main
+          delete-branch: true
+          commit-message: ${{ env.RELEASE_COMMIT_MESSAGE }}
+          title: ${{ env.RELEASE_COMMIT_MESSAGE }}
+          body: >
+            Opened automatically because a change reachable from `apps/www`
+            landed on `main`. Review the diff — most workspace dependency
+            bumps don't change www's actual behaviour — and merge via
+            **squash** (the merge commit message drives the publish step
+            below) to build and push `${{ env.DOCKERHUB_IMAGE }}`.
+
+  # ── Build + push the image ──────────────────────────────────────────────
+  # Only runs once the release PR above has actually been merged (or a
+  # maintainer forced it via workflow_dispatch publish_only). No nix/pnpm
+  # needed here - the Dockerfile's own build stages are self-contained.
+  publish:
+    name: Build & Push Docker Image
+    needs: detect
+    if: needs.detect.outputs.is_release_commit == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Read version
+        id: version
+        run: echo "version=$(jq -r .version apps/www/package.json)" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/www/Dockerfile
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}
+            ${{ env.DOCKERHUB_IMAGE }}:latest

--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -108,6 +108,8 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 # ------------------------------------------------------------
 FROM mirror.gcr.io/library/nginx:alpine AS runtime
 
+COPY apps/www/nginx.security-headers.conf /etc/nginx/security-headers.conf
+
 RUN <<'EOF' > /etc/nginx/conf.d/default.conf
 server {
     listen 80;
@@ -125,11 +127,7 @@ server {
         add_header Cache-Control "public, no-transform";
     }
 
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    include /etc/nginx/security-headers.conf;
 }
 EOF
 

--- a/apps/www/nginx.https.conf
+++ b/apps/www/nginx.https.conf
@@ -5,6 +5,11 @@
 # terminates TLS with the same mkcert certs `vite dev` already uses
 # (apps/www/vite.config.ts / certs/nixos.local+3*.pem), so getUserMedia
 # (mic access, e.g. the interview app) sees a secure context over the LAN.
+#
+# `include /etc/nginx/security-headers.conf` below resolves even though this
+# file replaces default.conf via a bind mount: security-headers.conf is
+# COPY'd into the image by the Dockerfile itself, not part of conf.d, so it
+# survives the mount untouched.
 server {
     listen 80;
     server_name localhost nixos.local;
@@ -21,11 +26,7 @@ server {
         add_header Cache-Control "public, no-transform";
     }
 
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    include /etc/nginx/security-headers.conf;
 }
 
 server {
@@ -47,9 +48,5 @@ server {
         add_header Cache-Control "public, no-transform";
     }
 
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    include /etc/nginx/security-headers.conf;
 }

--- a/apps/www/nginx.security-headers.conf
+++ b/apps/www/nginx.security-headers.conf
@@ -1,0 +1,18 @@
+# Single source of truth for the response headers served by both the
+# production image (Dockerfile) and local HTTPS dev (nginx.https.conf) -
+# `include`d by both instead of duplicated, so a header change (e.g. #660)
+# only has to happen in one place. apps/www/tests/csp/csp.spec.ts reads this
+# file directly to test the header that's actually shipped.
+#
+# wasm-unsafe-eval: apps/www ships several wasm-bindgen crates (hangul game,
+# leetype, crossword, viewport-rotation) via some-ui-input - WebAssembly
+# instantiation is gated by this keyword independently of 'unsafe-eval'.
+# unsafe-eval is deliberately NOT included: the only JS eval caller in the
+# bundle is zod's `allowsEval` capability check, which already catches the
+# CSP failure and falls back to a non-eval path - widening the policy would
+# buy nothing but attack surface. See #660.
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "no-referrer-when-downgrade" always;
+add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'wasm-unsafe-eval'" always;

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,7 @@
 {
   "name": "www",
   "private": true,
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,7 +18,8 @@
     "lint:js": "cross-env NODE_OPTIONS='--max_old_space_size=4096' eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
     "prettier": "prettier \"**/*.{js,mjs,ts,tsx,md,mdx,json,yml,css}\" --ignore-path $(git rev-parse --show-toplevel)/.prettierignore --check --cache",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test --config playwright.config.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
@@ -54,6 +56,7 @@
     "zod": "4.0.5"
   },
   "devDependencies": {
+    "@playwright/test": "1.60.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.2.0",
     "@vitejs/plugin-react": "^6.0.3",

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -1,0 +1,44 @@
+/**
+ * Headless-Chromium Playwright configuration for apps/www.
+ *
+ * Scope: config/behaviour regression checks that don't need the app built
+ * (e.g. tests/csp - asserts the CSP header actually shipped in the Docker
+ * image, via page.route fulfilment rather than a running server/container).
+ * Not a browser/UI E2E suite for the app itself.
+ */
+
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.ts",
+
+  timeout: 15_000,
+  retries: 0,
+  workers: 1,
+
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+  ],
+
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: process.env["PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"]
+          ? {
+              executablePath:
+                process.env["PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"],
+            }
+          : {},
+      },
+    },
+  ],
+})

--- a/apps/www/tests/csp/csp.spec.ts
+++ b/apps/www/tests/csp/csp.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression coverage for #660: the production CSP header blocked
+ * WebAssembly instantiation (missing 'wasm-unsafe-eval'), breaking every
+ * wasm-bindgen crate apps/www ships (hangul game, leetype, crossword,
+ * viewport-rotation - all pulled in via some-ui-input).
+ *
+ * These tests don't boot nginx/Docker: they read the literal header string
+ * from apps/www/nginx.security-headers.conf (the file both the Dockerfile
+ * and nginx.https.conf `include`, so there is exactly one copy - see that
+ * file's header comment) and replay it via page.route fulfilment, which
+ * Chromium enforces identically to a real server response.
+ *
+ * The WASM/eval attempts run from an inline <script> in the served page,
+ * not from page.evaluate() - Playwright's page.evaluate() executes via CDP
+ * Runtime.evaluate, which Chromium's 'unsafe-eval' check exempts (a
+ * DevTools-console carve-out), so it would silently pass regardless of the
+ * CSP header. page.evaluate() is only used below to read back a result the
+ * inline script already computed.
+ */
+
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { expect, test, type Page } from "@playwright/test"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SECURITY_HEADERS_CONF = resolve(
+  __dirname,
+  "../../nginx.security-headers.conf"
+)
+
+type CSPProbeResult = {
+  wasmOk: boolean
+  wasmError: string | null
+  evalBlocked: boolean | null
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- TS global augmentation requires `interface`, not `type`
+  interface Window {
+    __cspProbeResult?: CSPProbeResult
+  }
+}
+
+function readShippedCSP(): string {
+  const conf = readFileSync(SECURITY_HEADERS_CONF, "utf8")
+  const match = /Content-Security-Policy\s+"([^"]+)"/.exec(conf)
+  if (!match) {
+    throw new Error(
+      `Could not find a Content-Security-Policy header in ${SECURITY_HEADERS_CONF}`
+    )
+  }
+  return match[1]
+}
+
+// Inline <script> (real page script, not a CDP-injected evaluate call) that
+// attempts the same two operations the #660 report flagged: instantiating a
+// WebAssembly module and calling the Function constructor. The smallest
+// legal WASM module is just the 4-byte magic number plus a 4-byte version
+// field - no imports/exports/functions required.
+const PROBE_HTML = `<!DOCTYPE html>
+<html>
+<body>
+<script>
+  window.__cspProbeResult = { wasmOk: false, wasmError: null, evalBlocked: null };
+  (async () => {
+    try {
+      const bytes = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+      await WebAssembly.instantiate(bytes);
+      window.__cspProbeResult.wasmOk = true;
+    } catch (e) {
+      window.__cspProbeResult.wasmError = String((e && e.message) || e);
+    }
+    try {
+      new Function("return 1")();
+      window.__cspProbeResult.evalBlocked = false;
+    } catch (e) {
+      window.__cspProbeResult.evalBlocked = true;
+    }
+  })();
+</script>
+</body>
+</html>`
+
+async function runCSPProbe(page: Page, csp: string): Promise<CSPProbeResult> {
+  await page.route("**/*", (route) =>
+    route.fulfill({
+      body: PROBE_HTML,
+      contentType: "text/html",
+      headers: { "content-security-policy": csp },
+    })
+  )
+  await page.goto("https://localhost/__csp-regression__")
+  await page.waitForFunction(
+    () => window.__cspProbeResult?.evalBlocked !== null
+  )
+  const result = await page.evaluate(() => window.__cspProbeResult)
+  if (!result) {
+    throw new Error("CSP probe script did not run")
+  }
+  return result
+}
+
+test.describe("www Content-Security-Policy", () => {
+  test("the shipped header permits WebAssembly instantiation", async ({
+    page,
+  }) => {
+    const result = await runCSPProbe(page, readShippedCSP())
+
+    expect(result.wasmOk, result.wasmError ?? undefined).toBe(true)
+  })
+
+  test("the shipped header still blocks plain JS eval", async ({ page }) => {
+    const result = await runCSPProbe(page, readShippedCSP())
+
+    // zod's `allowsEval` capability check (a dependency pulled in by
+    // apps/www) already catches this failure and falls back to a non-eval
+    // path - see the header comment in nginx.security-headers.conf. This
+    // assertion pins that we deliberately did NOT add 'unsafe-eval' to fix
+    // #660, so a future edit can't silently widen the policy.
+    expect(result.evalBlocked).toBe(true)
+  })
+
+  test("sanity: a header without wasm-unsafe-eval blocks WebAssembly (proves the assertion above is meaningful)", async ({
+    page,
+  }) => {
+    const preFixHeader =
+      "default-src 'self' http: https: data: blob: 'unsafe-inline'"
+
+    const result = await runCSPProbe(page, preFixHeader)
+
+    expect(result.wasmOk).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
         specifier: 4.0.5
         version: 4.0.5
     devDependencies:
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1


### PR DESCRIPTION
## Description

Two independent changes for `apps/www`:

**1. Fixes #660 — CSP blocked WebAssembly**

The production CSP header (`default-src 'self' http: https: data: blob: 'unsafe-inline'`) lacked `'wasm-unsafe-eval'`, so every wasm-bindgen crate www ships (hangul game, leetype, crossword, viewport-rotation — all pulled in via `some-ui-input`) failed to instantiate in the browser.

- Added `'wasm-unsafe-eval'` to the CSP.
- Deliberately **did not** add `'unsafe-eval'`. Triaged the JS-eval violation in the issue's console log to `zod`'s `allowsEval` capability check (`node_modules/zod/v4/core/util.js`) — it already catches the CSP failure in a try/catch and falls back to a non-eval path, so it's not actually broken, just noisy. Widening the policy to silence it would buy nothing but attack surface.
- The header was duplicated 3× (Dockerfile heredoc + two server blocks in `nginx.https.conf`), which is exactly how a fix in one place stays broken in the others. Extracted it into `apps/www/nginx.security-headers.conf`, `include`d by both — now there's one copy.

**2. Playwright regression coverage for the CSP header**

Added `apps/www/tests/csp/csp.spec.ts`. It doesn't boot nginx/Docker — it reads the literal header string out of `nginx.security-headers.conf` and replays it via `page.route` fulfilment, which Chromium enforces identically to a real server response. Three assertions:
- the shipped header permits WebAssembly instantiation (would have caught #660)
- the shipped header still blocks plain JS eval (pins that we didn't widen the policy)
- a sanity check that the pre-fix header actually fails the WASM assertion (proves the harness can detect the regression, not just pass by construction)

Worth noting: the WASM/eval attempts run from an inline `<script>` in the served page, not from `page.evaluate()` — Playwright's `page.evaluate()` executes via CDP `Runtime.evaluate`, which Chromium's `unsafe-eval` check exempts (a DevTools-console carve-out). Learned this the hard way while writing the eval-blocked assertion; documented in the test file's header comment.

Wired into `pr.yml` as a new step in the Node CI job, scoped to a `git diff` check against the CSP/nginx config surface (Dockerfile, nginx confs, the test files themselves) so it doesn't run on every PR — matches the existing "Lint styles (changed files)" step's scoping pattern in the same job.

**3. `www-docker-release.yml` — Docker Hub publish CI**

`apps/www` sits at the wide end of this repo's dependency graph — nearly every workspace package (and, transitively through `some-ui-input`, several wasm crates) can end up in its build. A workspace dependency bumping its own version is a poor publish trigger on its own: it very often carries no user-visible change to www at all. So this doesn't build+push off a green build.

- **Detect**: patterned after `wasm-release.yml`'s detect job (bash + explicit outputs, no `strategy.matrix` since there's only one image). Uses turbo's `www...[from...to]` dependency-aware filter — validated locally that it correctly returns an empty task list for commits that don't touch www's dependency closure, and the full closure for commits that do (e.g. a `packages/ui/*` change) — rather than a plain `apps/www/**` path filter, which would miss transitive dependency bumps entirely.
- **Release PR**: on a detected change, opens/updates a PR via `@changesets/cli` (`changeset version`) + `peter-evans/create-pull-request`, on a dedicated `changeset-release/www-docker` branch — **deliberately not** `changesets/action`, since `release.yml` and `wasm-release.yml` already point that action at the same `changeset-release/main` branch (the exact coupling `wasm-release.yml`'s cascading-bump workarounds in #657–#659 exist to patch around). A third consumer of that shared branch would mix an unrelated Docker-publish decision into the same PR as npm version bumps. Also isolates the version-bump step so it only ever consumes the changeset this workflow wrote, not any changeset still awaiting `release.yml`/`wasm-release.yml`'s own runs.
- **Publish**: only runs once that PR is merged (detected via commit message, same technique `wasm-release.yml` already uses — requires squash-merge, noted in the workflow comments). Builds `apps/www/Dockerfile` and pushes `paulgsc/www:<version>` + `paulgsc/www:latest` to Docker Hub.

Needs two repo secrets that don't exist yet: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings — `tsc --noEmit`, `eslint`, and `prettier --check` all clean on the new/touched files; pre-existing lint debt in untouched files (`scripts/analyze-bundle.js`, `src/reportWebVitals.ts`, `src/routes/overlays/youtube.tsx`) was left alone
- [x] I have added tests that prove my fix is effective — `apps/www/tests/csp/csp.spec.ts`, verified locally to fail with the exact #660 error when the fix is reverted and pass when restored
- [x] New and existing unit/e2e tests pass locally with my changes

## Follow-ups for a maintainer

- Add `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets before `www-docker-release.yml`'s publish job can run.
- First run of `www-docker-release.yml` will open a release PR (or can be forced via `workflow_dispatch`) — worth a dry run to confirm the Docker Hub push works end-to-end.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C2HAAFNVXsToAqcHKhTsTB)_