### PR TITLE
feat(some-filter): pure decide() + transport Bootstrap adoption (S3, S4)

### DIFF
--- a/extensions/some-filter/src/adapter/__tests__/bootstrap.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/bootstrap.test.ts
@@ -1,0 +1,171 @@
+import { isSelfTagged } from "@some-extension/transport/actuator/self-tag"
+import {
+  installedAt,
+  isInstalled,
+} from "@some-extension/transport/bootstrap/static"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { PREPAINT_VEIL_ID } from "../../lib/content/prepaint"
+import {
+  createFilterBootstrap,
+  wasRemovedByUs,
+  wasRemovedByVendor,
+} from "../bootstrap"
+
+const root = document.documentElement
+
+afterEach(() => {
+  document.getElementById(PREPAINT_VEIL_ID)?.remove()
+  root.removeAttribute("data-transport-bootstrap")
+  root.classList.remove("sw-dirty")
+  vi.restoreAllMocks()
+})
+
+describe("createFilterBootstrap — install", () => {
+  it("installs the Bootstrap sentinel and creates a self-tagged veil", () => {
+    const fb = createFilterBootstrap(root)
+    fb.install()
+
+    expect(isInstalled(root)).toBe(true)
+
+    const veil = document.getElementById(PREPAINT_VEIL_ID)
+    expect(veil).not.toBeNull()
+    if (veil === null) return
+    expect(isSelfTagged(veil)).toBe(true)
+  })
+
+  it("is idempotent: a second call while already installed changes neither the sentinel nor the veil element", () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(1_000)
+    const fb = createFilterBootstrap(root)
+    fb.install()
+    vi.restoreAllMocks()
+
+    const firstInstalledAt = installedAt(root)
+    const firstVeil = document.getElementById(PREPAINT_VEIL_ID)
+
+    vi.spyOn(Date, "now").mockReturnValueOnce(2_000)
+    fb.install()
+    vi.restoreAllMocks()
+
+    expect(installedAt(root)).toBe(firstInstalledAt)
+    expect(document.getElementById(PREPAINT_VEIL_ID)).toBe(firstVeil)
+  })
+})
+
+describe("createFilterBootstrap — resetContent (Theorem D.1a: same-document navigation)", () => {
+  it("advances the epoch on every navigation while the sentinel and veil are untouched", () => {
+    const fb = createFilterBootstrap(root)
+    fb.install()
+
+    const installedAtValue = installedAt(root)
+    const veil = document.getElementById(PREPAINT_VEIL_ID)
+    const epochs: Array<number> = [fb.session.epoch]
+
+    for (let i = 0; i < 3; i++) {
+      fb.resetContent()
+      epochs.push(fb.session.epoch)
+
+      expect(isInstalled(root)).toBe(true)
+      expect(installedAt(root)).toBe(installedAtValue)
+      expect(document.getElementById(PREPAINT_VEIL_ID)).toBe(veil)
+    }
+
+    const [first, ...rest] = epochs
+    expect(first).toBeDefined()
+    let previous = first ?? -Infinity
+    for (const epoch of rest) {
+      expect(epoch).toBeGreaterThan(previous)
+      previous = epoch
+    }
+  })
+})
+
+describe("createFilterBootstrap — resetDocument (Theorem D.1b: refresh)", () => {
+  it("tears down the sentinel and veil; a subsequent install() reinstalls fresh with a strictly greater epoch", () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(1_000)
+    const fb = createFilterBootstrap(root)
+    fb.install()
+    vi.restoreAllMocks()
+
+    const originalInstalledAt = installedAt(root)
+    const epochBeforeReset = fb.session.epoch
+
+    fb.resetDocument()
+
+    expect(isInstalled(root)).toBe(false)
+    expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+
+    vi.spyOn(Date, "now").mockReturnValueOnce(2_000)
+    fb.install()
+    vi.restoreAllMocks()
+
+    expect(installedAt(root)).not.toBe(originalInstalledAt)
+    expect(fb.session.epoch).toBeGreaterThan(epochBeforeReset)
+    expect(document.getElementById(PREPAINT_VEIL_ID)).not.toBeNull()
+  })
+
+  it("runs every disposable before tearing down Bootstrap", () => {
+    const fb = createFilterBootstrap(root)
+    fb.install()
+
+    const calls: Array<string> = []
+    fb.resetDocument([
+      (): void => {
+        calls.push("a")
+      },
+      (): void => {
+        calls.push("b")
+      },
+    ])
+
+    expect(calls).toEqual(["a", "b"])
+    expect(isInstalled(root)).toBe(false)
+  })
+})
+
+describe("createFilterBootstrap — ownership signal (Remark 7.2)", () => {
+  it("distinguishes a vendor removal from our own teardown at the element level", () => {
+    const fb = createFilterBootstrap(root)
+    fb.install()
+    const veil = document.getElementById(PREPAINT_VEIL_ID)
+    expect(veil).not.toBeNull()
+    if (veil === null) return
+
+    veil.remove() // simulated vendor sweep — no releaseOwnership() first
+
+    expect(wasRemovedByVendor(veil)).toBe(true)
+    expect(wasRemovedByUs(veil)).toBe(false)
+  })
+
+  it("reassertIfRemoved() re-creates the veil after a simulated vendor removal", () => {
+    const fb = createFilterBootstrap(root)
+    fb.install()
+    const originalVeil = document.getElementById(PREPAINT_VEIL_ID)
+    expect(originalVeil).not.toBeNull()
+    if (originalVeil === null) return
+
+    originalVeil.remove() // vendor sweep
+    fb.reassertIfRemoved()
+
+    const reassertedVeil = document.getElementById(PREPAINT_VEIL_ID)
+    expect(reassertedVeil).not.toBeNull()
+    expect(reassertedVeil).not.toBe(originalVeil)
+  })
+
+  it("reassertIfRemoved() is a no-op after our own resetDocument() teardown", () => {
+    const fb = createFilterBootstrap(root)
+    fb.install()
+    fb.resetDocument()
+
+    fb.reassertIfRemoved()
+
+    expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+    expect(isInstalled(root)).toBe(false)
+  })
+
+  it("reassertIfRemoved() is a no-op before the first install()", () => {
+    const fb = createFilterBootstrap(root)
+    expect(() => fb.reassertIfRemoved()).not.toThrow()
+    expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+  })
+})

--- a/extensions/some-filter/src/adapter/__tests__/theme-adapter.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/theme-adapter.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { createHypothesis } from "@some-extension/transport/estimator/hypothesis"
+import { describe, expect, it } from "vitest"
+
+import { parseColor, relativeLuminance } from "../../lib/content/color"
+import type { SurfaceAttr, SurfaceKey } from "../contracts"
+import { SWATCHES } from "../swatches"
+import { decide } from "../theme-adapter"
+
+const swatch = SWATCHES.default
+
+/** Builds a SurfaceAttr the same way S1 traces it: parseColor + relativeLuminance. */
+function attrFor(css: string, opacity = 1): SurfaceAttr {
+  const color = parseColor(css)
+  if (color === null) throw new Error(`unparseable fixture color: ${css}`)
+  return {
+    color,
+    luminance: relativeLuminance(color[0], color[1], color[2]),
+    opacity,
+  }
+}
+
+describe("decide — Axiom D.1 structural checks", () => {
+  it("contains no DOM-mutating call or getComputedStyle", () => {
+    const path = join(process.cwd(), "src/adapter/theme-adapter.ts")
+    // Strip comments first — the module's own doc comments discuss (and
+    // rule out) getComputedStyle/document by name; only code should be
+    // checked for an actual reference.
+    const code = readFileSync(path, "utf-8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "")
+
+    expect(code).not.toMatch(/getComputedStyle/)
+    expect(code).not.toMatch(/\bdocument\./)
+  })
+})
+
+describe("decide — null swatch", () => {
+  it("returns ∅ regardless of hypothesis contents", () => {
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    h.set("rgb(255, 255, 255)", attrFor("rgb(255, 255, 255)"))
+    expect(decide(h, null)).toEqual([])
+  })
+})
+
+describe("decide — purity", () => {
+  it("returns the identical action set, in the same order, across repeated calls", () => {
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    h.set("rgb(255, 255, 255)", attrFor("rgb(255, 255, 255)"))
+    h.set("rgb(90, 90, 90)", attrFor("rgb(90, 90, 90)"))
+    h.set("rgb(13, 17, 23)", attrFor("rgb(13, 17, 23)"))
+
+    const first = decide(h, swatch)
+    const second = decide(h, swatch)
+
+    expect(second).toEqual(first)
+  })
+})
+
+describe("decide — no bright surfaces", () => {
+  it("returns ∅ for an empty hypothesis", () => {
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    expect(decide(h, swatch)).toEqual([])
+  })
+
+  it("emits no per-surface action for mid-luminance (untouched-band) evidence", () => {
+    // Paired with a bright anchor so the page-level verdict (below) doesn't
+    // also fire and mask the per-surface question this test asks; only the
+    // "mid" key's own actions are inspected.
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    h.set("anchor", attrFor("rgb(255, 255, 255)"))
+    h.set("mid", attrFor("rgb(90, 90, 90)"))
+
+    const actions = decide(h, swatch).filter(
+      (a) => "key" in a && a.key === "mid"
+    )
+    expect(actions).toEqual([])
+  })
+})
+
+describe("decide — mixed page", () => {
+  it("emits tag+emit for light surfaces and tag-only for preserve-band surfaces", () => {
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    h.set("light", attrFor("rgb(255, 255, 255)"))
+    h.set("near-black", attrFor("rgb(13, 17, 23)"))
+
+    const actions = decide(h, swatch)
+
+    expect(actions).toEqual([
+      { kind: "tag-surface", key: "light", role: "surface" },
+      {
+        kind: "emit-surface-color",
+        key: "light",
+        css: expect.any(String),
+      },
+      { kind: "tag-surface", key: "near-black", role: "preserve" },
+    ])
+  })
+
+  it("skips near-transparent evidence regardless of luminance", () => {
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    h.set("glass", attrFor("rgba(255, 255, 255, 0.05)", 0.05))
+    expect(decide(h, swatch)).toEqual([])
+  })
+})
+
+describe("decide — page-level already-dark verdict", () => {
+  it("withholds every per-surface action and emits restore-native when the mean luminance reads dark", () => {
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    // Every evidenced key is near-black; classifyPage()'s reframe (detect())
+    // would call this page already dark.
+    h.set("a", attrFor("rgb(13, 17, 23)"))
+    h.set("b", attrFor("rgb(5, 5, 5)"))
+
+    expect(decide(h, swatch)).toEqual([{ kind: "restore-native" }])
+  })
+
+  it("themes normally when the mean luminance reads light", () => {
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    h.set("a", attrFor("rgb(255, 255, 255)"))
+
+    const actions = decide(h, swatch)
+    expect(actions.some((a) => a.kind === "restore-native")).toBe(false)
+  })
+})
+
+describe("decide — golden fixture (parity with pre-refactor classifyElement)", () => {
+  const cases: ReadonlyArray<{
+    readonly name: string
+    readonly css: string
+    readonly expected: "surface" | "preserve" | "none"
+  }> = [
+    { name: "white", css: "rgb(255, 255, 255)", expected: "surface" },
+    { name: "light gray", css: "rgb(200, 200, 200)", expected: "surface" },
+    {
+      name: "near-black (today's bg-0)",
+      css: "rgb(13, 17, 23)",
+      expected: "preserve",
+    },
+    { name: "dark gray", css: "rgb(45, 45, 45)", expected: "preserve" },
+    { name: "mid gray (untouched)", css: "rgb(90, 90, 90)", expected: "none" },
+    {
+      name: "mid gray, upper band",
+      css: "rgb(130, 130, 130)",
+      expected: "none",
+    },
+  ]
+
+  for (const { name, css, expected } of cases) {
+    it(`classifies "${name}" (${css}) as ${expected}`, () => {
+      // Paired with a bright anchor (a distinct key) so the page-level
+      // verdict never masks the per-surface question — only actions for
+      // the "k" key are inspected.
+      const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+      h.set("anchor", attrFor("rgb(255, 255, 255)"))
+      h.set("k", attrFor(css))
+
+      const roles = decide(h, swatch)
+        .filter(
+          (a): a is Extract<typeof a, { kind: "tag-surface" }> =>
+            a.kind === "tag-surface" && a.key === "k"
+        )
+        .map((a) => a.role)
+
+      if (expected === "none") {
+        expect(roles).toEqual([])
+      } else {
+        expect(roles).toEqual([expected])
+      }
+    })
+  }
+})

--- a/extensions/some-filter/src/adapter/bootstrap.ts
+++ b/extensions/some-filter/src/adapter/bootstrap.ts
@@ -1,0 +1,131 @@
+/**
+ * Adopts transport's Bootstrap (Definition D.2) and Session/Lifecycle
+ * (Definition 5.4, Theorem D.1) for `some-filter`'s prepaint veil — S4 of
+ * the some-filter-on-transport epic (#685, #689).
+ *
+ * `public/prepaint.*`, installed at `document_start` and independent of
+ * classification, is "Bootstrap by another name, discovered before the
+ * theory that named it" (canon §9.2). This module does not replace
+ * `prepaint.ts`'s veil mechanics (still the only thing that creates or
+ * removes the actual DOM element) or `prepaint-start.js`'s document_start
+ * install (out of scope — that is the raw anti-flash critical path and is
+ * untouched by this story); it gives the *install/reset* decision a
+ * transport-shaped surface — Bootstrap's sentinel instead of an implicit
+ * "call enablePrepaint() and hope," and the two named reset paths Theorem
+ * D.1 distinguishes instead of `content.ts`'s ad-hoc `sessionStorage` +
+ * `yt-navigate-finish` handling. `content.ts` itself is not rewired to call
+ * this module yet — that wiring is S5's ("no per-surface actuation (S5)").
+ *
+ * The ownership signal (Remark 7.2) is mapped onto transport's `self-tag`
+ * primitive (`wasRemovedByVendor`/`wasRemovedByUs`) *in addition to*, not
+ * instead of, `prepaint.ts`'s own `sw-dirty` class: `sw-dirty` drives a
+ * pure-CSS backstop (`html.sw-dirty > body { background: #000 }`) that
+ * works even before any JS observer runs, which self-tag's data attributes
+ * cannot replace. `reassertIfRemoved()` below is the JS-observable half —
+ * the pure decision transport's self-tag makes checkable without a live
+ * MutationObserver.
+ */
+
+import {
+  disablePrepaint,
+  enablePrepaint,
+  PREPAINT_VEIL_ID,
+} from "@filter/lib/content/prepaint"
+import {
+  releaseOwnership,
+  tag,
+  wasRemovedByUs,
+  wasRemovedByVendor,
+} from "@some-extension/transport/actuator/self-tag"
+import * as bootstrapLayer from "@some-extension/transport/bootstrap/static"
+import {
+  teardownContent,
+  teardownDocument,
+} from "@some-extension/transport/lifecycle/teardown"
+import type { Disposable } from "@some-extension/transport/lifecycle/teardown"
+import {
+  createSessionLifecycle,
+  type SessionLifecycle,
+} from "@some-extension/transport/session/lifecycle"
+
+const OWNERSHIP_TAG_VALUE = "prepaint-veil"
+
+export type FilterBootstrap = {
+  readonly session: SessionLifecycle
+
+  /**
+   * Installs Bootstrap's sentinel on `root` (Corollary D.1.1's day-zero
+   * case) and ensures the veil exists and is self-tagged. Idempotent as a
+   * whole because each step it composes already is: `bootstrapLayer.install`
+   * no-ops once a sentinel exists, `enablePrepaint` no-ops once a veil
+   * exists, `tag` no-ops when re-applying the same value. Deliberately does
+   * *not* gate veil creation on "was Bootstrap already installed" — the
+   * sentinel and the veil element are tracked independently (Remark 7.2's
+   * whole point is that the veil can go missing while the sentinel does
+   * not), so `reassertIfRemoved()` below can call this same `install()`
+   * after a vendor removes only the veil and still get it back.
+   */
+  install(): void
+
+  /** Theorem D.1(a): same-document (SPA) navigation. Bootstrap, and the veil, are untouched — only the content epoch advances. */
+  resetContent(disposables?: ReadonlyArray<Disposable>): void
+
+  /** Theorem D.1(b): refresh. Disposes the content session, releases and removes the veil, uninstalls the sentinel, and advances the epoch. A subsequent `install()` reinstalls fresh. */
+  resetDocument(disposables?: ReadonlyArray<Disposable>): void
+
+  /** Remark 7.2: re-installs iff the tracked veil was disconnected by the vendor rather than by this module's own `resetDocument()`. No-op before the first `install()`. */
+  reassertIfRemoved(): void
+}
+
+export function createFilterBootstrap(
+  root: Element = document.documentElement
+): FilterBootstrap {
+  const session = createSessionLifecycle()
+  let trackedVeil: Element | null = null
+
+  function currentVeil(): Element | null {
+    return root.ownerDocument.getElementById(PREPAINT_VEIL_ID)
+  }
+
+  function install(): void {
+    bootstrapLayer.install(root)
+    enablePrepaint()
+
+    const veil = currentVeil()
+    if (veil !== null) {
+      tag(veil, OWNERSHIP_TAG_VALUE)
+    }
+    trackedVeil = veil
+  }
+
+  function teardownBootstrap(): void {
+    if (trackedVeil !== null) {
+      releaseOwnership(trackedVeil)
+    }
+    disablePrepaint()
+    bootstrapLayer.uninstall(root)
+    trackedVeil = null
+  }
+
+  return {
+    session,
+
+    install,
+
+    resetContent(disposables: ReadonlyArray<Disposable> = []): void {
+      teardownContent(disposables, session)
+    },
+
+    resetDocument(disposables: ReadonlyArray<Disposable> = []): void {
+      teardownDocument(disposables, session, teardownBootstrap)
+    },
+
+    reassertIfRemoved(): void {
+      if (trackedVeil !== null && wasRemovedByVendor(trackedVeil)) {
+        install()
+      }
+    },
+  }
+}
+
+export { wasRemovedByUs, wasRemovedByVendor }

--- a/extensions/some-filter/src/adapter/contracts.ts
+++ b/extensions/some-filter/src/adapter/contracts.ts
@@ -96,7 +96,21 @@ export type EmitSurfaceColorAction = {
   readonly css: string
 }
 
-export type FilterAction = TagSurfaceAction | EmitSurfaceColorAction
+/**
+ * The page-level counterpart to `theme-detector.ts`'s `alreadyDark` verdict
+ * (added in S3, #688): `runAutoTheme()`'s `if (verdict.alreadyDark)
+ * restoreVendor()` branch becomes an action `decide` emits instead of an
+ * imperative call — withholding every per-surface action for the round
+ * rather than issuing them and having a caller undo the result.
+ */
+export type RestoreNativeAction = {
+  readonly kind: "restore-native"
+}
+
+export type FilterAction =
+  | TagSurfaceAction
+  | EmitSurfaceColorAction
+  | RestoreNativeAction
 
 /**
  * The instantiated kernel: `Adapter<SurfaceKey, SurfaceAttr, FilterAction>`.

--- a/extensions/some-filter/src/adapter/theme-adapter.ts
+++ b/extensions/some-filter/src/adapter/theme-adapter.ts
@@ -1,0 +1,109 @@
+/**
+ * The theme Adapter — `decide : Ĥ → Fin(A)` (Definition D.3, canon §D.1,
+ * Axiom D.1). S3 of the some-filter-on-transport epic (#685, #688).
+ *
+ * Pure, total, no DOM, no `getComputedStyle`: everything domain-specific
+ * about theming a page collapses into this one function of the estimator's
+ * current hypothesis (S1's `SurfaceKey`/`SurfaceAttr`) and the active
+ * swatch (S2). `theme-detector.ts` and `theme-apply.ts`'s JS patcher are
+ * untouched by this story — they remain the live pipeline until S5 rewires
+ * `content.ts` onto Sensor → Estimator → Scheduler → Actuator. This module
+ * is the *destination* of that rewiring, built and proven correct first.
+ *
+ * Per-surface classification reuses `color.ts`/`modify-colors.ts`'s
+ * existing, canon-blessed luminance math unchanged (S3's own framing: "keep
+ * the existing luminance math... it simply moves inside decide as pure
+ * computation over Ĥ, instead of running against live getComputedStyle
+ * reads"). The page-level verdict folds `theme-detector.ts`'s
+ * `classifyPage()`/`detect()` decision arithmetic (weighted-average
+ * luminance vs. a threshold) into a pure predicate over Ĥ's evidenced
+ * keys — deliberately *unweighted* (Ĥ's `SurfaceAttr` carries no per-key
+ * weight; `classifyPage()`'s tiered/viewport-coverage weighting is what
+ * decides *which* evidence lands in Ĥ and is therefore a Sensor concern,
+ * S5's to supply, not this pure function's to re-derive from live DOM).
+ */
+
+import {
+  modifyBackgroundColor,
+  rgbaToCss,
+} from "@filter/lib/content/modify-colors"
+import type { Hypothesis } from "@some-extension/transport/contracts/hypothesis"
+
+import type { FilterAction, SurfaceAttr, SurfaceKey } from "./contracts"
+import type { Swatch } from "./swatches"
+
+// Mirrors theme-apply.ts's classifyElement thresholds exactly (unchanged math).
+const LIGHT_THRESHOLD = 0.3
+const PRESERVE_THRESHOLD = 0.06
+const OPACITY_SKIP_THRESHOLD = 0.1
+
+// Mirrors theme-detector.ts's classifyPage()/detect() default threshold.
+const PAGE_LUMINANCE_THRESHOLD = 0.4
+
+/**
+ * `detect()`'s `alreadyDark` verdict, folded into a pure predicate over Ĥ:
+ * an unweighted mean luminance across every evidenced key, compared against
+ * the same threshold `classifyPage()` uses. No evidence yet (`count === 0`)
+ * mirrors `classifyPage()`'s own zero-samples case — assume light (the
+ * browser-default-white bias), i.e. not already dark.
+ */
+function pageAlreadyDark(
+  hypothesis: Hypothesis<SurfaceKey, SurfaceAttr>
+): boolean {
+  let total = 0
+  let count = 0
+
+  for (const key of hypothesis.keys()) {
+    const attr = hypothesis.get(key)
+    if (attr === undefined) continue
+    total += attr.luminance
+    count += 1
+  }
+
+  if (count === 0) return false
+
+  const avgLuminance = total / count
+  return avgLuminance <= PAGE_LUMINANCE_THRESHOLD
+}
+
+/**
+ * `decide(Ĥ)`. A `swatch` of `null` is the degenerate "no theme selected"
+ * case and mirrors the null adapter (Theorem D.2): `∅` unconditionally,
+ * before the page-level verdict is even evaluated.
+ */
+export function decide(
+  hypothesis: Hypothesis<SurfaceKey, SurfaceAttr>,
+  swatch: Swatch | null
+): ReadonlyArray<FilterAction> {
+  if (swatch === null) {
+    return []
+  }
+
+  if (pageAlreadyDark(hypothesis)) {
+    return [{ kind: "restore-native" }]
+  }
+
+  const actions: Array<FilterAction> = []
+
+  for (const key of hypothesis.keys()) {
+    const attr = hypothesis.get(key)
+    if (attr === undefined) continue
+    if (attr.opacity < OPACITY_SKIP_THRESHOLD) continue
+
+    if (attr.luminance > LIGHT_THRESHOLD) {
+      actions.push({ kind: "tag-surface", key, role: "surface" })
+      actions.push({
+        kind: "emit-surface-color",
+        key,
+        css: rgbaToCss(modifyBackgroundColor(attr.color)),
+      })
+      continue
+    }
+
+    if (attr.luminance < PRESERVE_THRESHOLD) {
+      actions.push({ kind: "tag-surface", key, role: "preserve" })
+    }
+  }
+
+  return actions
+}


### PR DESCRIPTION
## Description

Lands S3 and S4 of the `some-filter`-on-`transport` epic (#685), milestone [metamathematics. (M16)](https://github.com/paulgsc/some-ui/milestone/16).

**Stacked on #704** (S1/S2, not yet merged) — S3 imports `SurfaceKey`/`SurfaceAttr`/`FilterAction` from S1's `contracts.ts` and the default swatch from S2's `swatches.ts`, so this PR's base is `claude/land-prs-686-687-xuenx0`, not `main`. Only the last two commits (`9d0f9bf6`, `12e2c6a8`) are new; the diff view will include #704's commits until that one merges and this is rebased onto `main`.

**S3 (#688) — The theme Adapter.** `extensions/some-filter/src/adapter/theme-adapter.ts`:
- `decide(hypothesis, swatch)` — pure, total, no DOM, no `getComputedStyle` (structurally verified by a test that strips comments and greps the source for both).
- Per-surface classification reuses `color.ts`/`modify-colors.ts`'s existing luminance math **unchanged** — same `LIGHT_THRESHOLD`/preserve-band/opacity-skip constants as today's `classifyElement`, proven against a golden-fixture parity table.
- The page-level already-dark verdict folds `theme-detector.ts`'s `classifyPage()`/`detect()` threshold arithmetic into an unweighted mean over `Ĥ`'s evidenced keys, emitting a new `RestoreNativeAction` (extending S1's `FilterAction`) instead of an imperative `restoreVendor()` call. The tiered/viewport-coverage *weighting* that decides what lands in `Ĥ` in the first place stays a Sensor concern, deferred to S5.
- A `null` swatch mirrors the null adapter (Theorem D.2): `decide` returns `∅` unconditionally.
- 15 tests: purity/referential-transparency, null-swatch, no-bright-surfaces, mixed-page role split, near-transparent skip, the page-level verdict both ways, and a 6-case golden-fixture table.

**S4 (#689) — Bootstrap adoption.** `extensions/some-filter/src/adapter/bootstrap.ts`:
- Gives `public/prepaint.*`'s veil install/enable/disable a transport-shaped surface: Bootstrap's sentinel (Definition D.2) instead of an implicit "call `enablePrepaint()` and hope," and the two reset paths Theorem D.1 distinguishes (`resetContent` for same-document navigation, `resetDocument` for refresh) instead of `content.ts`'s ad-hoc `sessionStorage` + `yt-navigate-finish` handling.
- `install()` composes three independently-idempotent primitives (`bootstrapLayer.install`, `enablePrepaint`, `tag`) rather than gating veil creation on "was Bootstrap already installed" — the sentinel and the veil element are tracked independently, which is what lets `reassertIfRemoved()` recover a vendor-swept veil without touching the sentinel.
- The ownership signal (Remark 7.2) is mapped onto transport's `self-tag` primitive (`wasRemovedByVendor`/`wasRemovedByUs`) **in addition to**, not instead of, `prepaint.ts`'s `sw-dirty` class — `sw-dirty` still drives the pure-CSS backstop that works before any JS observer runs.
- 9 tests: install + idempotence, SPA-nav (sentinel/veil untouched, epoch advances), refresh (sentinel + veil torn down, reinstall gets a new sentinel and a strictly-greater epoch), disposables run before teardown, and the vendor-removal-vs-intentional-teardown distinction (structurally and via `reassertIfRemoved()`).

Both stories build the *destination* of S5's pipeline rewiring without wiring it in yet: `theme-detector.ts`, `theme-apply.ts`'s JS patcher, `prepaint.ts`, `prepaint-start.js`, and `content.ts` are all untouched by this PR (non-goals: "no sensing, no actuation, no bootstrap concerns (S4)" for S3; "no decision logic (S3), no per-surface actuation (S5)" for S4).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules — **not yet**: this PR is stacked on #704 (S1/S2), which must merge first

## Test plan

- `pnpm --filter @some-extension/filter typecheck` — passes
- `pnpm --filter @some-extension/filter lint:js` — passes
- `pnpm --filter @some-extension/filter test` — 135/135 passing (24 new: 15 in `theme-adapter.test.ts`, 9 in `bootstrap.test.ts`)
- `pnpm --filter @some-extension/transport typecheck` / `test` — unaffected, still passing (136/136)

Fixes #688
Fixes #689


---
_Generated by [Claude Code](https://claude.ai/code/session_01LavqbpL6aDeWXX3Kqe9Fgw)_