### PR TITLE
feat(some-filter): instantiate transport kernel + swatch registry (S1, S2)

### DIFF
--- a/extensions/docs/dom-state-estimation-canon.typ
+++ b/extensions/docs/dom-state-estimation-canon.typ
@@ -1384,6 +1384,69 @@ specifically.
   load the other must be strong enough to carry.
 ]
 
+#heading(level: 2, numbering: none)[C.6 · Comfort as a distinct, non-zero-leak invariant (proposed, issue 687)]
+
+Definition C.0 and Axiom C.1 govern a *zero-leak* $Phi$: a page displayed at
+native vendor luminance for even one frame is a completed failure, and
+$Phi$'s job stops at excluding that failure. Remark C.1 states
+`some-filter`'s $Phi$ in exactly those terms --- "no page is ever displayed
+at native vendor luminance when dark is required" --- and the `some-filter`
+case study (§9.2) notes explicitly that over-darkening a genuinely-light
+element "costs perceptual quality, which $Phi$ (Remark C.1) does not
+forbid." That gap is not an oversight: a zero-leak $Phi$ is deliberately
+silent on quality, because Proposition C.1's necessity-of-(a) argument only
+licenses paying custody's cost to exclude a completed, binary failure, never
+to optimize a continuous one. Making "the theme is comfortable" checkable at
+all requires a second, independent predicate, and it must not be confused
+with $Phi$ itself: violating it briefly is a quality regression, not a leak,
+and Axiom C.1's pessimistic default does not apply to it.
+
+#definition("C.3", name: [Comfort invariant $Phi_"comfort"$])[
+  Let a *swatch* $sigma$ fix, at minimum, a background color $"bg"(sigma)$
+  and a primary text color $"text"_0 (sigma)$. Write $L(c) in [0,1]$ for a
+  color's WCAG relative luminance, $"sat"(c) in [0,1]$ for its HSL
+  saturation, and
+  $ "contrast"(c_1, c_2) = ("max"(L(c_1),L(c_2)) + 0.05) / ("min"(L(c_1),L(c_2)) + 0.05) $
+  for the standard contrast ratio. $sigma$ satisfies $Phi_"comfort"$ iff all
+  four hold:
+  + *Text is never the brightest thing on screen:* $L("text"_0 (sigma)) <=
+    kappa_"text"$, for a fixed ceiling $kappa_"text" < 1$ strictly below
+    white's luminance.
+  + *Contrast lives in a comfort band:* $kappa_"lo" <=
+    "contrast"("bg"(sigma), "text"_0 (sigma)) <= kappa_"hi"$, for fixed
+    $kappa_"lo" < kappa_"hi" < 21$ (21 is the `#fff`-on-`#000` maximum).
+  + *The neutral carries a chromatic bias:* $"sat"("bg"(sigma)) >=
+    kappa_"sat"$ and $"sat"("text"_0 (sigma)) >= kappa_"sat"$, for a fixed
+    floor $kappa_"sat" > 0$ --- an achromatic gray ($"sat" = 0$) fails.
+  + *The background is a reference, not a void:* $L("bg"(sigma)) >
+    kappa_"blk"$, for a fixed floor $kappa_"blk" > 0$ --- literal black
+    fails.
+]
+
+#remark("C.6")[
+  $Phi_"comfort"$ is deliberately *not* zero-leak (Definition C.0): a swatch
+  that transiently fails it is a worse-looking page, not the frame-of-native-
+  luminance failure Axiom C.1 exists to exclude at any cost. It is therefore
+  checked once, statically, over the finite swatch registry
+  (`some-filter`'s `src/adapter/swatches.ts`, landed with issue 687) rather than
+  continuously re-evaluated by the estimator/planner machinery of §5--§8 the
+  way $Phi$ is. Where $Phi_"comfort"$ *is* expected to inherit this canon's
+  discipline is a later story in the `some-filter`-on-transport epic (issue 685):
+  once the pipeline can assert *rendered* colors converge to a chosen
+  swatch at all (the positive form of Theorem C.1's contraction bound
+  applied to a concrete target), the same predicate is re-run against the
+  DOM's computed styles, turning "the theme is comfortable" from a
+  registry-time guarantee into a page-time one. Whether $Phi_"comfort"$ is
+  eventually promoted into $Phi$ itself (making comfort zero-leak too) or
+  remains a permanently separate, non-zero-leak sibling is left open here;
+  nothing in Definition C.3 forces either resolution, and doing so
+  prematurely would be exactly the kind of un-evidenced amendment §10's
+  triage procedure warns against. The concrete constants $kappa_"text"$,
+  $kappa_"lo"$, $kappa_"hi"$, $kappa_"sat"$, $kappa_"blk"$ are an
+  implementation choice, not part of this amendment; `some-filter`'s
+  `comfortReport`/`satisfiesComfort` record the values currently in force.
+]
+
 // ═══════════════════════════════════════════════════════════════════════════
 = The Transport Layer Architecture
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1993,6 +2056,26 @@ solely as a source-code commit message; it must be reflected in this file.
   C.1) rather than new environment assumptions. The conformance checklist
   (§8.3) gained two items (the $L_D$/$L_C$ boundary; the no-concrete-adapter-import
   declaration); the glossary and notation index were extended accordingly.
+- *v1.3 → v1.4* (2026-07-18, proposed with issue 687). A *minor* amendment (§10's
+  own criterion: it adds a new predicate without altering an existing axiom
+  or theorem, the same class as a §9 case study or a §10.1 triage addition):
+  it adds "C.6 · Comfort as a distinct, non-zero-leak invariant,"
+  defining the *comfort invariant* $Phi_"comfort"$ (Definition C.3) and
+  Remark C.6 distinguishing it from the zero-leak $Phi$ that Definition C.0
+  and Axiom C.1 govern. Motivation: the `some-filter`-on-transport epic
+  (issue 685) needed a checkable form of the claim, raised in review, that "the
+  bg is dark" is not the same property as "the theme reduces eye strain" ---
+  §9.2 already notes over-darkening "costs perceptual quality, which $Phi$
+  does not forbid," and $Phi_"comfort"$ names the predicate that gap was
+  missing. $Phi_"comfort"$ is intentionally *not* folded into $Phi$: it is
+  not zero-leak, Axiom C.1's pessimistic default does not apply to it, and
+  it is checked statically over a finite swatch registry
+  (`some-filter/src/adapter/swatches.ts`) rather than continuously by the
+  estimator/planner machinery §5--§8 governs. No existing axiom, definition,
+  or theorem in §1--§8, §C, or §D was weakened or renumbered. Whether
+  $Phi_"comfort"$ is later promoted into $Phi$ itself, once a rendered-page
+  assertion exists to justify it, is explicitly left open rather than
+  decided here.
 
 // ═══════════════════════════════════════════════════════════════════════════
 #heading(level: 1, numbering: none)[Appendix A --- Glossary]

--- a/extensions/some-filter/package.json
+++ b/extensions/some-filter/package.json
@@ -3,7 +3,8 @@
     "url": "https://github.com/paulgsc/some-ui/issues"
   },
   "dependencies": {
-    "@some-extension/common": "workspace:*"
+    "@some-extension/common": "workspace:*",
+    "@some-extension/transport": "workspace:*"
   },
   "devDependencies": {
     "@some-ui/tsconfig": "workspace:*",

--- a/extensions/some-filter/src/adapter/__tests__/swatches.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/swatches.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  comfortReport,
+  DEFAULT_SWATCH_ID,
+  getSwatch,
+  satisfiesComfort,
+  SWATCHES,
+  type Swatch,
+} from "../swatches"
+
+describe("SWATCHES", () => {
+  it("every registry entry satisfies Φ_comfort", () => {
+    for (const swatch of Object.values(SWATCHES)) {
+      expect(satisfiesComfort(swatch), swatch.id).toBe(true)
+    }
+  })
+
+  it("the default swatch is byte-for-byte today's palette", () => {
+    const defaultSwatch = SWATCHES[DEFAULT_SWATCH_ID]
+    expect(defaultSwatch.bg0).toBe("#0d1117")
+    expect(defaultSwatch.text0).toBe("#e2e8f0")
+    expect(defaultSwatch.codeFg).toBe("#e879f9")
+  })
+
+  it("getSwatch falls back to the default for an unknown id", () => {
+    expect(getSwatch("does-not-exist")).toBe(SWATCHES[DEFAULT_SWATCH_ID])
+  })
+
+  it("getSwatch resolves a known id", () => {
+    expect(getSwatch("purple-gray")).toBe(SWATCHES["purple-gray"])
+  })
+})
+
+describe("Φ_comfort", () => {
+  it("rejects a #fff-on-#000 maximum-contrast swatch", () => {
+    const hostile: Swatch = {
+      ...SWATCHES[DEFAULT_SWATCH_ID],
+      id: "hostile",
+      label: "Hostile",
+      bg0: "#000000",
+      text0: "#ffffff",
+    }
+
+    const report = comfortReport(hostile)
+    expect(report.bgNotBlack).toBe(false)
+    expect(report.textNotBrightest).toBe(false)
+    expect(report.chromaticBias).toBe(false)
+    expect(report.contrastInBand).toBe(false)
+    expect(satisfiesComfort(hostile)).toBe(false)
+  })
+
+  it("rejects an achromatic gray (no chromatic bias)", () => {
+    const achromatic: Swatch = {
+      ...SWATCHES[DEFAULT_SWATCH_ID],
+      id: "achromatic",
+      label: "Achromatic",
+      bg0: "#141414",
+      text0: "#e0e0e0",
+    }
+
+    expect(comfortReport(achromatic).chromaticBias).toBe(false)
+    expect(satisfiesComfort(achromatic)).toBe(false)
+  })
+})

--- a/extensions/some-filter/src/adapter/contracts.ts
+++ b/extensions/some-filter/src/adapter/contracts.ts
@@ -1,0 +1,108 @@
+/**
+ * `some-filter`'s instantiation of the transport kernel's generic
+ * parameters — the key space `K`, attribute space `Attr`, and action
+ * alphabet `A` of `Adapter<K, Attr, A>` (Definition D.3, canon §D.1).
+ * `@some-extension/transport` has no opinion about what these are (#618
+ * ran the whole kernel with `K = string`, `Attr = { seq: number }`); this
+ * module is that choice, written down as types.
+ *
+ * Types only, mirroring the shape of `@some-extension/transport/contracts/*`:
+ * no `decide` implementation (S3), no swatch registry data (S2, #687), no
+ * DOM reference or pipeline wiring (S5). A throwaway `decide: () => []`
+ * stub was used during development to confirm these three choices satisfy
+ * `Adapter` before this file was written; it is not committed —
+ * `FilterAdapter` below is the permanent, zero-runtime-cost form of that
+ * same proof.
+ */
+
+import type { RGBA } from "@filter/lib/content/color"
+import type { Adapter } from "@some-extension/transport/contracts/adapter"
+
+/**
+ * The key space `K` (Definition 5.1) — canon §5.
+ *
+ * A key is a canonicalized *observed background color* — a surface bucket
+ * — not a DOM node or node identity. `theme-apply.ts`'s existing
+ * `colorTokens` registry (`tokenForBackground`) already makes this choice
+ * implicitly: it dedupes by color rather than by element, because the same
+ * background color recurs across thousands of nodes (a site's shared
+ * card/table/button background) and the decide-what-to-do-with-it question
+ * is per-color, not per-node. Today `tokenForBackground` dedupes on the
+ * *computed dark output* (`modifiedCss`); because `modifyBackgroundColor`
+ * is a pure function of the source color, that is operationally equivalent
+ * to deduping on the *source* color. `SurfaceKey` canonicalizes the source
+ * instead — the more principled choice, since it keeps target-color
+ * computation inside `decide` (S3) rather than baked into the estimator's
+ * notion of identity. Keying `K` on node identity instead would force one
+ * hypothesis entry per occurrence rather than per distinct surface, against
+ * Definition 5.1's whole point ("one hypothesis per key").
+ *
+ * Concretely: the canonical `rgba()` form of `color.ts`'s `parseColor`
+ * output, integer-quantized. Two elements share a key exactly when
+ * `classifyElement` would make the same call for both.
+ */
+export type SurfaceKey = string
+
+/**
+ * The attribute space `Attr` (Definition 5.1) — canon §5.
+ *
+ * The evidence `classifyElement` already derives per element via
+ * `color.ts`, minus anything that would duplicate transport's own
+ * bookkeeping. `color` and `luminance` mirror `parseColor` +
+ * `relativeLuminance`'s return values; `opacity` is the alpha channel
+ * `classifyElement` already reads to skip near-transparent glass layers
+ * (`color.ts`'s `parseColor` guards `a < 0.05`, `classifyElement`'s own
+ * early-return guards `a < 0.1`).
+ *
+ * Deliberately excluded: a per-attribute certainty/tier field. Definition
+ * 4.1's `raw | partial | full` codomain is transport's own evidentiary
+ * bookkeeping — kept in the estimator's `ProvenanceStore`
+ * (`estimator/update.ts`), not the public `Hypothesis<K, Attr>` surface
+ * (Definition 5.1's own comment: "not part of the public Hypothesis query
+ * surface"). Folding a tier into `Attr` here would duplicate state
+ * transport already orders on.
+ */
+export type SurfaceAttr = {
+  readonly color: RGBA
+  readonly luminance: number
+  readonly opacity: number
+}
+
+/**
+ * The action alphabet `A` (Definition D.3) — canon §D.1, §7.
+ *
+ * The two effects `theme-apply.ts`'s JS luminance patcher performs today,
+ * re-expressed as declarative records instead of direct DOM writes:
+ *   - `patchElement` sets `el.dataset.swPatched = token | "preserve"` —
+ *     a `tag-surface` action, parameterized by which `SwatchRole` the
+ *     surface was classified into.
+ *   - `tokenForBackground` appends a `[data-sw-patched="…"]{…}` rule to the
+ *     dynamic stylesheet the first time a distinct dark surface color is
+ *     needed — an `emit-surface-color` action, one per key, not per node.
+ * Both extend transport's base `Action` (the `kind` discriminant); the
+ * Actuator (S5) will be the only module permitted to realize them.
+ */
+export type SwatchRole = "surface" | "preserve"
+
+export type TagSurfaceAction = {
+  readonly kind: "tag-surface"
+  readonly key: SurfaceKey
+  readonly role: SwatchRole
+}
+
+export type EmitSurfaceColorAction = {
+  readonly kind: "emit-surface-color"
+  readonly key: SurfaceKey
+  readonly css: string
+}
+
+export type FilterAction = TagSurfaceAction | EmitSurfaceColorAction
+
+/**
+ * The instantiated kernel: `Adapter<SurfaceKey, SurfaceAttr, FilterAction>`.
+ * Naming this alias forces `FilterAction` to satisfy transport's `Action`
+ * bound at the type level — the permanent proof that `K`, `Attr`, and `A`
+ * as chosen above type-check against `@some-extension/transport`'s exported
+ * `Adapter`, with no logic and no DOM reference anywhere in this file.
+ */
+export type FilterAdapter = Adapter<SurfaceKey, SurfaceAttr, FilterAction>

--- a/extensions/some-filter/src/adapter/swatches.ts
+++ b/extensions/some-filter/src/adapter/swatches.ts
@@ -1,0 +1,287 @@
+/**
+ * The swatch registry — Definition D.3's domain vocabulary (canon §D.1),
+ * promoted from `theme-apply.ts`'s hardcoded `TOKENS` string to typed data.
+ * Domain data: it lives here, in `some-filter`, never in
+ * `@some-extension/transport` (Corollary D.2.1).
+ *
+ * A *swatch* is one named point in the dark-palette design space. The
+ * ergonomics note that motivated this milestone (referenced from #687)
+ * argues a comfortable dark theme is a family of chromatic-gray palettes —
+ * cool blue-gray, soft green-gray, purple-gray, warm paper, neutral,
+ * low-contrast — not one `#fff`-on-`#000` maximum-contrast recipe, because
+ * near-white text on a near-black background "becomes the new sun": its
+ * apparent luminance dominates the visual field regardless of its RGB
+ * value. Six such palettes are seeded below; `DEFAULT_SWATCH_ID` is
+ * byte-for-byte today's palette, so selecting it is behavior-preserving.
+ *
+ * `Φ_comfort` (bottom of this file) is the checkable form of that argument:
+ * text is never the brightest thing on screen, contrast lives in a comfort
+ * band rather than pinned at the 21:1 maximum, the neutral carries a
+ * chromatic bias, and the background is a mid-dark reference rather than a
+ * void. It is defined here, statically, over the registry; S6 asserts the
+ * same predicate on rendered output. A canon amendment proposing `Φ_comfort`
+ * as a named predicate (extending `Φ` or as a sibling) is proposed alongside
+ * this story per §10 — see `extensions/docs/dom-state-estimation-canon.typ`.
+ */
+
+import { relativeLuminance, type RGBA } from "@filter/lib/content/color"
+import { rgbToHSL } from "@filter/lib/content/modify-colors"
+
+/**
+ * Generalizes `theme-apply.ts`'s `TOKENS` fields. Every CSS custom property
+ * `buildDarkThemeCSS()` currently emits (`--sw-bg-0`, …, plus the
+ * previously-hardcoded `code`/`kbd`/`samp` color) has a role here.
+ */
+export type Swatch = {
+  readonly id: string
+  readonly label: string
+  readonly bg0: string
+  readonly bg1: string
+  readonly bg2: string
+  readonly bg3: string
+  readonly surface: string
+  readonly border: string
+  readonly text0: string
+  readonly text1: string
+  readonly text2: string
+  readonly link: string
+  readonly linkVisited: string
+  readonly inputBg: string
+  readonly inputBorder: string
+  readonly selectionBg: string
+  readonly codeFg: string
+}
+
+export const DEFAULT_SWATCH_ID = "default"
+
+/**
+ * `as const satisfies Record<string, Swatch>` — literal id keys are
+ * preserved for `keyof typeof SWATCHES`, while every entry is still checked
+ * against the full `Swatch` shape: omitting a role on any entry is a type
+ * error, not a silently-`undefined` field (the registry's own acceptance
+ * bar, #687).
+ */
+export const SWATCHES = {
+  // Today's palette, verbatim (`theme-apply.ts`'s former `TOKENS`) — the
+  // active default, so behavior is unchanged until a picker (follow-on)
+  // selects otherwise.
+  default: {
+    id: "default",
+    label: "Default",
+    bg0: "#0d1117",
+    bg1: "#13161d",
+    bg2: "#1a1e27",
+    bg3: "#21252f",
+    surface: "#1e222b",
+    border: "rgba(255, 255, 255, 0.08)",
+    text0: "#e2e8f0",
+    text1: "#94a3b8",
+    text2: "#475569",
+    link: "#7aa2f7",
+    linkVisited: "#9d8cf7",
+    inputBg: "#1a1e27",
+    inputBorder: "rgba(255, 255, 255, 0.15)",
+    selectionBg: "rgba(122, 162, 247, 0.25)",
+    codeFg: "#e879f9",
+  },
+  "cool-blue-gray": {
+    id: "cool-blue-gray",
+    label: "Cool Blue Gray",
+    bg0: "#121620",
+    bg1: "#181c25",
+    bg2: "#1f242f",
+    bg3: "#272b37",
+    surface: "#242833",
+    border: "rgba(255, 255, 255, 0.08)",
+    text0: "#cbd5e1",
+    text1: "#8797aa",
+    text2: "#44505e",
+    link: "#7993f6",
+    linkVisited: "#a788f6",
+    inputBg: "#1f242f",
+    inputBorder: "rgba(255, 255, 255, 0.15)",
+    selectionBg: "rgba(121, 147, 246, 0.25)",
+    codeFg: "#f577f8",
+  },
+  "soft-green-gray": {
+    id: "soft-green-gray",
+    label: "Soft Green Gray",
+    bg0: "#141a17",
+    bg1: "#1a201d",
+    bg2: "#222925",
+    bg3: "#29312d",
+    surface: "#262d29",
+    border: "rgba(255, 255, 255, 0.08)",
+    text0: "#cfe0d4",
+    text1: "#8ca794",
+    text2: "#475c4d",
+    link: "#79f6c2",
+    linkVisited: "#88eff6",
+    inputBg: "#222925",
+    inputBorder: "rgba(255, 255, 255, 0.15)",
+    selectionBg: "rgba(121, 246, 194, 0.25)",
+    codeFg: "#7795f8",
+  },
+  "purple-gray": {
+    id: "purple-gray",
+    label: "Purple Gray",
+    bg0: "#17141d",
+    bg1: "#1d1a23",
+    bg2: "#25222c",
+    bg3: "#2d2934",
+    surface: "#292630",
+    border: "rgba(255, 255, 255, 0.08)",
+    text0: "#ddd3e8",
+    text1: "#9d8ab1",
+    text2: "#534464",
+    link: "#ad79f6",
+    linkVisited: "#eb88f6",
+    inputBg: "#25222c",
+    inputBorder: "rgba(255, 255, 255, 0.15)",
+    selectionBg: "rgba(173, 121, 246, 0.25)",
+    codeFg: "#f877ab",
+  },
+  "warm-paper-dark": {
+    id: "warm-paper-dark",
+    label: "Warm Paper Dark",
+    bg0: "#1c1815",
+    bg1: "#221e1b",
+    bg2: "#2b2623",
+    bg3: "#332e2a",
+    surface: "#2f2a27",
+    border: "rgba(255, 255, 255, 0.08)",
+    text0: "#ebe1d3",
+    text1: "#b6a388",
+    text2: "#675741",
+    link: "#f6b979",
+    linkVisited: "#f6f688",
+    inputBg: "#2b2623",
+    inputBorder: "rgba(255, 255, 255, 0.15)",
+    selectionBg: "rgba(246, 185, 121, 0.25)",
+    codeFg: "#9ff877",
+  },
+  "neutral-gray": {
+    id: "neutral-gray",
+    label: "Neutral Gray",
+    bg0: "#17181a",
+    bg1: "#1d1e20",
+    bg2: "#252628",
+    bg3: "#2d2e30",
+    surface: "#292a2d",
+    border: "rgba(255, 255, 255, 0.08)",
+    text0: "#d9dadc",
+    text1: "#999b9e",
+    text2: "#515255",
+    link: "#7999f6",
+    linkVisited: "#a288f6",
+    inputBg: "#252628",
+    inputBorder: "rgba(255, 255, 255, 0.15)",
+    selectionBg: "rgba(121, 153, 246, 0.25)",
+    codeFg: "#ef77f8",
+  },
+  "low-contrast-comfort": {
+    id: "low-contrast-comfort",
+    label: "Low Contrast Comfort",
+    bg0: "#16181c",
+    bg1: "#1c1e22",
+    bg2: "#24262b",
+    bg3: "#2b2e32",
+    surface: "#282a2f",
+    border: "rgba(255, 255, 255, 0.08)",
+    text0: "#a8b0ba",
+    text1: "#757d87",
+    text2: "#3e4248",
+    link: "#7999f6",
+    linkVisited: "#a288f6",
+    inputBg: "#24262b",
+    inputBorder: "rgba(255, 255, 255, 0.15)",
+    selectionBg: "rgba(121, 153, 246, 0.25)",
+    codeFg: "#ef77f8",
+  },
+} as const satisfies Record<string, Swatch>
+
+export type SwatchId = keyof typeof SWATCHES
+
+function isSwatchId(id: string): id is SwatchId {
+  return id in SWATCHES
+}
+
+/** Falls back to the default swatch for an id outside the registry. */
+export function getSwatch(id: string): Swatch {
+  return isSwatchId(id) ? SWATCHES[id] : SWATCHES[DEFAULT_SWATCH_ID]
+}
+
+// ── Φ_comfort ─────────────────────────────────────────────────────────────
+//
+// "Dark" is not the property; "comfortable" is. Today's zero-leak Φ only
+// forbids bright leaks (Remark C.1) — a swatch can pass it while frying the
+// eyes (`#fff` on `#000`, contrast 21:1). Φ_comfort is the additional,
+// checkable predicate the ergonomics note actually argues for. It is
+// defined here over a `Swatch`'s primary (bg0, text0) pair, the pairing the
+// note's own claims are about; S6 re-runs it on rendered output.
+
+const TEXT_LUMINANCE_CEILING = 0.92
+const CONTRAST_BAND_MIN = 7.5
+const CONTRAST_BAND_MAX = 16
+const CHROMATIC_SATURATION_FLOOR = 0.03
+const BACKGROUND_LUMINANCE_FLOOR = 0.001
+
+function hexToRGBA(hex: string): RGBA {
+  const clean = hex.replace("#", "")
+  const r = Number.parseInt(clean.slice(0, 2), 16) / 255
+  const g = Number.parseInt(clean.slice(2, 4), 16) / 255
+  const b = Number.parseInt(clean.slice(4, 6), 16) / 255
+  return [r, g, b, 1]
+}
+
+function contrastRatio(luminanceA: number, luminanceB: number): number {
+  const [hi, lo] =
+    luminanceA >= luminanceB
+      ? [luminanceA, luminanceB]
+      : [luminanceB, luminanceA]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+export type ComfortReport = {
+  /** Primary text is never the brightest thing on screen (no `#fff` text). */
+  readonly textNotBrightest: boolean
+  /** Contrast lives in the comfort band, not pinned at the 21:1 maximum. */
+  readonly contrastInBand: boolean
+  /** The neutral carries a chromatic bias — a gray with a hue, not achromatic. */
+  readonly chromaticBias: boolean
+  /** The background is a mid-dark reference, not a void (`#000`). */
+  readonly bgNotBlack: boolean
+}
+
+/** Pure predicate over a `Swatch`'s (bg0, text0) pair. No DOM access. */
+export function comfortReport(swatch: Swatch): ComfortReport {
+  const bg = hexToRGBA(swatch.bg0)
+  const text = hexToRGBA(swatch.text0)
+
+  const bgLuminance = relativeLuminance(bg[0], bg[1], bg[2])
+  const textLuminance = relativeLuminance(text[0], text[1], text[2])
+  const contrast = contrastRatio(bgLuminance, textLuminance)
+  const bgSaturation = rgbToHSL(bg).s
+  const textSaturation = rgbToHSL(text).s
+
+  return {
+    textNotBrightest: textLuminance <= TEXT_LUMINANCE_CEILING,
+    contrastInBand:
+      contrast >= CONTRAST_BAND_MIN && contrast <= CONTRAST_BAND_MAX,
+    chromaticBias:
+      bgSaturation >= CHROMATIC_SATURATION_FLOOR &&
+      textSaturation >= CHROMATIC_SATURATION_FLOOR,
+    bgNotBlack: bgLuminance > BACKGROUND_LUMINANCE_FLOOR,
+  }
+}
+
+/** `Φ_comfort(swatch)` — every clause of `comfortReport` holds. */
+export function satisfiesComfort(swatch: Swatch): boolean {
+  const report = comfortReport(swatch)
+  return (
+    report.textNotBrightest &&
+    report.contrastInBand &&
+    report.chromaticBias &&
+    report.bgNotBlack
+  )
+}

--- a/extensions/some-filter/src/lib/content/theme-apply.ts
+++ b/extensions/some-filter/src/lib/content/theme-apply.ts
@@ -21,6 +21,11 @@
  *   shouldSkip(). Vendor DOM is left in place; extension nodes self-exclude.
  */
 
+import {
+  DEFAULT_SWATCH_ID,
+  SWATCHES,
+  type Swatch,
+} from "@filter/adapter/swatches"
 import type { FilterConfig } from "@filter/types/config"
 
 import { parseColor, relativeLuminance } from "./color"
@@ -31,27 +36,33 @@ export const DARK_THEME_ATTR = "data-sw-dark"
 export const LEGACY_THEME_ATTR = "data-sw-legacy"
 
 // ── Tokens ────────────────────────────────────────────────────────────────────
+// Values come from the active swatch (default: SWATCHES.default, byte-for-byte
+// today's palette) rather than a hardcoded literal — see src/adapter/swatches.ts.
 
-const TOKENS = `
-  --sw-bg-0: #0d1117;
-  --sw-bg-1: #13161d;
-  --sw-bg-2: #1a1e27;
-  --sw-bg-3: #21252f;
-  --sw-surface: #1e222b;
-  --sw-border: rgba(255, 255, 255, 0.08);
+function swatchTokens(swatch: Swatch): string {
+  return `
+  --sw-bg-0: ${swatch.bg0};
+  --sw-bg-1: ${swatch.bg1};
+  --sw-bg-2: ${swatch.bg2};
+  --sw-bg-3: ${swatch.bg3};
+  --sw-surface: ${swatch.surface};
+  --sw-border: ${swatch.border};
 
-  --sw-text-0: #e2e8f0;
-  --sw-text-1: #94a3b8;
-  --sw-text-2: #475569;
+  --sw-text-0: ${swatch.text0};
+  --sw-text-1: ${swatch.text1};
+  --sw-text-2: ${swatch.text2};
 
-  --sw-link: #7aa2f7;
-  --sw-link-visited: #9d8cf7;
+  --sw-link: ${swatch.link};
+  --sw-link-visited: ${swatch.linkVisited};
 
-  --sw-input-bg: #1a1e27;
-  --sw-input-border: rgba(255, 255, 255, 0.15);
+  --sw-input-bg: ${swatch.inputBg};
+  --sw-input-border: ${swatch.inputBorder};
 
-  --sw-selection-bg: rgba(122, 162, 247, 0.25);
+  --sw-selection-bg: ${swatch.selectionBg};
+
+  --sw-code: ${swatch.codeFg};
 `
+}
 
 // ── CSS layer ─────────────────────────────────────────────────────────────────
 
@@ -60,13 +71,15 @@ const TOKENS = `
 // :not([data-my-ext])    — excludes the marked node itself
 const EXT_GUARD = ":not([data-my-ext]):not([data-my-ext] *)"
 
-export function buildDarkThemeCSS(): string {
+export function buildDarkThemeCSS(
+  swatch: Swatch = SWATCHES[DEFAULT_SWATCH_ID]
+): string {
   return `
 /* ── SW Dark Theme ──────────────────────────────────────────────────────── */
 
 /* Tokens on :root */
 :root {
-  ${TOKENS}
+  ${swatchTokens(swatch)}
 }
 
 /* Dark canvas on html and body — but not if they are somehow extension-owned
@@ -118,7 +131,7 @@ body${EXT_GUARD} {
 
 :where(code, kbd, samp)${EXT_GUARD} {
   background-color: var(--sw-bg-3) !important;
-  color: #e879f9 !important;
+  color: var(--sw-code) !important;
 }
 
 :where(pre)${EXT_GUARD} {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       '@some-extension/common':
         specifier: workspace:*
         version: link:../common
+      '@some-extension/transport':
+        specifier: workspace:*
+        version: link:../transport
     devDependencies:
       '@some-ui/tsconfig':
         specifier: workspace:*
@@ -11718,6 +11721,7 @@ packages:
   stream-to-promise@3.0.0:
     resolution: {integrity: sha512-h+7wLeFiYegOdgTfTxjRsrT7/Op7grnKEIHWgaO1RTHwcwk7xRreMr3S8XpDfDMesSxzgM2V4CxNCFAGo6ssnA==}
     engines: {node: '>= 10'}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}


### PR DESCRIPTION
## Description

Lands S1 and S2 of the `some-filter`-on-`transport` epic (#685), milestone [metamathematics. (M16)](https://github.com/paulgsc/some-ui/milestone/16).

**S1 (#686) — Instantiate the kernel.** `extensions/some-filter/src/adapter/contracts.ts` names `some-filter`'s three transport-kernel type parameters, types only:
- `SurfaceKey` — a canonicalized *observed background color* (a surface bucket), not a DOM node identity. Doc comment traces this to `theme-apply.ts`'s existing `colorTokens`/`tokenForBackground` dedup-by-color behavior and argues why keying on the source color (rather than the currently-cached dark output) is the more principled choice.
- `SurfaceAttr` — the `(color, luminance, opacity)` evidence `classifyElement` already derives via `color.ts`. Deliberately excludes a certainty/tier field, with a comment explaining why: that's transport's own `ProvenanceStore` bookkeeping (Definition 5.1), not part of the public `Hypothesis` surface.
- `FilterAction` — `TagSurfaceAction | EmitSurfaceColorAction`, re-expressing the two DOM effects the current JS patcher performs (`data-sw-patched` writes + the dynamic stylesheet rule) as declarative records.
- `FilterAdapter = Adapter<SurfaceKey, SurfaceAttr, FilterAction>` — the permanent, zero-runtime-cost proof that these three types satisfy `@some-extension/transport`'s exported `Adapter` contract (the throwaway `decide: () => []` stub used to confirm this during development was not committed).

**S2 (#687) — Swatches as data.** `extensions/some-filter/src/adapter/swatches.ts`:
- `Swatch` type generalizing `theme-apply.ts`'s hardcoded `TOKENS` fields.
- `SWATCHES` registry: `default` is byte-for-byte today's palette (behavior-preserving), plus six chromatic-gray palettes from the milestone's ergonomics note (Cool Blue Gray, Soft Green Gray, Purple Gray, Warm Paper Dark, Neutral Gray, Low Contrast Comfort).
- `Φ_comfort` (`comfortReport` / `satisfiesComfort`): a pure predicate over a swatch's `(bg0, text0)` pair — text is never the brightest thing on screen, contrast lives in a comfort band rather than pinned at 21:1, the neutral carries a chromatic bias, and the background isn't pure black.
- `buildDarkThemeCSS()` now reads its CSS custom properties from the active swatch (default: the registry default) instead of a literal; the `code`/`kbd`/`samp` color now reads `var(--sw-code)` instead of a hardcoded hex.
- Proposes the matching canon amendment: `extensions/docs/dom-state-estimation-canon.typ` gains a new "C.6 · Comfort as a distinct, non-zero-leak invariant" section (Definition C.3, Remark C.6) and a `v1.3 → v1.4` entry in the Recorded amendments log, per the story's requirement that amendments be reflected in the canon file, not just source.

Both stories are types/data only — no pipeline wiring, no `decide` implementation, no picker UI (all explicitly out of scope per the epic; tracked as S3–S7).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (canon amendment)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Test plan

- `pnpm --filter @some-extension/filter typecheck` — passes
- `pnpm --filter @some-extension/filter lint:js` — passes
- `pnpm --filter @some-extension/filter test` — 111/111 passing, including a new `swatches.test.ts` asserting every registry entry satisfies `Φ_comfort`, plus `#fff`-on-`#000` and achromatic-gray counterexamples confirming the predicate actually rejects unsafe swatches
- `pnpm --filter @some-extension/transport typecheck` / `test` — unaffected, still passing (136/136)
- Verified (via a throwaway test, not committed) that `buildDarkThemeCSS()` with the default swatch reproduces every original `TOKENS` literal byte-for-byte

Closes #686
Closes #687


---
_Generated by [Claude Code](https://claude.ai/code/session_01LavqbpL6aDeWXX3Kqe9Fgw)_