### PR TITLE
fix(deps): patch ws DoS vulnerability (GHSA-3h5v-q93c-6h6q)

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "overrides": {
       "@types/react": "^19.0.4",
       "@eslint/core": "0.17.0",
-      "@eslint/config-helpers": "0.4.2"
+      "@eslint/config-helpers": "0.4.2",
+      "ws": "^8.21.1"
     }
   },
   "eslintConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@types/react': ^19.0.4
   '@eslint/core': 0.17.0
   '@eslint/config-helpers': 0.4.2
+  ws: ^8.21.1
 
 importers:
 
@@ -12861,32 +12862,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.13.0:
-    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -16374,7 +16351,7 @@ snapshots:
 
   '@tanstack/devtools-event-bus@0.2.1':
     dependencies:
-      ws: 8.21.0
+      ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -20694,7 +20671,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.21.0
+      ws: 8.21.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -23785,7 +23762,7 @@ snapshots:
       recast: 0.23.12
       semver: 7.8.5
       use-sync-external-store: 1.6.0(react@19.0.0)
-      ws: 8.21.0
+      ws: 8.21.1
     optionalDependencies:
       '@types/react': 19.2.17
       prettier: 3.4.2
@@ -23812,7 +23789,7 @@ snapshots:
       recast: 0.23.12
       semver: 7.8.5
       use-sync-external-store: 1.6.0(react@19.0.0)
-      ws: 8.21.0
+      ws: 8.21.1
     optionalDependencies:
       '@types/react': 19.2.17
       prettier: 3.9.0
@@ -24935,7 +24912,7 @@ snapshots:
       tmp: 0.2.1
       update-notifier: 6.0.2
       watchpack: 2.4.0
-      ws: 8.13.0
+      ws: 8.21.1
       yargs: 17.7.1
       zip-dir: 2.0.0
     transitivePeerDependencies:
@@ -25009,7 +24986,7 @@ snapshots:
       tmp: 0.2.3
       update-notifier: 7.3.1
       watchpack: 2.4.2
-      ws: 8.18.0
+      ws: 8.21.1
       yargs: 17.7.2
       zip-dir: 2.0.0
     transitivePeerDependencies:
@@ -25160,11 +25137,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.13.0: {}
-
-  ws@8.18.0: {}
-
-  ws@8.21.0: {}
+  ws@8.21.1: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## Description

Fixes [Dependabot alert #47](https://github.com/paulgsc/some-ui/security/dependabot/47): `ws` versions `>=8.0.0 <8.17.1` are vulnerable to a denial-of-service via a request with an excessive number of headers (CVE-2024-37890 / GHSA-3h5v-q93c-6h6q).

`ws@8.13.0` was pulled in transitively via `web-ext@7.12.0` (used by `some-scrobbler` and `some-cycle`, both pinned to `web-ext: ^7.6.2`). A second copy, `ws@8.18.0`, came in via `web-ext@8.3.0`. Dependabot itself couldn't resolve this because the vulnerable range extends past what those `web-ext` versions declare.

Added a `pnpm.overrides` entry pinning `ws` to `^8.21.1` workspace-wide, which resolves all three `ws` copies in the lockfile down to one patched version. This also closes two related open alerts on the same package: #161 (uninitialized memory disclosure) and #172 (memory exhaustion via tiny fragments), both of which need `ws >= 8.20.1`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Verification

- `pnpm install` succeeds and consolidates `ws` to a single `8.21.1` entry in `pnpm-lock.yaml`.
- `pnpm audit` no longer reports any `ws` advisories (down from 3).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WdRGZ64aAyNMCsduQpHfwd)_