### PR TITLE
Add .gitignore protection hook to prevent Claude modifications

### DIFF
--- a/.claude/hooks/protect-gitignore.sh
+++ b/.claude/hooks/protect-gitignore.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Blocks Claude from creating, editing, or removing any .gitignore file in
+# this repo (root or nested), regardless of instructions given later in the
+# conversation. Changes to .gitignore must be made by a human.
+
+input=$(cat)
+tool_name=$(jq -r '.tool_name // empty' <<<"$input")
+
+MSG='Blocked by project policy: .gitignore files must not be changed by Claude. If a change is needed, a human must edit .gitignore directly.'
+
+deny() {
+  jq -n --arg reason "$MSG" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+is_gitignore() {
+  # $1 = file path (possibly empty/relative/absolute)
+  [ -n "$1" ] && [ "$(basename -- "$1")" = ".gitignore" ]
+}
+
+case "$tool_name" in
+  Edit|Write)
+    file_path=$(jq -r '.tool_input.file_path // empty' <<<"$input")
+    is_gitignore "$file_path" && deny
+    ;;
+  NotebookEdit)
+    file_path=$(jq -r '.tool_input.notebook_path // .tool_input.file_path // empty' <<<"$input")
+    is_gitignore "$file_path" && deny
+    ;;
+  Bash)
+    command=$(jq -r '.tool_input.command // empty' <<<"$input")
+    # Evaluate line by line so an unrelated ">" or command word elsewhere in
+    # a multi-line command (e.g. an email trailer in a commit message body)
+    # can't combine with a same-string .gitignore mention to false-positive.
+    while IFS= read -r line; do
+      # Only look at lines that mention a .gitignore path at all.
+      if grep -qE '(^|[^[:alnum:]_-])\.gitignore([^[:alnum:]_-]|$)' <<<"$line"; then
+        # ...and where .gitignore is itself the target of a mutating idiom:
+        # redirected into, or passed as an argument to an in-place-edit /
+        # delete / move / copy / overwrite tool. Read-only commands like
+        # `cat .gitignore`, `grep foo .gitignore`, `git check-ignore`, or
+        # prose that merely mentions the filename (e.g. a commit message)
+        # pass through.
+        if grep -qE '>{1,2}[[:space:]]*[^[:space:]]*\.gitignore\b|\b(sed|perl)\b[^|&;]*-i[^|&;]*\.gitignore\b|\b(tee|rm|mv|cp|truncate|dd|awk|python[0-9.]*|node)\b[^|&;]*\.gitignore\b' <<<"$line"; then
+          deny
+        fi
+      fi
+    done <<<"$command"
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-gitignore.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Description

This change adds a project-level security hook that prevents Claude from creating, editing, or deleting `.gitignore` files in the repository. The hook is enforced at the tool-use level and blocks any attempt to modify `.gitignore` files through Edit, Write, NotebookEdit, or Bash tools, regardless of instructions given in the conversation.

The protection is implemented via a new pre-tool-use hook script that:
- Blocks direct file edits/writes to any `.gitignore` file (root or nested)
- Detects and blocks bash commands that attempt to mutate `.gitignore` files (redirects, in-place edits, deletions, moves, copies, etc.)
- Allows read-only operations like `cat`, `grep`, or `git check-ignore` to pass through
- Distinguishes between actual file operations and mere mentions of `.gitignore` in prose (e.g., commit messages)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation

This ensures that critical `.gitignore` configuration cannot be accidentally or maliciously modified by Claude, requiring any changes to be made explicitly by a human developer. This is a security best practice for repository configuration files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Test Plan

The hook will be automatically invoked by Claude's tool-use system when attempting to modify `.gitignore` files. Manual verification can be done by attempting to edit a `.gitignore` file in conversation and confirming the denial message is returned.

https://claude.ai/code/session_01JM5BcZ6DU1c9v9NnJ5GP5Z