### PR TITLE
fix(extensions): keep archived pnpm-lock.yaml in sync with pruned package.json

### DIFF
--- a/extensions/scripts/package-source.sh
+++ b/extensions/scripts/package-source.sh
@@ -54,6 +54,18 @@ node -e "
 (cd "$(dirname "$PRUNED_PKG_JSON")" && cp "$PRUNED_PKG_JSON" package.json && zip -q "$ARCHIVE" package.json && rm -f package.json)
 rm -f "$PRUNED_PKG_JSON"
 
+# pnpm-lock.yaml was archived verbatim by the git archive above, so its root
+# importer still lists the deps just pruned from package.json (each pointing
+# at a `link:` path this archive doesn't include). Left as-is, that mismatch
+# makes `pnpm install --frozen-lockfile` — the first command in
+# README.build.md — fail for anyone extracting this archive. Prune the same
+# entries from a copy of the lockfile and splice it in over the archived one.
+PRUNED_LOCKFILE="$(mktemp)"
+cp "$REPO_ROOT/pnpm-lock.yaml" "$PRUNED_LOCKFILE"
+node "$REPO_ROOT/extensions/scripts/prune-lockfile-root-deps.mjs" "$PRUNED_LOCKFILE" "$ARCHIVE_ONLY_DEPS"
+(cd "$(dirname "$PRUNED_LOCKFILE")" && cp "$PRUNED_LOCKFILE" pnpm-lock.yaml && zip -q "$ARCHIVE" pnpm-lock.yaml && rm -f pnpm-lock.yaml)
+rm -f "$PRUNED_LOCKFILE"
+
 echo "::notice::Source archive created: $ARCHIVE (git SHA: $GIT_SHA)"
 echo "SOURCE_ARCHIVE=$ARCHIVE" >> "${GITHUB_OUTPUT:-/dev/null}"
 echo "SOURCE_VERSION=$VERSION" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/extensions/scripts/prune-lockfile-root-deps.mjs
+++ b/extensions/scripts/prune-lockfile-root-deps.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Prunes the named dependencies from the root ('.') importer's
+// dependencies/devDependencies blocks of a pnpm-lock.yaml file, in place.
+//
+// Why: package-source.sh splices a pruned copy of the root package.json into
+// the AMO source archive, dropping devDependencies whose source isn't
+// archived (e.g. some-ui-utils, only needed by Storybook's root decorators).
+// The archived pnpm-lock.yaml was left untouched, so its root importer still
+// listed those same deps with a `link:` version pointing at a directory the
+// archive never includes. `pnpm install --frozen-lockfile` — the exact first
+// command in README.build.md — fails on that mismatch for anyone extracting
+// the archive, which is the AMO reviewer this archive exists for.
+//
+// Usage: node prune-lockfile-root-deps.mjs <lockfile-path> '["dep-a","dep-b"]'
+import { readFileSync, writeFileSync } from "node:fs"
+
+const [, , lockfilePath, pruneNamesJson] = process.argv
+if (!lockfilePath || !pruneNamesJson) {
+  // eslint-disable-next-line no-console -- CLI script; this is the usage message.
+  console.error(
+    "usage: prune-lockfile-root-deps.mjs <lockfile-path> '[\"dep-a\"]'"
+  )
+  // eslint-disable-next-line no-process-exit -- CLI script; non-zero exit signals bad args to the caller.
+  process.exit(2)
+}
+const pruneNames = new Set(JSON.parse(pruneNamesJson))
+
+const indentOf = (line) => line.match(/^ */)[0].length
+
+const lines = readFileSync(lockfilePath, "utf8").split("\n")
+const out = []
+let inRootImporter = false
+// Set to the indent of a dropped key while its sub-lines (specifier, version)
+// are skipped; cleared once a line at that indent or shallower reappears.
+let skipIndent = null
+
+for (const line of lines) {
+  if (skipIndent !== null) {
+    if (line.trim() !== "" && indentOf(line) > skipIndent) continue
+    skipIndent = null
+  }
+
+  if (/^importers:\s*$/.test(line)) {
+    out.push(line)
+    continue
+  }
+  if (/^ {2}\.:\s*$/.test(line)) {
+    inRootImporter = true
+    out.push(line)
+    continue
+  }
+  // Left the root importer block once a line at its own indent (2 spaces)
+  // shows up that isn't the `.:` header itself (the next importer, or a
+  // top-level lockfile key like `packages:`).
+  if (
+    inRootImporter &&
+    line.trim() !== "" &&
+    indentOf(line) <= 2 &&
+    !/^ {2}\.:\s*$/.test(line)
+  ) {
+    inRootImporter = false
+  }
+
+  // Dependency entry keys under `dependencies:`/`devDependencies:` sit at
+  // 6-space indent (4 for the section header + 2 for map nesting).
+  if (inRootImporter && indentOf(line) === 6) {
+    const m = line.match(/^ {6}(?:'([^']+)'|([^:'\s#][^:]*)):\s*$/)
+    if (m) {
+      const name = m[1] ?? m[2]
+      if (pruneNames.has(name)) {
+        skipIndent = 6
+        continue
+      }
+    }
+  }
+
+  out.push(line)
+}
+
+writeFileSync(lockfilePath, out.join("\n"))


### PR DESCRIPTION
## Description

`extensions/scripts/package-source.sh` builds the source archive AMO requires reviewers to reproduce a build from. It prunes archive-excluded workspace devDependencies (e.g. `some-ui-utils`, only needed by Storybook's root-level decorators, whose source isn't archived) from the root `package.json` it splices into the zip — but never touched `pnpm-lock.yaml`, which was archived verbatim by `git archive`. The root importer's lockfile entry for those deps still pointed at a `link:` path the archive doesn't include, so `package.json` and `pnpm-lock.yaml` disagreed inside the extracted archive.

`README.build.md`'s first documented step is `pnpm install --frozen-lockfile`. That command failed with `ERR_PNPM_OUTDATED_LOCKFILE` for anyone extracting the archive and following the instructions verbatim — including an AMO reviewer trying to reproduce the build, which is the archive's entire purpose. Found while dry-running the reviewer flow end-to-end ahead of a `suspender-ledger` sign dispatch.

Fix: `extensions/scripts/prune-lockfile-root-deps.mjs` drops the same `ARCHIVE_ONLY_DEPS` entries from the root importer of a copy of the lockfile, using indentation-bounded line removal (no YAML dependency added). `package-source.sh` now splices this pruned lockfile into the archive alongside the already-pruned `package.json`.

## Verification

Ran the actual reviewer flow, not just the build:
1. Built `suspender-ledger` normally, generated a source archive via `package-source.sh`.
2. Extracted the archive into a clean directory with no repo context.
3. `pnpm install --frozen-lockfile` — previously failed, now succeeds.
4. `pnpm --filter "@some-extension/suspender-ledger" build` — succeeds.
5. `sha256sum` diff of the resulting `dist/` against the real repo's `dist/` — byte-identical.

Also confirmed `pnpm lint:ext` (web-ext lint) and the new script's own `eslint` pass cleanly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — inline comments explain the indent-bounded skip logic and why the prune exists
- [ ] I have made corresponding changes to the documentation — no doc changes needed; behavior now matches what `README.build.md`/`amo-compliance.md` already document
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — verified manually via full end-to-end reviewer-flow reproduction (see above); no existing test harness covers this CI packaging script
- [ ] New and existing unit tests pass locally with my changes — no unit tests exist for this script; `pnpm lint:ext`/build were run manually as noted above
- [ ] Any dependent changes have been merged and published in downstream modules — n/a

## Screenshots

n/a — CI/tooling script change, no UI surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_016HxsV7W34QkvA9Lwr33ALy)_