### PR TITLE
test(wireframes): property/regression tests, tsc+eslint fixes, 3 FSM bugs found and fixed

### DIFF
--- a/apps/www/src/routes/overlays/youtube.tsx
+++ b/apps/www/src/routes/overlays/youtube.tsx
@@ -1,9 +1,11 @@
 import { componentRegistry } from "@some-ui/content-registry"
-import { dramaTree } from "@some-ui/content-registry/data/layout-tree"
-import { useSceneDrivenLayout } from "@some-ui/content-registry/hooks/use-scene-driven-layout"
 import { createFileRoute } from "@tanstack/react-router"
 import { useSceneLifetimes } from "some-ui-utils"
-import { OrchestratedYouTubeViewport } from "wireframes"
+import {
+  dramaTree,
+  OrchestratedYouTubeViewport,
+  useSceneDrivenLayout,
+} from "wireframes"
 
 // Search params validation
 type YouTubeWireframeSearch = {

--- a/packages/ui/wireframes/package.json
+++ b/packages/ui/wireframes/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "@some-ui/tsconfig": "workspace:*",
-    "@some-ui/vite-config": "workspace:*"
+    "@some-ui/vite-config": "workspace:*",
+    "fast-check": "^3.23.1"
   },
   "exports": {
     ".": {
@@ -52,6 +53,7 @@
     "lint": "pnpm lint:js && pnpm prettier && pnpm typecheck",
     "lint:js": "cross-env NODE_OPTIONS='--max_old_space_size=4096' eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
     "prettier": "prettier \"**/*.{js,mjs,ts,tsx,md,mdx,json,yml,css}\" --ignore-path $(git rev-parse --show-toplevel)/.prettierignore --check --cache",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "watch:build": "rollup --bundleConfigAsCjs -c --watch",
     "watch:lint": "eslint --watch --cache --fix \"**/*.{js,mjs,ts,tsx}\""

--- a/packages/ui/wireframes/src/components/youtube/resizable-wireframe/index.stories.tsx
+++ b/packages/ui/wireframes/src/components/youtube/resizable-wireframe/index.stories.tsx
@@ -1,40 +1,10 @@
 import { componentRegistry } from "@some-ui/content-registry"
-import { useSceneDrivenLayout } from "@some-ui/content-registry/hooks/use-scene-driven-layout"
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useSceneDrivenLayout } from "@wireframes/hooks/use-scene-driven-layout"
 import { dramaTree } from "@wireframes/lib/layout-tree"
 import { useSceneLifetimes } from "some-ui-utils"
 
 import { OrchestratedYouTubeViewport } from "."
-
-// ============================================================================
-// Meta Configuration
-// ============================================================================
-
-const meta = {
-  title: "UI/Wireframes/OrchestratedYouTubeViewport",
-  component: OrchestratedYouTubeViewport,
-  parameters: {
-    layout: "fullscreen",
-    docs: {
-      description: {
-        component: `
-# Orchestrated YouTube Viewport
-
-Each panel is a parent component that can contain multiple time-limited children.
-        `,
-      },
-    },
-  },
-  argTypes: {
-    transitionMs: {
-      control: { type: "range", min: 0, max: 1000, step: 50 },
-    },
-  },
-  tags: ["autodocs"],
-} satisfies Meta<typeof OrchestratedYouTubeViewport>
-
-export default meta
-type Story = StoryObj<typeof meta>
 
 // ============================================================================
 // Helper: AnimatedStory Wrapper
@@ -67,6 +37,36 @@ const AnimatedStory = ({
     </div>
   )
 }
+
+// ============================================================================
+// Meta Configuration
+// ============================================================================
+
+const meta = {
+  title: "UI/Wireframes/OrchestratedYouTubeViewport",
+  component: AnimatedStory,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: `
+# Orchestrated YouTube Viewport
+
+Each panel is a parent component that can contain multiple time-limited children.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    transitionMs: {
+      control: { type: "range", min: 0, max: 1000, step: 50 },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof AnimatedStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
 
 // ============================================================================
 // Stories

--- a/packages/ui/wireframes/src/index.ts
+++ b/packages/ui/wireframes/src/index.ts
@@ -1,2 +1,6 @@
 export * from "@wireframes/components"
+export { useSceneDrivenLayout } from "./hooks/use-scene-driven-layout"
 export type { LayoutNode } from "./lib"
+export { dramaTree, studyTree, topikTree, voiceTree } from "./lib/layout-tree"
+export { SCENE_LAYOUT_MAP } from "./types/layout-trees-map"
+export type { SceneName } from "./types/layout-trees-map"

--- a/packages/ui/wireframes/src/lib/__tests__/layout-intent-arbitrary.ts
+++ b/packages/ui/wireframes/src/lib/__tests__/layout-intent-arbitrary.ts
@@ -1,0 +1,66 @@
+import fc from "fast-check"
+import type { YouTubeRegion } from "some-types-utils"
+
+import type { LayoutIntent } from "../layout-intent"
+
+/**
+ * A small, fixed alphabet (the real YouTubeRegion slots) instead of unique
+ * generated strings - this forces repeats and self-references within short
+ * sequences, which is exactly where "weird timeline" bugs (duplicated or
+ * vanished regions) hide.
+ */
+export const regionArbitrary: fc.Arbitrary<YouTubeRegion> = fc.constantFrom(
+  "video",
+  "title",
+  "mainContent",
+  "footerLeft",
+  "sidebarTop",
+  "sidebarBottom",
+  "footerRight"
+)
+
+export const edgeArbitrary: fc.Arbitrary<"left" | "right" | "top" | "bottom"> =
+  fc.constantFrom("left", "right", "top", "bottom")
+
+const reorderEdgeArbitrary: fc.Arbitrary<"before" | "after"> = fc.constantFrom(
+  "before",
+  "after"
+)
+
+export const layoutIntentArbitrary: fc.Arbitrary<LayoutIntent<YouTubeRegion>> =
+  fc.oneof(
+    fc.record({
+      kind: fc.constant("place" as const),
+      region: regionArbitrary,
+      relativeTo: fc.option(regionArbitrary, { nil: undefined }),
+      edge: edgeArbitrary,
+    }),
+    fc.record({
+      kind: fc.constant("move" as const),
+      region: regionArbitrary,
+      relativeTo: regionArbitrary,
+      edge: edgeArbitrary,
+    }),
+    fc.record({
+      kind: fc.constant("remove" as const),
+      region: regionArbitrary,
+    }),
+    fc.record({
+      kind: fc.constant("reorder" as const),
+      region: regionArbitrary,
+      relativeTo: regionArbitrary,
+      edge: reorderEdgeArbitrary,
+    }),
+    fc.record({
+      kind: fc.constant("resize" as const),
+      region: regionArbitrary,
+      edge: edgeArbitrary,
+      deltaPx: fc.integer({ min: -400, max: 400 }),
+      containerSizePx: fc.integer({ min: 100, max: 2000 }),
+    })
+  )
+
+export const layoutIntentSequenceArbitrary = fc.array(layoutIntentArbitrary, {
+  minLength: 1,
+  maxLength: 50,
+})

--- a/packages/ui/wireframes/src/lib/__tests__/tree-invariants.ts
+++ b/packages/ui/wireframes/src/lib/__tests__/tree-invariants.ts
@@ -1,0 +1,44 @@
+import type { LayoutNode } from "../layout-weighted"
+
+/**
+ * Counts occurrences of every leaf id in the tree. Unlike `extractLeafIds`
+ * (a Set), this surfaces duplicate leaves instead of silently collapsing them -
+ * duplication is exactly the class of bug a Set-based assertion would hide.
+ */
+export function countLeafOccurrences<R>(
+  tree: LayoutNode<R> | null
+): Map<R, number> {
+  const counts = new Map<R, number>()
+  if (tree === null) return counts
+
+  const stack: Array<LayoutNode<R>> = [tree]
+  while (stack.length) {
+    const node = stack.pop()!
+    if (node.type === "leaf") {
+      counts.set(node.id, (counts.get(node.id) ?? 0) + 1)
+    } else {
+      for (const { node: child } of node.children) stack.push(child)
+    }
+  }
+  return counts
+}
+
+/** Every split must have at least 2 children; a 0/1-child split is a broken tree. */
+export function isStructurallyValid<R>(tree: LayoutNode<R> | null): boolean {
+  if (tree === null) return true
+  if (tree.type === "leaf") return true
+  if (tree.children.length < 2) return false
+  return tree.children.every(({ node }) => isStructurallyValid(node))
+}
+
+/** A zero/negative/NaN weight silently corrupts every downstream rect. */
+export function allWeightsPositiveFinite<R>(
+  tree: LayoutNode<R> | null
+): boolean {
+  if (tree === null) return true
+  if (tree.type === "leaf") return true
+  return tree.children.every(
+    ({ node, weight }) =>
+      Number.isFinite(weight) && weight > 0 && allWeightsPositiveFinite(node)
+  )
+}

--- a/packages/ui/wireframes/src/lib/layout-intent.property.test.ts
+++ b/packages/ui/wireframes/src/lib/layout-intent.property.test.ts
@@ -1,0 +1,213 @@
+import fc from "fast-check"
+import type { YouTubeRegion } from "some-types-utils"
+import { describe, expect, it } from "vitest"
+
+import {
+  edgeArbitrary,
+  layoutIntentSequenceArbitrary,
+  regionArbitrary,
+} from "./__tests__/layout-intent-arbitrary"
+import {
+  allWeightsPositiveFinite,
+  countLeafOccurrences,
+  isStructurallyValid,
+} from "./__tests__/tree-invariants"
+import { applyIntent } from "./layout-intent"
+import type { LayoutNode } from "./layout-weighted"
+
+/**
+ * `applyIntent` is the FSM at the center of the wireframes editor: state is a
+ * layout tree, events are user edits (place/move/remove/reorder/resize). Per
+ * https://github.com/paulgsc/some-ui/issues/344's idiom, these properties
+ * encode invariants that must hold under ANY sequence of edits - not "does
+ * placing one region produce the rect I expect" (that checks the bolt; a
+ * corrupted or vanished region under a longer, unanticipated sequence is the
+ * plane on fire).
+ */
+describe("applyIntent - tree invariants under random edit sequences", () => {
+  it("never produces a structurally broken tree or a non-positive weight", () => {
+    fc.assert(
+      fc.property(layoutIntentSequenceArbitrary, (intents) => {
+        let tree: LayoutNode<YouTubeRegion> | null = null
+
+        for (const intent of intents) {
+          tree = applyIntent(tree, intent)
+
+          expect(isStructurallyValid(tree)).toBe(true)
+          expect(allWeightsPositiveFinite(tree)).toBe(true)
+        }
+      })
+    )
+  })
+
+  it("remove drives the removed region's count to zero and leaves every other region's count untouched", () => {
+    fc.assert(
+      fc.property(
+        layoutIntentSequenceArbitrary,
+        regionArbitrary,
+        (intents, target) => {
+          let tree: LayoutNode<YouTubeRegion> | null = null
+          for (const intent of intents) tree = applyIntent(tree, intent)
+
+          const before = countLeafOccurrences(tree)
+          const after = countLeafOccurrences(
+            applyIntent(tree, { kind: "remove", region: target })
+          )
+
+          expect(after.get(target) ?? 0).toBe(0)
+
+          for (const [region, count] of before) {
+            if (region === target) continue
+            expect(after.get(region) ?? 0).toBe(count)
+          }
+        }
+      )
+    )
+  })
+
+  it("placing a brand-new region and immediately removing it is a no-op on the region multiset", () => {
+    fc.assert(
+      fc.property(
+        layoutIntentSequenceArbitrary,
+        regionArbitrary,
+        edgeArbitrary,
+        (intents, region, edge) => {
+          let tree: LayoutNode<YouTubeRegion> | null = null
+          for (const intent of intents) tree = applyIntent(tree, intent)
+
+          const before = countLeafOccurrences(tree)
+          // Only meaningful for a region that isn't already on the canvas -
+          // if it's already present, "place" now relocates it (see the
+          // dedicated regression test below), so remove would net-delete it
+          // instead of restoring `before`.
+          fc.pre((before.get(region) ?? 0) === 0)
+
+          const placed = applyIntent(tree, { kind: "place", region, edge })
+          const roundTripped = applyIntent(placed, { kind: "remove", region })
+
+          expect(countLeafOccurrences(roundTripped)).toEqual(before)
+        }
+      )
+    )
+  })
+
+  it("place never leaves more than one leaf with the placed region's id, even when it already exists elsewhere", () => {
+    fc.assert(
+      fc.property(
+        layoutIntentSequenceArbitrary,
+        regionArbitrary,
+        edgeArbitrary,
+        (intents, region, edge) => {
+          let tree: LayoutNode<YouTubeRegion> | null = null
+          for (const intent of intents) tree = applyIntent(tree, intent)
+
+          const placed = applyIntent(tree, { kind: "place", region, edge })
+
+          expect(countLeafOccurrences(placed).get(region)).toBe(1)
+        }
+      )
+    )
+  })
+
+  it("a self-referential move/reorder/place (region === relativeTo) is a no-op, never a silent deletion", () => {
+    fc.assert(
+      fc.property(
+        layoutIntentSequenceArbitrary,
+        regionArbitrary,
+        edgeArbitrary,
+        (intents, region, edge) => {
+          let tree: LayoutNode<YouTubeRegion> | null = null
+          for (const intent of intents) tree = applyIntent(tree, intent)
+
+          const before = countLeafOccurrences(tree)
+
+          const afterMove = applyIntent(tree, {
+            kind: "move",
+            region,
+            relativeTo: region,
+            edge,
+          })
+          const afterReorder = applyIntent(tree, {
+            kind: "reorder",
+            region,
+            relativeTo: region,
+            edge: edge === "left" || edge === "top" ? "before" : "after",
+          })
+          const afterPlace = applyIntent(tree, {
+            kind: "place",
+            region,
+            relativeTo: region,
+            edge,
+          })
+
+          expect(countLeafOccurrences(afterMove)).toEqual(before)
+          expect(countLeafOccurrences(afterReorder)).toEqual(before)
+          expect(countLeafOccurrences(afterPlace)).toEqual(before)
+        }
+      )
+    )
+  })
+
+  // --- Regression: this is the exact scenario the property above generalizes -
+  // pinned down concretely so the failure mode stays legible on its own.
+  it("regression: moving a region relative to itself keeps it on the canvas", () => {
+    const withVideo = applyIntent(null, {
+      kind: "place",
+      region: "video",
+      edge: "left",
+    })
+    const withTitle = applyIntent(withVideo, {
+      kind: "place",
+      region: "title",
+      edge: "right",
+    })
+
+    const movedOntoItself = applyIntent(withTitle, {
+      kind: "move",
+      region: "video",
+      relativeTo: "video",
+      edge: "right",
+    })
+
+    expect(countLeafOccurrences(movedOntoItself).get("video")).toBe(1)
+  })
+
+  it("regression: re-placing an already-present region relocates it instead of duplicating it", () => {
+    const withVideo = applyIntent(null, {
+      kind: "place",
+      region: "video",
+      edge: "left",
+    })
+
+    const replaced = applyIntent(withVideo, {
+      kind: "place",
+      region: "video",
+      edge: "right",
+    })
+
+    expect(countLeafOccurrences(replaced).get("video")).toBe(1)
+  })
+
+  it("regression: placing a region with no anchor still works once the canvas already has 2+ panels", () => {
+    const withVideo = applyIntent(null, {
+      kind: "place",
+      region: "video",
+      edge: "left",
+    })
+    const withTitle = applyIntent(withVideo, {
+      kind: "place",
+      region: "title",
+      edge: "right",
+    })
+
+    // No `relativeTo` - previously this silently no-op'd once the tree was
+    // already a split rather than a lone leaf.
+    const withMainContent = applyIntent(withTitle, {
+      kind: "place",
+      region: "mainContent",
+      edge: "left",
+    })
+
+    expect(countLeafOccurrences(withMainContent).get("mainContent")).toBe(1)
+  })
+})

--- a/packages/ui/wireframes/src/lib/layout-intent.ts
+++ b/packages/ui/wireframes/src/lib/layout-intent.ts
@@ -38,10 +38,26 @@ export function applyIntent<R>(
   intent: LayoutIntent<R>
 ): LayoutNode<R> | null {
   switch (intent.kind) {
-    case "place":
-      return placeRegion(tree, intent.region, intent.relativeTo, intent.edge)
+    case "place": {
+      // A region can't be placed relative to itself - there's nothing to
+      // anchor to once it's removed, so treat it as a no-op rather than
+      // silently dropping the region (see the "move" case below).
+      if (intent.relativeTo === intent.region) return tree
+
+      // Re-placing a region that already exists elsewhere relocates it
+      // instead of inserting a second leaf with the same id.
+      const alreadyPresent = extractLeafIds(tree).has(intent.region)
+      const base = alreadyPresent ? removeRegion(tree, intent.region) : tree
+
+      return placeRegion(base, intent.region, intent.relativeTo, intent.edge)
+    }
 
     case "move": {
+      // A region can't be moved relative to itself: removing it first would
+      // make the anchor disappear, so `placeRegion` would never find it to
+      // reinsert against - silently deleting the region instead of moving it.
+      if (intent.region === intent.relativeTo) return tree
+
       // Remove first, then place
       const withoutRegion = removeRegion(tree, intent.region)
       return placeRegion(
@@ -52,13 +68,19 @@ export function applyIntent<R>(
       )
     }
 
-    case "remove":
+    case "remove": {
       return removeRegion(tree, intent.region)
+    }
 
-    case "reorder":
+    case "reorder": {
+      // Same self-reference hazard as "move": reordering removes the region
+      // before re-inserting it relative to the anchor.
+      if (intent.region === intent.relativeTo) return tree
+
       return reorderRegion(tree, intent.region, intent.relativeTo, intent.edge)
+    }
 
-    case "resize":
+    case "resize": {
       return resizeRegion(
         tree,
         intent.region,
@@ -66,9 +88,14 @@ export function applyIntent<R>(
         intent.deltaPx,
         intent.containerSizePx
       )
+    }
 
-    default:
-      return tree
+    default: {
+      // `intent` is exhaustively narrowed to `never` here - a bare `throw`
+      // (rather than a helper call) sidesteps accessing `.kind` on `never`.
+      intent satisfies never
+      throw new Error(`Unhandled layout intent: ${JSON.stringify(intent)}`)
+    }
   }
 }
 
@@ -89,38 +116,18 @@ function placeRegion<R>(
     return { type: "leaf", id: region }
   }
 
-  if (relativeTo === "root") {
+  // No anchor given (or an explicit "root" anchor): attach the new region as
+  // a top-level sibling of the whole tree. This has to hold regardless of
+  // whether `tree` is a lone leaf or an already-nested split - falling
+  // through to `return tree` below for the split case would silently drop
+  // the region instead of placing it.
+  if (relativeTo === "root" || relativeTo === undefined) {
     return placeRelativeToRoot(tree, region, edge)
   }
 
-  if (tree.type === "leaf" && !relativeTo) {
-    const newAxis = edge === "left" || edge === "right" ? "row" : "col"
-    const before = edge === "left" || edge === "top"
-
-    // KEY: Use weight = 1 for equal proportional distribution
-    return {
-      type: "split",
-      axis: newAxis,
-      splitId: generateSplitId(),
-      children: before
-        ? [
-            { node: { type: "leaf", id: region }, weight: 1 },
-            { node: tree, weight: 1 },
-          ]
-        : [
-            { node: tree, weight: 1 },
-            { node: { type: "leaf", id: region }, weight: 1 },
-          ],
-    }
-  }
-
-  if (relativeTo !== undefined) {
-    const cloned = cloneTree(tree)
-    const inserted = insertRelativeTo(cloned, region, relativeTo, edge)
-    return normalizeTree(inserted)
-  }
-
-  return tree
+  const cloned = cloneTree(tree)
+  const inserted = insertRelativeTo(cloned, region, relativeTo, edge)
+  return normalizeTree(inserted)
 }
 
 function placeRelativeToRoot<R>(

--- a/packages/ui/wireframes/src/lib/layout-weighted.property.test.ts
+++ b/packages/ui/wireframes/src/lib/layout-weighted.property.test.ts
@@ -1,0 +1,137 @@
+import fc from "fast-check"
+import type { YouTubeRegion } from "some-types-utils"
+import { describe, expect, it } from "vitest"
+
+import {
+  layoutIntentSequenceArbitrary,
+  regionArbitrary,
+} from "./__tests__/layout-intent-arbitrary"
+import { applyIntent } from "./layout-intent"
+import type { Rect, SolvedNode } from "./layout-types"
+import type { LayoutNode } from "./layout-weighted"
+import { solveLayout, solveLayoutWithFocus } from "./layout-weighted"
+
+const EPSILON = 1e-6
+
+function approxEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) < EPSILON
+}
+
+/**
+ * Verifies a solved tree actually tiles `expectedRect`: every split's children
+ * are contiguous along its axis (no gaps, no overlaps), match the parent's
+ * cross-axis extent, and together cover the parent exactly. A test that only
+ * checks one leaf's rect ("is the bolt tight") would miss a solver bug that
+ * leaves a sliver of the viewport unrendered or double-renders a region.
+ */
+function isValidTiling<T>(node: SolvedNode<T>, expectedRect: Rect): boolean {
+  if (
+    !approxEqual(node.rect.x, expectedRect.x) ||
+    !approxEqual(node.rect.y, expectedRect.y) ||
+    !approxEqual(node.rect.width, expectedRect.width) ||
+    !approxEqual(node.rect.height, expectedRect.height)
+  ) {
+    return false
+  }
+  if (node.rect.width < 0 || node.rect.height < 0) return false
+  if (node.type === "leaf") return true
+
+  const isRow = node.axis === "row"
+  let offset = isRow ? node.rect.x : node.rect.y
+
+  for (const child of node.children) {
+    if (isRow) {
+      if (
+        !approxEqual(child.rect.y, node.rect.y) ||
+        !approxEqual(child.rect.height, node.rect.height) ||
+        !approxEqual(child.rect.x, offset)
+      ) {
+        return false
+      }
+      offset += child.rect.width
+    } else {
+      if (
+        !approxEqual(child.rect.x, node.rect.x) ||
+        !approxEqual(child.rect.width, node.rect.width) ||
+        !approxEqual(child.rect.y, offset)
+      ) {
+        return false
+      }
+      offset += child.rect.height
+    }
+    if (!isValidTiling(child, child.rect)) return false
+  }
+
+  const totalExtent = isRow
+    ? node.rect.x + node.rect.width
+    : node.rect.y + node.rect.height
+
+  return approxEqual(offset, totalExtent)
+}
+
+function collectLeafIds<T>(node: SolvedNode<T>): Set<T> {
+  const ids = new Set<T>()
+  const stack: Array<SolvedNode<T>> = [node]
+  while (stack.length) {
+    const current = stack.pop()!
+    if (current.type === "leaf") {
+      ids.add(current.id)
+    } else {
+      stack.push(...current.children)
+    }
+  }
+  return ids
+}
+
+const viewportArbitrary = fc.record({
+  x: fc.constant(0),
+  y: fc.constant(0),
+  width: fc.integer({ min: 100, max: 2000 }),
+  height: fc.integer({ min: 100, max: 2000 }),
+})
+
+describe("solveLayout - geometry invariants", () => {
+  it("tiles the viewport exactly for any tree reachable via applyIntent - no gaps, overlaps, or overflow", () => {
+    fc.assert(
+      fc.property(
+        layoutIntentSequenceArbitrary,
+        viewportArbitrary,
+        (intents, viewport) => {
+          let tree: LayoutNode<YouTubeRegion> | null = null
+          for (const intent of intents) tree = applyIntent(tree, intent)
+          if (tree === null) return
+
+          const solved = solveLayout(tree, viewport)
+          expect(isValidTiling(solved, viewport)).toBe(true)
+        }
+      )
+    )
+  })
+
+  it("focus-aware solving still tiles the viewport and never adds or drops a region", () => {
+    fc.assert(
+      fc.property(
+        layoutIntentSequenceArbitrary,
+        viewportArbitrary,
+        regionArbitrary,
+        fc.double({ min: 0, max: 1, noNaN: true }),
+        (intents, viewport, focusId, intensity) => {
+          let tree: LayoutNode<YouTubeRegion> | null = null
+          for (const intent of intents) tree = applyIntent(tree, intent)
+          if (tree === null) return
+
+          const base = solveLayout(tree, viewport)
+          const focused = solveLayoutWithFocus(
+            tree,
+            viewport,
+            focusId,
+            intensity
+          )
+
+          expect(isValidTiling(focused, viewport)).toBe(true)
+          expect(collectLeafIds(focused)).toEqual(collectLeafIds(base))
+        }
+      )
+    )
+  })
+})

--- a/packages/ui/wireframes/src/lib/tree-serialization.property.test.ts
+++ b/packages/ui/wireframes/src/lib/tree-serialization.property.test.ts
@@ -1,0 +1,52 @@
+import fc from "fast-check"
+import type { YouTubeRegion } from "some-types-utils"
+import { describe, expect, it } from "vitest"
+
+import { layoutIntentSequenceArbitrary } from "./__tests__/layout-intent-arbitrary"
+import { applyIntent } from "./layout-intent"
+import type { LayoutNode } from "./layout-weighted"
+import {
+  deserializeLayout,
+  getTreeHash,
+  serializeLayout,
+} from "./tree-serialization"
+
+/**
+ * A saved layout that silently comes back different on reload is invisible
+ * until a user notices their editor state changed underneath them - the
+ * round trip below is the check that would actually catch that, as opposed
+ * to "serializing one hardcoded tree produces this exact string".
+ */
+describe("tree-serialization - round-trip and hash invariants", () => {
+  it("deserialize(serialize(tree)) reproduces the tree exactly, for any tree reachable via applyIntent", () => {
+    fc.assert(
+      fc.property(layoutIntentSequenceArbitrary, (intents) => {
+        let tree: LayoutNode<YouTubeRegion> | null = null
+        for (const intent of intents) tree = applyIntent(tree, intent)
+
+        const roundTripped = deserializeLayout<YouTubeRegion>(
+          serializeLayout(tree)
+        )
+
+        expect(roundTripped).toEqual(tree)
+      })
+    )
+  })
+
+  it("getTreeHash is a deterministic function of tree structure", () => {
+    fc.assert(
+      fc.property(layoutIntentSequenceArbitrary, (intents) => {
+        let tree: LayoutNode<YouTubeRegion> | null = null
+        for (const intent of intents) tree = applyIntent(tree, intent)
+
+        // Re-derive the same tree from an independent JSON round trip so this
+        // compares two structurally-equal-but-not-reference-equal trees.
+        const reconstructed = deserializeLayout<YouTubeRegion>(
+          serializeLayout(tree)
+        )
+
+        expect(getTreeHash(reconstructed)).toBe(getTreeHash(tree))
+      })
+    )
+  })
+})

--- a/packages/ui/wireframes/tsconfig.build.json
+++ b/packages/ui/wireframes/tsconfig.build.json
@@ -3,9 +3,15 @@
   "exclude": [
     "**/*.stories.tsx",
     "**/*.stories.ts",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.property.test.ts",
+    "**/__tests__/**",
     "../../../assets/**/*",
     "**/data/**",
     "**/demo/**",
-    "../../some-content/src/**/*"
+    "../../some-content/src/**/*",
+    "vitest.config.ts",
+    "vitest.setup.ts"
   ]
 }

--- a/packages/ui/wireframes/tsconfig.json
+++ b/packages/ui/wireframes/tsconfig.json
@@ -11,6 +11,11 @@
       "@some-ui/content-registry": ["../../some-content-registry/src"]
     }
   },
-  "include": ["src", "../../some-content-registry/src/**/*"],
+  "include": [
+    "src",
+    "../../some-content-registry/src/**/*",
+    "vitest.config.ts",
+    "vitest.setup.ts"
+  ],
   "exclude": ["node_modules", "build", "dist"]
 }

--- a/packages/ui/wireframes/vitest.config.ts
+++ b/packages/ui/wireframes/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from "path"
+import react from "@vitejs/plugin-react"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.{test,property.test}.{ts,tsx}"],
+  },
+  resolve: {
+    alias: {
+      "@wireframes": path.resolve(__dirname, "./src"),
+    },
+  },
+})

--- a/packages/ui/wireframes/vitest.setup.ts
+++ b/packages/ui/wireframes/vitest.setup.ts
@@ -1,0 +1,10 @@
+import "@testing-library/jest-dom/vitest"
+
+import { cleanup } from "@testing-library/react"
+import { afterEach, vi } from "vitest"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2026,6 +2026,9 @@ importers:
       '@some-ui/vite-config':
         specifier: workspace:*
         version: link:../../some-vite-config
+      fast-check:
+        specifier: ^3.23.1
+        version: 3.23.2
 
   packages/utils:
     dependencies:


### PR DESCRIPTION
## Description

Scoped entirely to the `wireframes` workspace (`packages/ui/wireframes`), plus the small `apps/www` fallout from the dehoist commit. This PR is stacked on #666 (base branch is `claude/www-dark-theme-multi-theme-oy97md`, which carries the `fix: dehoist wireframes lib modules` commit this work depends on) - it'll need retargeting to `main` once that merges.

**Why tests came first:** wireframes has no test suite, and it's one of the most complex workspaces in the repo (a tree-editing DSL + geometry solver). Per #341 / #344's idiom (referenced for the testing philosophy, not because this PR touches extensions), the goal was invariants that survive rewrites - "no sequence of edits can duplicate or vanish a region" - rather than one-hardcoded-case assertions that would pass right up until the tree actually catches fire.

**What got added** (`fast-check` property tests + a few characterization/regression tests, `vitest` wired up for the package for the first time):
- `layout-intent.property.test.ts` - `applyIntent` is the FSM at the center of the editor (state = layout tree, events = place/move/remove/reorder/resize). Properties: structural validity and positive weights hold under any random edit sequence; `remove` is precise; place-then-remove round-trips.
- `layout-weighted.property.test.ts` - `solveLayout`/`solveLayoutWithFocus` tile the viewport exactly (no gaps/overlaps/overflow) for any tree reachable via `applyIntent`, and focus-aware solving never adds or drops a region.
- `tree-serialization.property.test.ts` - `deserialize(serialize(tree))` round-trips exactly, and `getTreeHash` is deterministic.

**Bugs the property tests found in `layout-intent.ts` (fixed, not just documented - see prior discussion in-thread):**
1. Placing a region that already exists elsewhere created a second leaf with the same id instead of relocating it.
2. Moving/reordering a region relative to itself silently deleted it - it was removed, then `placeRegion` could never find its own anchor to reinsert against.
3. Placing with no anchor silently no-op'd once the canvas already had 2+ panels (the "attach at root" case only handled a lone-leaf tree).

All three now have both a property test and a concrete regression test pinning down the fix.

**tsc errors fixed:**
- `resizable-wireframe/index.stories.tsx` still imported `useSceneDrivenLayout` from its pre-dehoist location (`@some-ui/content-registry/hooks/...`); pointed it at the local hook. Its `Meta`/`Story` types also referenced `OrchestratedYouTubeViewport` directly while every story actually rendered the `AnimatedStory` wrapper, which has a narrower/optional prop shape - retargeted the types at `AnimatedStory`.
- Added `vitest.config.ts`/`vitest.setup.ts` to `tsconfig.json`'s `include` (mirrors the existing `honeycomb` package pattern) - they were tripping typed-lint's project service.

**eslint errors fixed:**
- `layout-intent.ts`'s `switch` was missing case braces and a fail-fast default, both required by this repo's `switch-lint` rules. The fail-fast default is a bare `throw` (not an `assertNever(...)` helper call) since `intent` narrows to `never` there and `intent.kind` isn't a valid property access on `never`.

**`apps/www`:** the dehoist commit left `routes/overlays/youtube.tsx` importing `dramaTree`/`useSceneDrivenLayout` from the now-removed `@some-ui/content-registry` paths (a real `tsc` break in `apps/www` right now). Fixed by exporting `dramaTree`/`studyTree`/`topikTree`/`voiceTree`, `useSceneDrivenLayout`, and `SCENE_LAYOUT_MAP` from wireframes' public barrel (`src/index.ts`), since they're core to the library now, and updating the route to consume them from there. Left `session-viewport.tsx`'s single-panel `MAIN_CONTENT_LAYOUT` as-is - its comment explains that's deliberate (every activity renders into one panel; a multi-region tree would show empty placeholder boxes).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (n/a - no docs exist yet for this workspace)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (`tsc --noEmit` and `eslint` both clean for `wireframes`; `apps/www` `tsc --noEmit` clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (12/12 passing)
- [ ] Any dependent changes have been merged and published in downstream modules (this PR depends on #666, not yet merged - see stacking note above)

## Screenshots

No UI changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoCoZSLscs5PdKETasH16W)_