### PR TITLE
fix(ci): stop splicing raw commit messages into www-docker-release's shell

### DIFF
--- a/.github/actions/www-detect/action.yml
+++ b/.github/actions/www-detect/action.yml
@@ -1,0 +1,41 @@
+name: "WWW Detect"
+description: "Decide www-docker-release.yml's release_mode: publish, release-pr, or skip."
+inputs:
+  event-name:
+    description: "github.event_name"
+    required: true
+  publish-only:
+    description: "workflow_dispatch inputs.publish_only (empty when not dispatched)"
+    required: false
+    default: ""
+  commit-message:
+    description: "github.event.head_commit.message (empty outside push events)"
+    required: false
+    default: ""
+  release-commit-message:
+    description: "The commit message www-docker-release.yml's own release PR is opened/merged with"
+    required: true
+  base-sha:
+    description: "github.event.before"
+    required: false
+    default: ""
+  head-sha:
+    description: "github.sha"
+    required: true
+outputs:
+  release_mode:
+    description: "One of: publish, release-pr, skip"
+    value: ${{ steps.run.outputs.release_mode }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        EVENT_NAME: ${{ inputs.event-name }}
+        PUBLISH_ONLY: ${{ inputs.publish-only }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        RELEASE_COMMIT_MESSAGE: ${{ inputs.release-commit-message }}
+        BASE_SHA: ${{ inputs.base-sha }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+      run: bash "${{ github.action_path }}/detect.sh"

--- a/.github/actions/www-detect/detect.sh
+++ b/.github/actions/www-detect/detect.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Is this push *the* release commit (the PR opened by the release-pr job
+# just got merged), rather than an ordinary source change? That commit only
+# touches apps/www/package.json + CHANGELOG.md, which still match this
+# workflow's trigger paths - it must still run, but as a publish rather than
+# another round of detection, or it would loop forever re-detecting its own
+# version bump as "www changed".
+is_release_commit=false
+if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$PUBLISH_ONLY" = "true" ]; then
+	is_release_commit=true
+elif [ "$EVENT_NAME" = "push" ] && [[ "$COMMIT_MESSAGE" == "$RELEASE_COMMIT_MESSAGE"* ]]; then
+	is_release_commit=true
+fi
+
+if [ "$is_release_commit" = "true" ]; then
+	release_mode=publish
+elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+	release_mode=release-pr
+elif [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+	# First push to main we've seen (or history was rewritten) - no prior
+	# state to diff against, so treat as changed.
+	release_mode=release-pr
+else
+	# `www...[from...to]` = www and everything it depends on, scoped to
+	# what actually changed in that range. An empty task list means
+	# nothing reachable from www moved.
+	#
+	# TURBO_TELEMETRY_DISABLED silences turbo's one-time telemetry
+	# banner, which otherwise prints ahead of the JSON on a fresh CI
+	# runner (no persisted `~/.turbo/config.json`) and breaks a plain
+	# `jq` parse of stdout.
+	task_count=$(
+		TURBO_TELEMETRY_DISABLED=1 \
+			nix develop .#ci --command pnpm turbo run build \
+			--filter="www...[${BASE_SHA}...${HEAD_SHA}]" \
+			--dry=json |
+			jq '.tasks | length'
+	)
+	if [ "$task_count" -gt 0 ]; then
+		release_mode=release-pr
+	else
+		release_mode=skip
+	fi
+fi
+
+echo "release_mode=${release_mode}" >>"$GITHUB_OUTPUT"

--- a/.github/actions/www-version/action.yml
+++ b/.github/actions/www-version/action.yml
@@ -1,0 +1,7 @@
+name: "WWW Version"
+description: "Apply the pending www changeset (bump version + changelog) without disturbing changesets awaiting other release tracks."
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: bash "${{ github.action_path }}/version.sh"

--- a/.github/actions/www-version/version.sh
+++ b/.github/actions/www-version/version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `changeset version` consumes every pending changeset in .changeset/, not
+# just the www-docker one written just before this step runs - left alone,
+# it would also sweep up (and delete) any changeset still awaiting
+# release.yml or wasm-release.yml's own runs, silently absorbing an
+# unrelated npm package or wasm crate bump into this Docker-only release.
+# Move everything else aside first and restore it after, so this release
+# track only ever touches www's own changeset.
+staging_dir=$(mktemp -d)
+find .changeset -maxdepth 1 -name '*.md' ! -name 'www-docker-*.md' \
+	-exec mv {} "$staging_dir/" \;
+
+nix develop .#ci --command npx changeset version
+
+shopt -s nullglob
+other_changesets=("$staging_dir"/*.md)
+if [ "${#other_changesets[@]}" -gt 0 ]; then
+	mv "${other_changesets[@]}" .changeset/
+fi

--- a/.github/workflows/www-docker-release.yml
+++ b/.github/workflows/www-docker-release.yml
@@ -48,18 +48,25 @@ concurrency:
   cancel-in-progress: false
 jobs:
   # ── Detect whether www's build graph actually changed ───────────────────
-  # Patterned after wasm-release.yml's detect job (bash + explicit outputs)
-  # rather than dorny/paths-filter: paths-filter isn't dependency-graph-aware
-  # (see pr.yml), and a plain `apps/www/**` filter would miss the transitive
+  # Patterned after wasm-release.yml's detect job (explicit outputs) rather
+  # than dorny/paths-filter: paths-filter isn't dependency-graph-aware (see
+  # pr.yml), and a plain `apps/www/**` filter would miss the transitive
   # workspace-dependency bumps that are the whole reason this workflow opens
   # a PR instead of publishing directly. No strategy.matrix here, unlike
   # wasm-release.yml's per-crate matrix — there's exactly one image to build.
+  #
+  # The decision itself lives in ./.github/actions/www-detect, not inline
+  # bash: GitHub's `${{ }}` templating splices context values (like a raw
+  # commit message) into the shell script as unquoted text before bash ever
+  # sees it, which is exactly what broke this job (see #674) — a multi-line
+  # commit message closed out of the `[[ ]]` early. Passing those values
+  # through `with:`/`env:` into the action keeps them as real shell
+  # variables that can be quoted correctly.
   detect:
     name: Detect www Changes
     runs-on: ubuntu-latest
     outputs:
-      has_changes: ${{ steps.detect.outputs.has_changes }}
-      is_release_commit: ${{ steps.detect.outputs.is_release_commit }}
+      release_mode: ${{ steps.detect.outputs.release_mode }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -72,49 +79,15 @@ jobs:
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
         env:
           HUSKY: 0
-      - name: Detect changes reachable from www
-        id: detect
-        run: |
-          set -euo pipefail
-
-          # Is this push *the* release commit (the PR above just got
-          # merged), rather than an ordinary source change? That commit only
-          # touches apps/www/package.json + CHANGELOG.md, which still match
-          # this workflow's trigger paths — it must still run, but skip
-          # re-opening/updating the PR (see release-pr job) or it would loop
-          # forever re-detecting its own version bump as "www changed".
-          is_release_commit=false
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_only }}" = "true" ]; then
-            is_release_commit=true
-          elif [ "${{ github.event_name }}" = "push" ] && [[ "${{ github.event.head_commit.message }}" == "${{ env.RELEASE_COMMIT_MESSAGE }}"* ]]; then
-            is_release_commit=true
-          fi
-          echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
-
-          if [ "$is_release_commit" = "true" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            has_changes=true
-          else
-            BASE="${{ github.event.before }}"
-            if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-              # First push to main we've seen (or history was rewritten) -
-              # no prior state to diff against, so treat as changed.
-              has_changes=true
-            else
-              # `www...[from...to]` = www and everything it depends on,
-              # scoped to what actually changed in that range. An empty
-              # task list means nothing reachable from www moved.
-              nix develop .#ci --command pnpm turbo run build \
-                --filter="www...[${BASE}...${{ github.sha }}]" \
-                --dry=json > /tmp/www-detect.json
-              task_count=$(sed -n '/^{/,$p' /tmp/www-detect.json | jq '.tasks | length')
-              if [ "$task_count" -gt 0 ]; then
-                has_changes=true
-              else
-                has_changes=false
-              fi
-            fi
-          fi
-          echo "has_changes=${has_changes}" >> "$GITHUB_OUTPUT"
+      - id: detect
+        uses: ./.github/actions/www-detect
+        with:
+          event-name: ${{ github.event_name }}
+          publish-only: ${{ inputs.publish_only }}
+          commit-message: ${{ github.event.head_commit.message }}
+          release-commit-message: ${{ env.RELEASE_COMMIT_MESSAGE }}
+          base-sha: ${{ github.event.before }}
+          head-sha: ${{ github.sha }}
   # ── Open/update the release PR ──────────────────────────────────────────
   # Runs `@changesets/cli` directly (not changesets/action - see header) to
   # bump apps/www's version + CHANGELOG, then opens a PR on a dedicated
@@ -124,7 +97,7 @@ jobs:
   release-pr:
     name: Open/Update www Release PR
     needs: detect
-    if: needs.detect.outputs.has_changes == 'true' && needs.detect.outputs.is_release_commit != 'true'
+    if: needs.detect.outputs.release_mode == 'release-pr'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -155,27 +128,8 @@ jobs:
           and push an updated `paulgsc/www` image to Docker Hub, or close it
           if the change doesn't warrant a new image.
           EOF
-      # `changeset version` consumes every pending changeset in .changeset/,
-      # not just the one written above - left alone, it would also sweep up
-      # (and delete) any changeset still awaiting release.yml or
-      # wasm-release.yml's own runs, silently absorbing an unrelated npm
-      # package or wasm crate bump into this Docker-only PR. Move everything
-      # else aside first and restore it after, so this release track only
-      # ever touches www's own changeset.
       - name: Apply version bump and changelog
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/other-changesets
-          find .changeset -maxdepth 1 -name '*.md' ! -name 'www-docker-*.md' \
-            -exec mv {} /tmp/other-changesets/ \;
-
-          nix develop .#ci --command npx changeset version
-
-          shopt -s nullglob
-          other_changesets=(/tmp/other-changesets/*.md)
-          if [ "${#other_changesets[@]}" -gt 0 ]; then
-            mv "${other_changesets[@]}" .changeset/
-          fi
+        uses: ./.github/actions/www-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Open release PR
@@ -196,7 +150,7 @@ jobs:
   publish:
     name: Build & Push Docker Image
     needs: detect
-    if: needs.detect.outputs.is_release_commit == 'true'
+    if: needs.detect.outputs.release_mode == 'publish'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Description

Closes #674. Fixes the `www-docker-release.yml` failure at https://github.com/paulgsc/some-ui/actions/runs/29614931389/job/87997828051.

The `detect` job spliced `${{ github.event.head_commit.message }}` directly into an inline `[[ ... ]]` bash conditional. GitHub's `${{ }}` templating substitutes that as raw, unescaped text before bash ever parses the script, so a multi-line commit message (quotes, parens, a blank line, from #673's merge commit) closed the conditional early and failed every push to main with `conditional binary operator expected`.

As #674 points out, that syntax bug was a symptom of a bigger problem: this workflow mixed policy (what should happen), detection, versioning, and orchestration into one god-file of inline bash. This PR splits those concerns out:

- **New `.github/actions/www-detect` composite action** — owns the release_mode decision. Context values (commit message, event name, SHAs) now flow through `with:`/`env:` instead of being spliced into `run:` script text, so they arrive as real, quotable shell variables. This is the actual fix for the crash.
- **Collapsed `has_changes` + `is_release_commit` into one `release_mode` output** (`publish` | `release-pr` | `skip`), so the workflow's job conditions read as intent instead of reconstructed boolean algebra.
- **Dropped the `sed -n '/^{/,$p' | jq` scrape** of turbo's dry-run JSON. That `sed` was silently compensating for turbo's one-time telemetry banner, which prints ahead of the JSON on a fresh CI runner with no persisted `~/.turbo/config.json`. Setting `TURBO_TELEMETRY_DISABLED=1` removes the banner so `jq` reads stdout directly — no more scraping around another tool's output format.
- **New `.github/actions/www-version` composite action** — owns the changeset stash/version/restore shuffle that used to live inline in the `release-pr` job.

The workflow file itself is now mostly wiring; the decisions it wires together live in versioned, independently testable action scripts.

Not done here (flagging as deliberately out of scope, per #674's own "consider"/aspirational suggestions): splitting into `workflow_call` reusable workflows, and a Rust `xtask`/`ci-tools` crate to replace bash entirely. Both are larger architectural bets than this bug fix + isolation pass warrants.

### Verification

Since this workflow only runs on push to `main` (plus `workflow_dispatch`), and there's no way to safely test the fix against a real push before merging, I dispatched it manually against this branch (run [29616190805](https://github.com/paulgsc/some-ui/actions/runs/29616190805)) before opening this PR:

- `detect` job (the one that was crashing) completed successfully, resolving `release_mode=release-pr`.
- `publish` job correctly skipped (release_mode wasn't `publish`), confirming the routing logic.
- `release-pr` job ran the new `www-version` action and updated the existing release PR (#662) with exactly the expected diff — a `CHANGELOG.md` entry and a `package.json` version bump. No unrelated files leaked in.
- Locally replayed the exact multi-line commit message from #673 that broke the original job through the new `detect.sh`, confirming no crash, plus all four `release_mode` branches with mocked `nix`/`turbo`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (n/a — CI workflow change, validated via a real dispatched run instead; see Verification)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XgE4UY8HePfE4KZzWuWVV9)_