### PR TITLE
feat(some-filter): transport pipeline migration + swatch-oracle e2e (S5, S6)

### DIFF
--- a/extensions/some-filter/src/adapter/__tests__/actuator.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/actuator.test.ts
@@ -1,0 +1,188 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { DARK_THEME_ATTR } from "@filter/lib/content/theme-apply"
+import { describe, expect, it } from "vitest"
+
+import { realize } from "../actuator"
+import type { FilterAction, SurfaceKey } from "../contracts"
+
+const STYLE_ID = "__sw_dark_theme"
+const DYNAMIC_STYLE_ID = "__sw_dark_dynamic"
+
+function cleanUp(): void {
+  document.documentElement.removeAttribute(DARK_THEME_ATTR)
+  document.getElementById(STYLE_ID)?.remove()
+  document.getElementById(DYNAMIC_STYLE_ID)?.remove()
+  document.querySelectorAll("[data-sw-patched]").forEach((el) => {
+    el.removeAttribute("data-sw-patched")
+  })
+  document.body.innerHTML = ""
+}
+
+describe("realize — Definition 7.3 structural check", () => {
+  it("is the only adapter module referencing setAttribute/dataset/appendChild/textContent writes for the dark-theme path", () => {
+    const dir = join(process.cwd(), "src/adapter")
+    const stripComments = (source: string): string =>
+      source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "")
+
+    const domWritePattern =
+      /\.setAttribute\(|\.removeAttribute\(|\.dataset\.|\.appendChild\(|\.textContent\s*=|\.classList\./
+
+    const pipeline = stripComments(
+      readFileSync(join(dir, "pipeline.ts"), "utf-8")
+    )
+    const themeAdapter = stripComments(
+      readFileSync(join(dir, "theme-adapter.ts"), "utf-8")
+    )
+
+    expect(pipeline).not.toMatch(domWritePattern)
+    expect(themeAdapter).not.toMatch(domWritePattern)
+  })
+})
+
+describe("realize — activate-theme", () => {
+  it("sets DARK_THEME_ATTR and injects the static stylesheet", () => {
+    realize([{ kind: "activate-theme", swatchId: "default" }], new Map())
+
+    expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(true)
+    expect(document.getElementById(STYLE_ID)).not.toBeNull()
+
+    cleanUp()
+  })
+})
+
+describe("realize — tag-surface + emit-surface-color", () => {
+  it("tags every element mapped to the key and emits a matching CSS rule", () => {
+    const div = document.createElement("div")
+    document.body.appendChild(div)
+    const key: SurfaceKey = "rgb(255, 255, 255)"
+    const elementsByKey = new Map([[key, [div]]])
+
+    const actions: ReadonlyArray<FilterAction> = [
+      { kind: "activate-theme", swatchId: "default" },
+      { kind: "tag-surface", key, role: "surface" },
+      { kind: "emit-surface-color", key, css: "rgb(10, 10, 20)" },
+    ]
+    realize(actions, elementsByKey)
+
+    expect(div.dataset.swPatched).toBe(key)
+    const dynamicText =
+      document.getElementById(DYNAMIC_STYLE_ID)?.textContent ?? ""
+    expect(dynamicText).toContain(`[data-sw-patched="${key}"]`)
+    expect(dynamicText).toContain("rgb(10, 10, 20)")
+
+    cleanUp()
+  })
+
+  it("tags every element sharing a key, not just the first", () => {
+    const a = document.createElement("div")
+    const b = document.createElement("div")
+    document.body.append(a, b)
+    const key: SurfaceKey = "rgb(255, 255, 255)"
+
+    realize(
+      [{ kind: "tag-surface", key, role: "surface" }],
+      new Map([[key, [a, b]]])
+    )
+
+    expect(a.dataset.swPatched).toBe(key)
+    expect(b.dataset.swPatched).toBe(key)
+
+    cleanUp()
+  })
+
+  it("tags 'preserve'-role elements with the literal preserve value, no CSS rule", () => {
+    const div = document.createElement("div")
+    document.body.appendChild(div)
+    const key: SurfaceKey = "rgb(13, 17, 23)"
+
+    realize(
+      [{ kind: "tag-surface", key, role: "preserve" }],
+      new Map([[key, [div]]])
+    )
+
+    expect(div.dataset.swPatched).toBe("preserve")
+    expect(document.getElementById(DYNAMIC_STYLE_ID)).toBeNull()
+
+    cleanUp()
+  })
+})
+
+describe("realize — idempotence (Theorem 7.2)", () => {
+  it("re-running the same actions twice is a no-op on observable DOM", () => {
+    const div = document.createElement("div")
+    document.body.appendChild(div)
+    const key: SurfaceKey = "rgb(255, 255, 255)"
+    const elementsByKey = new Map([[key, [div]]])
+    const actions: ReadonlyArray<FilterAction> = [
+      { kind: "activate-theme", swatchId: "default" },
+      { kind: "tag-surface", key, role: "surface" },
+      { kind: "emit-surface-color", key, css: "rgb(10, 10, 20)" },
+    ]
+
+    realize(actions, elementsByKey)
+    const afterFirst = document.head.innerHTML + document.body.innerHTML
+
+    realize(actions, elementsByKey)
+    const afterSecond = document.head.innerHTML + document.body.innerHTML
+
+    expect(afterSecond).toBe(afterFirst)
+
+    cleanUp()
+  })
+})
+
+describe("realize — restore-native", () => {
+  it("clears the dark attr, both stylesheets, and every data-sw-patched attribute", () => {
+    const div = document.createElement("div")
+    document.body.appendChild(div)
+    const key: SurfaceKey = "rgb(255, 255, 255)"
+    const elementsByKey = new Map([[key, [div]]])
+
+    realize(
+      [
+        { kind: "activate-theme", swatchId: "default" },
+        { kind: "tag-surface", key, role: "surface" },
+        { kind: "emit-surface-color", key, css: "rgb(10, 10, 20)" },
+      ],
+      elementsByKey
+    )
+
+    realize([{ kind: "restore-native" }], elementsByKey)
+
+    expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(false)
+    expect(document.getElementById(STYLE_ID)).toBeNull()
+    expect(document.getElementById(DYNAMIC_STYLE_ID)).toBeNull()
+    expect(document.querySelectorAll("[data-sw-patched]")).toHaveLength(0)
+
+    cleanUp()
+  })
+
+  it("leaves vendor DOM byte-identical after activate + restore (#236 invariant)", () => {
+    document.body.innerHTML =
+      '<div id="a" style="background-color: rgb(255, 255, 255)">' +
+      '<p style="background-color: rgb(200, 200, 200)">hi</p></div>'
+    const before = document.body.innerHTML
+
+    const div = document.getElementById("a")
+    expect(div).not.toBeNull()
+    if (div === null) return
+
+    const key: SurfaceKey = "rgb(255, 255, 255)"
+    realize(
+      [
+        { kind: "activate-theme", swatchId: "default" },
+        { kind: "tag-surface", key, role: "surface" },
+        { kind: "emit-surface-color", key, css: "rgb(10, 10, 20)" },
+      ],
+      new Map([[key, [div]]])
+    )
+    expect(document.body.innerHTML).not.toBe(before)
+
+    realize([{ kind: "restore-native" }], new Map())
+
+    expect(document.body.innerHTML).toBe(before)
+
+    cleanUp()
+  })
+})

--- a/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
@@ -109,8 +109,13 @@ describe("createContentSession — rescan() is immediate, not coalesced", () => 
   })
 
   it("a genuinely dark page (mean luminance low) restores native instead of tagging, immediately", () => {
+    // Three distinct dark keys, at/above theme-adapter.ts's
+    // MIN_EVIDENCE_FOR_DARK_VERDICT -- a single evidenced element is exactly
+    // the sparse-sample case that guard exists to distrust.
     document.body.innerHTML =
-      '<div id="a" style="background-color: rgb(13, 17, 23)"></div>'
+      '<div id="a" style="background-color: rgb(13, 17, 23)"></div>' +
+      '<div id="b" style="background-color: rgb(5, 5, 5)"></div>' +
+      '<div id="c" style="background-color: rgb(10, 10, 10)"></div>'
     const session = createSessionLifecycle()
     const contentSession = createContentSession(SWATCHES.default, session)
 

--- a/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
@@ -1,0 +1,178 @@
+import { DARK_THEME_ATTR } from "@filter/lib/content/theme-apply"
+import { createSessionLifecycle } from "@some-extension/transport/session/lifecycle"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { createContentSession, scan } from "../pipeline"
+import { SWATCHES } from "../swatches"
+
+const STYLE_ID = "__sw_dark_theme"
+const DYNAMIC_STYLE_ID = "__sw_dark_dynamic"
+
+function cleanUp(): void {
+  document.documentElement.removeAttribute(DARK_THEME_ATTR)
+  document.getElementById(STYLE_ID)?.remove()
+  document.getElementById(DYNAMIC_STYLE_ID)?.remove()
+  document.querySelectorAll("[data-sw-patched]").forEach((el) => {
+    el.removeAttribute("data-sw-patched")
+  })
+  document.body.innerHTML = ""
+}
+
+afterEach(() => {
+  cleanUp()
+})
+
+describe("scan", () => {
+  it("groups elements by their canonical background key", () => {
+    document.body.innerHTML =
+      '<div id="a" style="background-color: rgb(255, 255, 255)"></div>' +
+      '<div id="b" style="background-color: rgb(255, 255, 255)"></div>'
+
+    const { elementsByKey } = scan(document.body)
+
+    const key = "rgb(255, 255, 255)"
+    expect(elementsByKey.get(key)?.map((el) => el.id)).toEqual(["a", "b"])
+  })
+
+  it("does not classify root itself, only descendants", () => {
+    document.body.style.backgroundColor = "rgb(255, 255, 255)"
+    const { elementsByKey } = scan(document.body)
+    for (const elements of elementsByKey.values()) {
+      expect(elements).not.toContain(document.body)
+    }
+  })
+
+  it("skips extension-owned nodes and their descendants", () => {
+    document.body.innerHTML =
+      '<div data-my-ext><div id="inner" style="background-color: rgb(255, 255, 255)"></div></div>'
+
+    const { elementsByKey } = scan(document.body)
+
+    for (const elements of elementsByKey.values()) {
+      expect(elements.some((el) => el.id === "inner")).toBe(false)
+    }
+  })
+
+  it("skips media/script tags", () => {
+    document.body.innerHTML = "<img /><video></video><style>a{}</style>"
+    const { elementsByKey } = scan(document.body)
+    expect(elementsByKey.size).toBe(0)
+  })
+
+  it("finds no evidence on a page with no explicit backgrounds anywhere", () => {
+    document.body.innerHTML = "<main><h1>hi</h1></main>"
+    const { elementsByKey, attrsByKey } = scan(document.body)
+    expect(elementsByKey.size).toBe(0)
+    expect(attrsByKey.size).toBe(0)
+  })
+})
+
+describe("createContentSession — coalescing (Definition 7.2)", () => {
+  it("a burst of N mutations within the debounce window triggers exactly one decide/realize cycle", () => {
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML = '<div id="a"></div>'
+      const session = createSessionLifecycle()
+      let fireCount = 0
+      const contentSession = createContentSession(
+        SWATCHES.default,
+        session,
+        () => {
+          fireCount += 1
+        }
+      )
+
+      const target = document.getElementById("a")
+      expect(target).not.toBeNull()
+      if (target === null) return
+
+      // A burst of rescans well within the 50ms reconcile window.
+      for (let i = 0; i < 10; i++) {
+        target.style.backgroundColor = `rgb(${i}, ${i}, ${i})`
+        contentSession.rescan()
+      }
+
+      expect(fireCount).toBe(0) // nothing has fired yet — still coalescing
+
+      vi.advanceTimersByTime(100)
+
+      expect(fireCount).toBe(1)
+
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("two well-separated rescans (past the debounce window) fire twice", () => {
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML = '<div id="a"></div>'
+      const session = createSessionLifecycle()
+      let fireCount = 0
+      const contentSession = createContentSession(
+        SWATCHES.default,
+        session,
+        () => {
+          fireCount += 1
+        }
+      )
+
+      contentSession.rescan()
+      vi.advanceTimersByTime(100)
+      expect(fireCount).toBe(1)
+
+      contentSession.rescan()
+      vi.advanceTimersByTime(100)
+      expect(fireCount).toBe(2)
+
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe("createContentSession — end to end", () => {
+  it("a light page's div gets tagged and colored after the coalesced cycle fires", () => {
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML =
+        '<div id="a" style="background-color: rgb(255, 255, 255)"></div>'
+      const session = createSessionLifecycle()
+      const contentSession = createContentSession(SWATCHES.default, session)
+
+      contentSession.rescan()
+      vi.advanceTimersByTime(100)
+
+      expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(true)
+      const target = document.getElementById("a")
+      expect(target?.dataset.swPatched).toBe("rgb(255, 255, 255)")
+
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("a genuinely dark page (mean luminance low) restores native instead of tagging", () => {
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML =
+        '<div id="a" style="background-color: rgb(13, 17, 23)"></div>'
+      const session = createSessionLifecycle()
+      const contentSession = createContentSession(SWATCHES.default, session)
+
+      contentSession.rescan()
+      vi.advanceTimersByTime(100)
+
+      expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(false)
+      const target = document.getElementById("a")
+      expect(target?.dataset.swPatched).toBeUndefined()
+
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
@@ -67,8 +67,69 @@ describe("scan", () => {
   })
 })
 
-describe("createContentSession — coalescing (Definition 7.2)", () => {
-  it("a burst of N mutations within the debounce window triggers exactly one decide/realize cycle", () => {
+describe("createContentSession — rescan() is immediate, not coalesced", () => {
+  it("rescan() settles synchronously — no timer, no caller-visible delay", () => {
+    document.body.innerHTML =
+      '<div id="a" style="background-color: rgb(255, 255, 255)"></div>'
+    const session = createSessionLifecycle()
+    let fireCount = 0
+    const contentSession = createContentSession(
+      SWATCHES.default,
+      session,
+      () => {
+        fireCount += 1
+      }
+    )
+
+    contentSession.rescan()
+
+    expect(fireCount).toBe(1)
+    expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(true)
+    const target = document.getElementById("a")
+    expect(target?.dataset.swPatched).toBe("rgb(255, 255, 255)")
+
+    contentSession.teardown()
+  })
+
+  it("a genuinely dark page (mean luminance low) restores native instead of tagging, immediately", () => {
+    document.body.innerHTML =
+      '<div id="a" style="background-color: rgb(13, 17, 23)"></div>'
+    const session = createSessionLifecycle()
+    const contentSession = createContentSession(SWATCHES.default, session)
+
+    contentSession.rescan()
+
+    expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(false)
+    const target = document.getElementById("a")
+    expect(target?.dataset.swPatched).toBeUndefined()
+
+    contentSession.teardown()
+  })
+
+  it("repeated rescan() calls each settle immediately (N calls -> N fires)", () => {
+    document.body.innerHTML = '<div id="a"></div>'
+    const session = createSessionLifecycle()
+    let fireCount = 0
+    const contentSession = createContentSession(
+      SWATCHES.default,
+      session,
+      () => {
+        fireCount += 1
+      }
+    )
+
+    for (let i = 0; i < 5; i++) {
+      contentSession.rescan()
+    }
+
+    expect(fireCount).toBe(5)
+
+    contentSession.teardown()
+  })
+})
+
+describe("createContentSession — observer coalescing (Definition 7.2)", () => {
+  it("a burst of N real mutations within the debounce window triggers exactly one decide/realize cycle", async () => {
     vi.useFakeTimers()
     try {
       document.body.innerHTML = '<div id="a"></div>'
@@ -86,13 +147,18 @@ describe("createContentSession — coalescing (Definition 7.2)", () => {
       expect(target).not.toBeNull()
       if (target === null) return
 
-      // A burst of rescans well within the 50ms reconcile window.
+      contentSession.observe()
+
+      // A burst of real style mutations, well within the 50ms reconcile window.
       for (let i = 0; i < 10; i++) {
         target.style.backgroundColor = `rgb(${i}, ${i}, ${i})`
-        contentSession.rescan()
       }
+      // Flush the MutationObserver's own microtask-scheduled delivery --
+      // independent of (and not advanced by) the fake macrotask clock.
+      await Promise.resolve()
+      await Promise.resolve()
 
-      expect(fireCount).toBe(0) // nothing has fired yet — still coalescing
+      expect(fireCount).toBe(0) // ingested, but still coalescing -- no fire yet
 
       vi.advanceTimersByTime(100)
 
@@ -104,7 +170,7 @@ describe("createContentSession — coalescing (Definition 7.2)", () => {
     }
   })
 
-  it("two well-separated rescans (past the debounce window) fire twice", () => {
+  it("two well-separated mutations (past the debounce window) fire twice", async () => {
     vi.useFakeTimers()
     try {
       document.body.innerHTML = '<div id="a"></div>'
@@ -118,57 +184,21 @@ describe("createContentSession — coalescing (Definition 7.2)", () => {
         }
       )
 
-      contentSession.rescan()
+      const target = document.getElementById("a")
+      expect(target).not.toBeNull()
+      if (target === null) return
+
+      contentSession.observe()
+
+      target.style.backgroundColor = "rgb(1, 1, 1)"
+      await Promise.resolve()
       vi.advanceTimersByTime(100)
       expect(fireCount).toBe(1)
 
-      contentSession.rescan()
+      target.style.backgroundColor = "rgb(2, 2, 2)"
+      await Promise.resolve()
       vi.advanceTimersByTime(100)
       expect(fireCount).toBe(2)
-
-      contentSession.teardown()
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-})
-
-describe("createContentSession — end to end", () => {
-  it("a light page's div gets tagged and colored after the coalesced cycle fires", () => {
-    vi.useFakeTimers()
-    try {
-      document.body.innerHTML =
-        '<div id="a" style="background-color: rgb(255, 255, 255)"></div>'
-      const session = createSessionLifecycle()
-      const contentSession = createContentSession(SWATCHES.default, session)
-
-      contentSession.rescan()
-      vi.advanceTimersByTime(100)
-
-      expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(true)
-      const target = document.getElementById("a")
-      expect(target?.dataset.swPatched).toBe("rgb(255, 255, 255)")
-
-      contentSession.teardown()
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it("a genuinely dark page (mean luminance low) restores native instead of tagging", () => {
-    vi.useFakeTimers()
-    try {
-      document.body.innerHTML =
-        '<div id="a" style="background-color: rgb(13, 17, 23)"></div>'
-      const session = createSessionLifecycle()
-      const contentSession = createContentSession(SWATCHES.default, session)
-
-      contentSession.rescan()
-      vi.advanceTimersByTime(100)
-
-      expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(false)
-      const target = document.getElementById("a")
-      expect(target?.dataset.swPatched).toBeUndefined()
 
       contentSession.teardown()
     } finally {

--- a/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
@@ -65,6 +65,23 @@ describe("scan", () => {
     expect(elementsByKey.size).toBe(0)
     expect(attrsByKey.size).toBe(0)
   })
+
+  it("skips already-patched elements — their live color is the actuator's own output, not vendor evidence", () => {
+    // Once actuator.ts tags an element data-sw-patched and injects its
+    // !important hue-preserving rule, getComputedStyle on that element
+    // returns *our* darkened color forever after, never the vendor's
+    // original. Re-including it in the next scan feeds that self-inflicted
+    // color back into the (append-only, never-forgetting) hypothesis as if
+    // it were new evidence — the exact mechanism that let pageAlreadyDark()
+    // drift downward across repeated reactive rescans until it incorrectly
+    // concluded the page was already dark and restore-native undid the
+    // theme with no vendor change involved at all.
+    document.body.innerHTML =
+      '<div id="a" data-sw-patched="rgb(255, 255, 255)" style="background-color: rgb(13, 17, 23)"></div>'
+    const { elementsByKey, attrsByKey } = scan(document.body)
+    expect(elementsByKey.size).toBe(0)
+    expect(attrsByKey.size).toBe(0)
+  })
 })
 
 describe("createContentSession — rescan() is immediate, not coalesced", () => {
@@ -199,6 +216,53 @@ describe("createContentSession — observer coalescing (Definition 7.2)", () => 
       await Promise.resolve()
       vi.advanceTimersByTime(100)
       expect(fireCount).toBe(2)
+
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe("createContentSession — observer survives body replacement", () => {
+  it("keeps reacting to mutations after document.body is wholesale-replaced", async () => {
+    // A real SPA/hydration pattern (documentElement.replaceChild(newBody,
+    // document.body)), not just a churn-suite construction: observing the
+    // old body element directly would keep watching an orphaned, detached
+    // node forever once it's replaced -- nothing under the *new* body would
+    // ever be seen again, silently killing all future reclassification.
+    // Watching document.documentElement (never itself replaced by this
+    // pattern) and reading document.body live at fire time is what this
+    // test guards.
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML = '<div id="a"></div>'
+      const session = createSessionLifecycle()
+      let fireCount = 0
+      const contentSession = createContentSession(
+        SWATCHES.default,
+        session,
+        () => {
+          fireCount += 1
+        }
+      )
+
+      contentSession.observe()
+
+      const newBody = document.createElement("body")
+      newBody.innerHTML = '<div id="b"></div>'
+      document.documentElement.replaceChild(newBody, document.body)
+
+      const target = document.getElementById("b")
+      expect(target).not.toBeNull()
+      if (target === null) return
+
+      target.style.backgroundColor = "rgb(9, 9, 9)"
+      await Promise.resolve()
+      await Promise.resolve()
+      vi.advanceTimersByTime(100)
+
+      expect(fireCount).toBe(1)
 
       contentSession.teardown()
     } finally {

--- a/extensions/some-filter/src/adapter/__tests__/theme-adapter.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/theme-adapter.test.ts
@@ -59,9 +59,11 @@ describe("decide — purity", () => {
 })
 
 describe("decide — no bright surfaces", () => {
-  it("returns ∅ for an empty hypothesis", () => {
+  it("still activates the static theme layer for an empty hypothesis (no per-surface actions)", () => {
     const h = createHypothesis<SurfaceKey, SurfaceAttr>()
-    expect(decide(h, swatch)).toEqual([])
+    expect(decide(h, swatch)).toEqual([
+      { kind: "activate-theme", swatchId: swatch.id },
+    ])
   })
 
   it("emits no per-surface action for mid-luminance (untouched-band) evidence", () => {
@@ -88,6 +90,7 @@ describe("decide — mixed page", () => {
     const actions = decide(h, swatch)
 
     expect(actions).toEqual([
+      { kind: "activate-theme", swatchId: swatch.id },
       { kind: "tag-surface", key: "light", role: "surface" },
       {
         kind: "emit-surface-color",
@@ -101,7 +104,9 @@ describe("decide — mixed page", () => {
   it("skips near-transparent evidence regardless of luminance", () => {
     const h = createHypothesis<SurfaceKey, SurfaceAttr>()
     h.set("glass", attrFor("rgba(255, 255, 255, 0.05)", 0.05))
-    expect(decide(h, swatch)).toEqual([])
+    expect(decide(h, swatch)).toEqual([
+      { kind: "activate-theme", swatchId: swatch.id },
+    ])
   })
 })
 

--- a/extensions/some-filter/src/adapter/__tests__/theme-adapter.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/theme-adapter.test.ts
@@ -111,12 +111,14 @@ describe("decide — mixed page", () => {
 })
 
 describe("decide — page-level already-dark verdict", () => {
-  it("withholds every per-surface action and emits restore-native when the mean luminance reads dark", () => {
+  it("withholds every per-surface action and emits restore-native when the mean luminance reads dark (>= 3 evidenced keys)", () => {
     const h = createHypothesis<SurfaceKey, SurfaceAttr>()
     // Every evidenced key is near-black; classifyPage()'s reframe (detect())
-    // would call this page already dark.
+    // would call this page already dark. Three distinct keys, at/above
+    // MIN_EVIDENCE_FOR_DARK_VERDICT, so the verdict is actually trusted.
     h.set("a", attrFor("rgb(13, 17, 23)"))
     h.set("b", attrFor("rgb(5, 5, 5)"))
+    h.set("c", attrFor("rgb(10, 10, 10)"))
 
     expect(decide(h, swatch)).toEqual([{ kind: "restore-native" }])
   })
@@ -127,6 +129,26 @@ describe("decide — page-level already-dark verdict", () => {
 
     const actions = decide(h, swatch)
     expect(actions.some((a) => a.kind === "restore-native")).toBe(false)
+  })
+
+  it("does NOT emit restore-native from a sparse (< 3 keys) dark-reading sample, even if their mean is dark", () => {
+    // Guards against a real failure mode: a heavy client-rendered page can
+    // easily have only one or two dark chrome/skeleton elements evidenced
+    // early in hydration, well before its actual (light) body content has
+    // rendered. A reactive rescan firing on exactly that sparse a sample
+    // must not conclude "page is already dark" and strip the theme --
+    // restore-native's veil-drop is immediate and uncorrected once more
+    // (light) evidence later arrives. Two near-black keys alone -- below
+    // MIN_EVIDENCE_FOR_DARK_VERDICT -- must be treated as inconclusive, the
+    // same "insufficient evidence -> assume light" bias zero evidence
+    // already gets.
+    const h = createHypothesis<SurfaceKey, SurfaceAttr>()
+    h.set("a", attrFor("rgb(13, 17, 23)"))
+    h.set("b", attrFor("rgb(5, 5, 5)"))
+
+    const actions = decide(h, swatch)
+    expect(actions.some((a) => a.kind === "restore-native")).toBe(false)
+    expect(actions.some((a) => a.kind === "activate-theme")).toBe(true)
   })
 })
 

--- a/extensions/some-filter/src/adapter/actuator.ts
+++ b/extensions/some-filter/src/adapter/actuator.ts
@@ -1,0 +1,118 @@
+/**
+ * The Actuator — realizes S1/S3's `FilterAction`s against the DOM
+ * (Definition 7.3, canon §7; §8's `(ACT)` rule). S5 of the
+ * some-filter-on-transport epic (#685, #690).
+ *
+ * The *only* module that writes `data-sw-patched`, the dynamic per-surface
+ * color stylesheet, or (via `theme-apply.ts`'s exported primitives) the
+ * static dark-theme layer and `data-sw-dark`. Everything upstream —
+ * `pipeline.ts`'s Sensor/Estimator, `theme-adapter.ts`'s `decide` — only
+ * ever *describes* what should happen; this is where description becomes
+ * effect.
+ *
+ * Self-tagging (Definition 7.3, Remark 7.2): deliberately does *not* route
+ * through `@some-extension/transport/actuator/apply`'s generic
+ * `tag()`/self-tag-attribute wrapper. The structural exclusion Corollary
+ * 7.3.1 requires is already discharged the way canon §9.2 already
+ * describes for this extension — `[data-my-ext]` marks extension-owned
+ * subtrees (checked by the Sensor before an element is ever read, in
+ * `pipeline.ts`), and the Sensor's `MutationObserver` watches only
+ * `attributeFilter: ["class", "style"]`, so writing `data-sw-patched`,
+ * `data-sw-dark`, or the `<style>` elements' `textContent` can never
+ * itself re-trigger ingestion. Adding transport's generic ownership
+ * attributes on top would tag thousands of ordinary vendor elements with
+ * extension bookkeeping for no additional loop-suppression benefit.
+ *
+ * Idempotence (Theorem 7.2): every `realize` call rebuilds the dynamic
+ * stylesheet's *entire* content from the current action list (not an
+ * incremental append), so re-running the same actions twice is a no-op
+ * `style.textContent` assignment. Per-surface tagging never explicitly
+ * clears a stale attribute when an element's classification changes away
+ * from "surface"/"preserve" — this matches the pre-S5 patcher's own
+ * behavior exactly (`patchElement` never cleared either), not a new gap.
+ */
+
+import {
+  DARK_THEME_ATTR,
+  EXT_GUARD,
+  injectDarkTheme,
+  removeDarkTheme,
+  restoreVendor,
+} from "@filter/lib/content/theme-apply"
+
+import type { FilterAction, SurfaceKey } from "./contracts"
+import { getSwatch } from "./swatches"
+
+const DYNAMIC_STYLE_ID = "__sw_dark_dynamic"
+
+function dynamicStyleEl(): HTMLStyleElement {
+  const existing = document.getElementById(DYNAMIC_STYLE_ID)
+  if (existing instanceof HTMLStyleElement) return existing
+  const style = document.createElement("style")
+  style.id = DYNAMIC_STYLE_ID
+  document.head.appendChild(style)
+  return style
+}
+
+function clearPerSurfaceState(): void {
+  document.getElementById(DYNAMIC_STYLE_ID)?.remove()
+  document.querySelectorAll("[data-sw-patched]").forEach((el) => {
+    el.removeAttribute("data-sw-patched")
+  })
+}
+
+/**
+ * Realizes `actions` (S3's `Fin(A)`) against the DOM. `elementsByKey` is
+ * the current scan's `SurfaceKey -> elements` mapping (`pipeline.ts`) —
+ * `decide` only ever names a key, never a physical element, so the
+ * Actuator is where a key is resolved back to the carriers currently
+ * believed to share it.
+ */
+export function realize(
+  actions: ReadonlyArray<FilterAction>,
+  elementsByKey: ReadonlyMap<SurfaceKey, ReadonlyArray<Element>>
+): void {
+  const restoreNative = actions.some(
+    (action) => action.kind === "restore-native"
+  )
+  if (restoreNative) {
+    restoreVendor()
+    clearPerSurfaceState()
+    return
+  }
+
+  const activate = actions.find(
+    (action): action is Extract<typeof action, { kind: "activate-theme" }> =>
+      action.kind === "activate-theme"
+  )
+  if (activate !== undefined) {
+    document.documentElement.setAttribute(DARK_THEME_ATTR, "")
+    injectDarkTheme(getSwatch(activate.swatchId))
+  } else {
+    document.documentElement.removeAttribute(DARK_THEME_ATTR)
+    removeDarkTheme()
+  }
+
+  for (const action of actions) {
+    if (action.kind !== "tag-surface") continue
+    const value = action.role === "preserve" ? "preserve" : action.key
+    for (const el of elementsByKey.get(action.key) ?? []) {
+      if (el instanceof HTMLElement) {
+        el.dataset.swPatched = value
+      }
+    }
+  }
+
+  const colorRules = actions
+    .filter((action) => action.kind === "emit-surface-color")
+    .map(
+      (action) =>
+        `[data-sw-patched="${action.key}"]${EXT_GUARD}{background-color:${action.css}!important}`
+    )
+
+  if (colorRules.length > 0) {
+    dynamicStyleEl().textContent = colorRules.join("\n")
+  } else {
+    document.getElementById(DYNAMIC_STYLE_ID)?.remove()
+  }
+}

--- a/extensions/some-filter/src/adapter/contracts.ts
+++ b/extensions/some-filter/src/adapter/contracts.ts
@@ -107,7 +107,26 @@ export type RestoreNativeAction = {
   readonly kind: "restore-native"
 }
 
+/**
+ * The static-layer counterpart to `content.ts`'s unconditional
+ * `applyTheme("dark")` call (added in S5, #690, while wiring the real
+ * pipeline surfaced the gap): `activateDarkTheme()` sets `DARK_THEME_ATTR`
+ * and injects `buildDarkThemeCSS(swatch)` *regardless* of whether any
+ * per-surface evidence exists yet (the `transparent-page` e2e fixture — no
+ * element anywhere has an explicit background, so `Ĥ` is empty — still
+ * expects the static dark layer to activate). Emitted first, whenever a
+ * swatch is selected and the page does not already read as dark; the
+ * Actuator (S5) realizes it exactly once regardless of how many times
+ * `decide` re-emits it for an unchanged verdict (idempotent per Theorem
+ * 7.2, same as every other action here).
+ */
+export type ActivateThemeAction = {
+  readonly kind: "activate-theme"
+  readonly swatchId: string
+}
+
 export type FilterAction =
+  | ActivateThemeAction
   | TagSurfaceAction
   | EmitSurfaceColorAction
   | RestoreNativeAction

--- a/extensions/some-filter/src/adapter/pipeline.ts
+++ b/extensions/some-filter/src/adapter/pipeline.ts
@@ -1,0 +1,194 @@
+/**
+ * The content-session pipeline — Sensor → Estimator → Scheduler, seamed
+ * into the Adapter (`theme-adapter.ts`'s `decide`) and the Actuator
+ * (`actuator.ts`'s `realize`). S5 of the some-filter-on-transport epic
+ * (#685, #690): stands up `@some-extension/transport`'s stages in place of
+ * `theme-apply.ts`'s old hand-rolled `patchObserver`/`patchAll`.
+ *
+ * Sensor: `scan()` walks the subtree exactly where `patchAll` used to
+ * (skipping `[data-my-ext]` and the same media/script tags), reading each
+ * element's computed background via `color.ts` — the one place in this
+ * story that still calls `getComputedStyle` (Axiom D.1 scopes the DOM-free
+ * requirement to `decide`, not to sensing). A `MutationObserver` with the
+ * same `attributeFilter: ["class", "style"]` as before re-triggers it.
+ *
+ * Estimator: one `update()` per *distinct* observed key per scan (Ĥ is
+ * keyed by color, not by element — S1) using transport's own
+ * `estimator/hypothesis` + `estimator/update`. `tier` is always `"full"`
+ * (Definition 4.1): a background color is either read successfully in one
+ * step or not read at all — there is no partial/multi-step extraction here
+ * for `ξ` to stage.
+ *
+ * Scheduler: `RECONCILE_POLICY`/`BOUNDED_DELIVERY_MS` are Definition 7.2's
+ * `R`, declared once here (§8.3's conformance requirement) — a burst of N
+ * mutations inside the debounce window coalesces into exactly one
+ * `decide`/`realize` cycle.
+ */
+
+import { parseColor, relativeLuminance } from "@filter/lib/content/color"
+import { rgbaToCss } from "@filter/lib/content/modify-colors"
+import { invoke } from "@some-extension/transport/adapter/invoke"
+import { createHypothesis } from "@some-extension/transport/estimator/hypothesis"
+import {
+  createProvenanceStore,
+  update,
+  type ProvenanceStore,
+} from "@some-extension/transport/estimator/update"
+import {
+  createCoalescer,
+  type Coalescer,
+  type ReconcilePolicy,
+} from "@some-extension/transport/scheduler/reconcile"
+import type { SessionLifecycle } from "@some-extension/transport/session/lifecycle"
+
+import { realize } from "./actuator"
+import type { FilterAction, SurfaceAttr, SurfaceKey } from "./contracts"
+import type { Swatch } from "./swatches"
+import { decide } from "./theme-adapter"
+
+/** Definition 7.2's `R`, declared once (§8.3's conformance requirement). */
+export const RECONCILE_POLICY: ReconcilePolicy = { debounceMs: 50 }
+export const BOUNDED_DELIVERY_MS = 250
+
+const SKIP_TAGS = new Set([
+  "SCRIPT",
+  "STYLE",
+  "LINK",
+  "META",
+  "NOSCRIPT",
+  "IMG",
+  "VIDEO",
+  "CANVAS",
+  "AUDIO",
+  "PICTURE",
+  "EMBED",
+  "OBJECT",
+  "SVG",
+  "IFRAME",
+])
+
+function shouldSkip(el: Element): boolean {
+  if (SKIP_TAGS.has(el.tagName)) return true
+  if (el.id === "__sw_overlay_root") return true
+  if (el.hasAttribute("data-my-ext")) return true
+  if (el.closest("[data-my-ext]")) return true
+  return false
+}
+
+function readAttr(el: Element): SurfaceAttr | null {
+  const bg = getComputedStyle(el).backgroundColor
+  const c = parseColor(bg)
+  if (c === null) return null
+  return {
+    color: c,
+    luminance: relativeLuminance(c[0], c[1], c[2]),
+    opacity: c[3],
+  }
+}
+
+export type ScanResult = {
+  readonly elementsByKey: ReadonlyMap<SurfaceKey, ReadonlyArray<Element>>
+  readonly attrsByKey: ReadonlyMap<SurfaceKey, SurfaceAttr>
+}
+
+/** Walks `root`'s descendants (never `root` itself — matches `patchAll`'s old scope; `root`'s own canvas is the static layer's job). */
+export function scan(root: Element): ScanResult {
+  const elementsByKey = new Map<SurfaceKey, Array<Element>>()
+  const attrsByKey = new Map<SurfaceKey, SurfaceAttr>()
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+  let node: Node | null = walker.nextNode()
+
+  while (node !== null) {
+    if (node instanceof HTMLElement && !shouldSkip(node)) {
+      const attr = readAttr(node)
+      if (attr !== null) {
+        const key = rgbaToCss(attr.color)
+        const list = elementsByKey.get(key)
+        if (list !== undefined) {
+          list.push(node)
+        } else {
+          elementsByKey.set(key, [node])
+          attrsByKey.set(key, attr)
+        }
+      }
+    }
+    node = walker.nextNode()
+  }
+
+  return { elementsByKey, attrsByKey }
+}
+
+export type ContentSession = {
+  /** Full re-scan + one coalesced decide/realize cycle. Safe to call repeatedly — the SPA re-patch path (`yt-navigate-finish`) is just another call. */
+  rescan(root?: Element): void
+  /** Attaches the Sensor's MutationObserver over `root`. Idempotent. */
+  observe(root?: Element): void
+  /** Disconnects the observer and cancels any pending coalesced invocation. */
+  teardown(): void
+}
+
+export type OnFire = (actions: ReadonlyArray<FilterAction>) => void
+
+export function createContentSession(
+  swatch: Swatch | null,
+  session: SessionLifecycle,
+  onFire?: OnFire
+): ContentSession {
+  const hypothesis = createHypothesis<SurfaceKey, SurfaceAttr>()
+  const provenance: ProvenanceStore<SurfaceKey> = createProvenanceStore()
+  let lastScan: ScanResult = { elementsByKey: new Map(), attrsByKey: new Map() }
+  let observer: MutationObserver | null = null
+
+  function ingest(root: Element): void {
+    lastScan = scan(root)
+    const timestamp = Date.now()
+    for (const [key, attrs] of lastScan.attrsByKey) {
+      update(hypothesis, provenance, {
+        key,
+        attrs,
+        epoch: session.epoch,
+        tier: "full",
+        timestamp,
+      })
+    }
+  }
+
+  function fire(): void {
+    const actions = invoke(hypothesis, { decide: (h) => decide(h, swatch) })
+    realize(actions, lastScan.elementsByKey)
+    onFire?.(actions)
+  }
+
+  const coalescer: Coalescer = createCoalescer(RECONCILE_POLICY, fire)
+
+  return {
+    rescan(root: Element = document.body): void {
+      ingest(root)
+      coalescer.trigger()
+    },
+    observe(root: Element = document.body): void {
+      if (observer !== null) return
+      observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.type === "childList" || mutation.type === "attributes") {
+            ingest(root)
+            coalescer.trigger()
+            return
+          }
+        }
+      })
+      observer.observe(root, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["class", "style"],
+      })
+    },
+    teardown(): void {
+      observer?.disconnect()
+      observer = null
+      coalescer.dispose()
+    },
+  }
+}

--- a/extensions/some-filter/src/adapter/pipeline.ts
+++ b/extensions/some-filter/src/adapter/pipeline.ts
@@ -141,22 +141,46 @@ export function createContentSession(
   let observer: MutationObserver | null = null
 
   function ingest(root: Element): void {
-    lastScan = scan(root)
-    const timestamp = Date.now()
-    for (const [key, attrs] of lastScan.attrsByKey) {
-      update(hypothesis, provenance, {
-        key,
-        attrs,
-        epoch: session.epoch,
-        tier: "full",
-        timestamp,
-      })
+    try {
+      lastScan = scan(root)
+      const timestamp = Date.now()
+      for (const [key, attrs] of lastScan.attrsByKey) {
+        update(hypothesis, provenance, {
+          key,
+          attrs,
+          epoch: session.epoch,
+          tier: "full",
+          timestamp,
+        })
+      }
+    } catch (error) {
+      // Both call sites (rescan(), the MutationObserver callback) are
+      // synchronous and neither is itself wrapped by the caller — an
+      // uncaught throw here would abort whatever synchronous call chain
+      // invoked it (withPrepaintSuppressed() in content.ts included) before
+      // coalescer.trigger() below ever runs, silently holding the page
+      // under the veil forever with the failure visible nowhere. Still call
+      // trigger() on the partial/stale hypothesis so fire()'s own try/catch
+      // gets a chance to settle *something* rather than nothing at all.
+      // eslint-disable-next-line no-console
+      console.error("[some-filter] pipeline ingest() failed:", error)
     }
   }
 
   function fire(): void {
-    const actions = invoke(hypothesis, { decide: (h) => decide(h, swatch) })
-    realize(actions, lastScan.elementsByKey)
+    let actions: ReadonlyArray<FilterAction> = []
+    try {
+      actions = invoke(hypothesis, { decide: (h) => decide(h, swatch) })
+      realize(actions, lastScan.elementsByKey)
+    } catch (error) {
+      // onFire must run regardless — content.ts uses it to set the debug
+      // attrs a live-browser wait (or a e2e test) polls for and to resolve
+      // the veil (commitVisualState/disablePrepaint). A thrown decide/
+      // realize left this callback un-run entirely, holding the page under
+      // the veil forever with the failure visible nowhere but here.
+      // eslint-disable-next-line no-console
+      console.error("[some-filter] pipeline fire() failed:", error)
+    }
     onFire?.(actions)
   }
 

--- a/extensions/some-filter/src/adapter/pipeline.ts
+++ b/extensions/some-filter/src/adapter/pipeline.ts
@@ -188,8 +188,17 @@ export function createContentSession(
 
   return {
     rescan(root: Element = document.body): void {
+      // Immediate, not coalesced: rescan() is always an explicit,
+      // caller-initiated round (the initial classification, an SPA
+      // re-patch) — never a raw mutation-storm callback. Debouncing it
+      // would make the whole auto-theme path's very first visible outcome
+      // depend on a timer firing with no caller in a position to notice or
+      // recover if it doesn't (content.ts's veil-lift lives inside onFire).
+      // The coalescer is reserved for the one path Definition 7.2 actually
+      // governs: the observer callback below, where a burst of N raw
+      // mutations must still settle as exactly one decide/realize round.
       ingest(root)
-      coalescer.trigger()
+      fire()
     },
     observe(root: Element = document.body): void {
       if (observer !== null) return

--- a/extensions/some-filter/src/adapter/pipeline.ts
+++ b/extensions/some-filter/src/adapter/pipeline.ts
@@ -72,6 +72,25 @@ function shouldSkip(el: Element): boolean {
   if (el.id === "__sw_overlay_root") return true
   if (el.hasAttribute("data-my-ext")) return true
   if (el.closest("[data-my-ext]")) return true
+  // A "surface"-tagged element's live computed background is the
+  // actuator's own hue-preserving darkened output (actuator.ts's
+  // emit-surface-color rule targets it with !important, which always wins
+  // over the vendor's original inline/stylesheet value) — never the
+  // vendor's true color again, for as long as the tag stands. Reading it
+  // back in as fresh evidence is pure self-feedback: the hypothesis (which
+  // never forgets a key, by design — Ĥ is append-only) accumulates the
+  // extension's own dark output as if it were new vendor signal, and
+  // pageAlreadyDark()'s mean drifts down with every reactive rescan until
+  // it eventually crosses the threshold and decide() emits restore-native
+  // — the page "undoes its own theming" under nothing but its own churn,
+  // with no vendor change involved at all. Excluding tagged elements from
+  // classification breaks the loop at its source. (Elements tagged
+  // "preserve" get `revert`ed, not overridden, so their computed style
+  // already reflects the vendor's true color — but scan() has no cheap way
+  // to distinguish the two tag values here, and re-including "preserve"
+  // elements only forgoes reacting to a vendor recolor of an already
+  // near-black surface, a narrow loss next to the runaway alternative.)
+  if (el.hasAttribute("data-sw-patched")) return true
   return false
 }
 
@@ -122,8 +141,8 @@ export function scan(root: Element): ScanResult {
 export type ContentSession = {
   /** Full re-scan + one coalesced decide/realize cycle. Safe to call repeatedly — the SPA re-patch path (`yt-navigate-finish`) is just another call. */
   rescan(root?: Element): void
-  /** Attaches the Sensor's MutationObserver over `root`. Idempotent. */
-  observe(root?: Element): void
+  /** Attaches the Sensor's MutationObserver over `document.documentElement` (survives body/head replacement). Idempotent. */
+  observe(): void
   /** Disconnects the observer and cancels any pending coalesced invocation. */
   teardown(): void
 }
@@ -200,18 +219,30 @@ export function createContentSession(
       ingest(root)
       fire()
     },
-    observe(root: Element = document.body): void {
+    observe(): void {
       if (observer !== null) return
+      // Watches <html> (document.documentElement), not document.body: a
+      // vendor page can wholesale-replace body (and head) via
+      // documentElement.replaceChild — a real SPA/hydration pattern, not
+      // just a churn-suite construction — which detaches whatever node an
+      // observer had captured, silently killing all future reclassification
+      // (the observer keeps watching the orphaned old body forever; nothing
+      // under the new one is ever seen again). document.documentElement
+      // itself is never replaced by any of that — only its children are
+      // swapped — so it is the one structurally stable root to observe
+      // from. ingest() below re-reads `document.body` live at fire time
+      // (not a value captured here) for the same reason: after a body
+      // swap, `document.body` the getter already points at the new one.
       observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
           if (mutation.type === "childList" || mutation.type === "attributes") {
-            ingest(root)
+            ingest(document.body)
             coalescer.trigger()
             return
           }
         }
       })
-      observer.observe(root, {
+      observer.observe(document.documentElement, {
         childList: true,
         subtree: true,
         attributes: true,

--- a/extensions/some-filter/src/adapter/theme-adapter.ts
+++ b/extensions/some-filter/src/adapter/theme-adapter.ts
@@ -45,6 +45,23 @@ const OPACITY_SKIP_THRESHOLD = 0.1
 // Mirrors theme-detector.ts's classifyPage()/detect() default threshold.
 const PAGE_LUMINANCE_THRESHOLD = 0.4
 
+// Below this many evidenced keys, an unweighted mean is not a page-level
+// verdict — it is one or two elements' colors standing in for the whole
+// page. Real pages routinely render a handful of dark chrome/skeleton
+// elements (nav bars, loading placeholders) well before their actual (light)
+// body content hydrates; on a heavy client-rendered SPA that reloads itself
+// shortly after initial paint (an observed real-world pattern, exact
+// trigger unconfirmed), a reactive rescan can fire while evidence is this
+// sparse and conclude "page is already dark" from pure happenstance. That
+// verdict then emits restore-native, which strips the theme and — via
+// content.ts's onFire, applied=false takes the immediate disablePrepaint()
+// branch rather than the atomic commitVisualState() swap — drops the veil
+// right away, exposing the page's true (light) background with no further
+// correction once more evidence arrives. Below the threshold, the existing
+// "insufficient evidence -> assume light" bias (previously only count === 0)
+// just extends to "not enough evidence to trust either way."
+const MIN_EVIDENCE_FOR_DARK_VERDICT = 3
+
 /**
  * `detect()`'s `alreadyDark` verdict, folded into a pure predicate over Ĥ:
  * an unweighted mean luminance across every evidenced key, compared against
@@ -65,7 +82,7 @@ function pageAlreadyDark(
     count += 1
   }
 
-  if (count === 0) return false
+  if (count < MIN_EVIDENCE_FOR_DARK_VERDICT) return false
 
   const avgLuminance = total / count
   return avgLuminance <= PAGE_LUMINANCE_THRESHOLD

--- a/extensions/some-filter/src/adapter/theme-adapter.ts
+++ b/extensions/some-filter/src/adapter/theme-adapter.ts
@@ -21,6 +21,11 @@
  * weight; `classifyPage()`'s tiered/viewport-coverage weighting is what
  * decides *which* evidence lands in Ĥ and is therefore a Sensor concern,
  * S5's to supply, not this pure function's to re-derive from live DOM).
+ *
+ * `ActivateThemeAction` (S5, #690) is always the first action whenever a
+ * swatch is active and the page doesn't already read as dark — the static
+ * layer (`buildDarkThemeCSS`) is a page-wide binary switch, independent of
+ * whether any individual surface needs its own tag/emit action.
  */
 
 import {
@@ -83,7 +88,12 @@ export function decide(
     return [{ kind: "restore-native" }]
   }
 
-  const actions: Array<FilterAction> = []
+  // Static layer first, independent of per-surface evidence: a page with
+  // zero evidenced keys (nothing anywhere has an explicit background) still
+  // gets the dark canvas + text tokens (the transparent-page fixture).
+  const actions: Array<FilterAction> = [
+    { kind: "activate-theme", swatchId: swatch.id },
+  ]
 
   for (const key of hypothesis.keys()) {
     const attr = hypothesis.get(key)

--- a/extensions/some-filter/src/content/content.ts
+++ b/extensions/some-filter/src/content/content.ts
@@ -116,8 +116,10 @@ function runAutoTheme(): void {
   // not poison computed styles, so the Sensor's scan reads true vendor
   // colors with the veil still up. withPrepaintSuppressed freezes
   // transitions/animations around the *scan* only, so getComputedStyle
-  // reads settled values — the coalesced decide/realize cycle that follows
-  // does no further DOM reads.
+  // reads settled values. rescan() (below) settles decide/realize
+  // synchronously within this same call — no timer in the way of the
+  // initial verdict; only the MutationObserver's own burst-coalescing
+  // (pipeline.ts's observe()) is debounced.
   //
   // commitVisualState()/disablePrepaint() run on *every* fire, not just the
   // first: both are idempotent no-ops once the veil is already down, and

--- a/extensions/some-filter/src/content/content.ts
+++ b/extensions/some-filter/src/content/content.ts
@@ -1,4 +1,9 @@
 import {
+  createContentSession,
+  type ContentSession,
+} from "@filter/adapter/pipeline"
+import { DEFAULT_SWATCH_ID, SWATCHES } from "@filter/adapter/swatches"
+import {
   isExtensionMessage,
   isGetTabFilterStateResponse,
 } from "@filter/lib/content/guard"
@@ -8,17 +13,13 @@ import {
   enablePrepaint,
   withPrepaintSuppressed,
 } from "@filter/lib/content/prepaint"
-import {
-  applyTheme,
-  repatchPage,
-  restoreVendor,
-} from "@filter/lib/content/theme-apply"
-import { detect } from "@filter/lib/content/theme-detector"
+import { applyTheme, restoreVendor } from "@filter/lib/content/theme-apply"
 import { DEFAULT_TAB_STATE, nextTabState } from "@filter/lib/tab-state"
 import { ext } from "@filter/platform/content"
 import type { FilterConfig } from "@filter/types/config"
 import type { TabState } from "@filter/types/tab"
 import { assertNever } from "@some-extension/common"
+import { createSessionLifecycle } from "@some-extension/transport/session/lifecycle"
 
 const DEFAULT_FILTER: FilterConfig = {
   invert: 1,
@@ -60,16 +61,28 @@ let currentState: TabState = DEFAULT_TAB_STATE
 let filterConfig: FilterConfig = DEFAULT_FILTER
 let autoWasApplied = false
 
+// The content session's epoch source (Definition 5.4). Reset on every
+// SPA-navigation re-patch (Theorem D.1(a)) — a full page reset (refresh)
+// gets a fresh one for free, since this whole module re-initializes.
+const sessionLifecycle = createSessionLifecycle()
+let contentSession: ContentSession | null = null
+
 function applyState(state: TabState): void {
   currentState = state
   writeCachedState(state)
+
+  // Auto's pipeline owns its own MutationObserver — leaving auto (or
+  // re-entering it) must stop the previous one before anything else runs,
+  // or a stale session keeps reacting to mutations under the new mode.
+  contentSession?.teardown()
+  contentSession = null
 
   restoreVendor()
 
   if (state === "auto") {
     // Do not pre-remove the veil here. runAutoTheme uses withPrepaintSuppressed
-    // for snapshot isolation and handles veil teardown atomically after the
-    // theme is committed (or restored).
+    // for snapshot isolation; the pipeline's onFire hook handles veil teardown
+    // once the first decide/realize cycle actually settles.
     runAutoTheme()
     return
   }
@@ -92,43 +105,46 @@ function cycleState(): void {
 // ── Auto theming (apply-then-detect) ────────────────────────────────────────────
 
 function runAutoTheme(): void {
-  // Apply-then-detect. The dark theme is the default; the detector only takes
-  // it back off for pages that are already dark.
+  // Apply-then-detect, now folded into decide() (S3): the pipeline scans
+  // true vendor colors under the veil, feeds them to the Estimator, and
+  // decide() itself withholds every per-surface action (emitting only
+  // restore-native) when the page reads as already dark — the "apply
+  // unconditionally, then restore" two-step is gone; decide() settles it
+  // in one pure call.
   //
-  // Ordering note: our theme is injected with `!important`, so once it is in the
-  // cascade getComputedStyle no longer reports vendor colors. The detector must
-  // therefore snapshot the verdict from TRUE vendor styles first — which it can
-  // do safely because the overlay veil (unlike the old restyle-in-place
-  // prepaint) does not poison computed styles. We then apply the theme
-  // unconditionally (default-on) and restore vendor only when the verdict says
-  // the page was already dark.
+  // Ordering note: the veil (unlike the old restyle-in-place prepaint) does
+  // not poison computed styles, so the Sensor's scan reads true vendor
+  // colors with the veil still up. withPrepaintSuppressed freezes
+  // transitions/animations around the *scan* only, so getComputedStyle
+  // reads settled values — the coalesced decide/realize cycle that follows
+  // does no further DOM reads.
   //
-  // detect(), applyTheme(), and the optional restoreVendor() all run inside the
-  // same suppression lock so the initial patch reads settled, non-transition-
-  // interpolated colors and the veil teardown below is atomic.
-  const { alreadyDark, avgLuminance } = withPrepaintSuppressed(() => {
-    const verdict = detect()
-    applyTheme("dark")
-    if (verdict.alreadyDark) {
-      restoreVendor()
+  // commitVisualState()/disablePrepaint() run on *every* fire, not just the
+  // first: both are idempotent no-ops once the veil is already down, and
+  // re-running them unconditionally is what lets the SPA re-patch path
+  // (yt-navigate-finish re-shows the veil, below) reuse this same callback
+  // to lift it again, instead of needing its own copy of this logic.
+  contentSession = createContentSession(
+    SWATCHES[DEFAULT_SWATCH_ID],
+    sessionLifecycle,
+    (actions) => {
+      const applied = actions.some((action) => action.kind === "activate-theme")
+      autoWasApplied = applied
+      document.body.dataset.swThemeApplied = applied ? "dark" : "none"
+      updateDebugAttrs()
+
+      if (applied) {
+        commitVisualState()
+      } else {
+        disablePrepaint()
+      }
     }
-    return verdict
+  )
+
+  withPrepaintSuppressed(() => {
+    contentSession?.rescan()
   })
-
-  autoWasApplied = !alreadyDark
-
-  if (autoWasApplied) {
-    commitVisualState()
-  } else {
-    disablePrepaint()
-  }
-
-  document.body.dataset.swLuminance =
-    avgLuminance !== null ? avgLuminance.toFixed(3) : "unknown"
-
-  document.body.dataset.swThemeApplied = autoWasApplied ? "dark" : "none"
-
-  updateDebugAttrs()
+  contentSession.observe()
 }
 
 function updateDebugAttrs(): void {
@@ -183,22 +199,26 @@ function init(): void {
     }
   })()
 
-  // SPA navigation re-patch: re-run the luminance patcher after pushState
-  // navigations and YouTube's custom navigation event so newly rendered
-  // subtrees are themed even when no new DOM nodes are added.
+  // SPA navigation re-patch: re-scan after pushState navigations and
+  // YouTube's custom navigation event so newly rendered subtrees are
+  // themed even when no new DOM nodes trigger the Sensor's own observer
+  // (Theorem D.1(a) — same-document navigation, epoch advances). This is
+  // no longer a bespoke re-patch call: it is the same coalesced
+  // decide/realize cycle every other mutation goes through, re-triggered
+  // by hand for an event the Sensor's MutationObserver cannot see itself.
   // Note: third-party tab suspenders that replace the page with their own
   // origin URL are out-of-process and cannot be covered here; our re-
   // engagement on the real-URL reload is handled by the normal init path.
   //
-  // We re-enable the veil before repatching so there is no frame where
-  // newly rendered vendor elements are visible without the dark theme token.
-  // commitVisualState() lifts the veil after two rAFs — by which point the
-  // repatch tokens are already in the cascade.
+  // We re-enable the veil before rescanning so there is no frame where
+  // newly rendered vendor elements are visible without the dark theme
+  // token — the pipeline's onFire hook (above) lifts it again once this
+  // round settles.
   window.addEventListener("yt-navigate-finish", () => {
     if (autoWasApplied) {
+      sessionLifecycle.resetContent()
       enablePrepaint()
-      repatchPage()
-      commitVisualState()
+      contentSession?.rescan()
     }
   })
 }

--- a/extensions/some-filter/src/content/content.ts
+++ b/extensions/some-filter/src/content/content.ts
@@ -272,10 +272,25 @@ ext.runtime.onMessage.addListener((msg: unknown): void => {
 
 // ── Run ───────────────────────────────────────────────────────────────────────
 
+function bootInit(): void {
+  try {
+    init()
+  } catch (error) {
+    // A throw in init() (a transport factory failing, restoreVendor or
+    // withPrepaintSuppressed dying before the pipeline's onFire hook ever
+    // runs) otherwise leaves the veil up forever with the failure visible
+    // nowhere — the silent-hang class of bug that reads, from the outside, as
+    // "the extension loads but never processes." Surface it on the console so
+    // it is at least diagnosable rather than a mute stall.
+    // eslint-disable-next-line no-console
+    console.error("[some-filter] content init() threw:", error)
+  }
+}
+
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", init, { once: true })
+  document.addEventListener("DOMContentLoaded", bootInit, { once: true })
 } else {
-  init()
+  bootInit()
 }
 
 export {}

--- a/extensions/some-filter/src/lib/__tests__/tab-state.test.ts
+++ b/extensions/some-filter/src/lib/__tests__/tab-state.test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_TAB_STATE, nextTabState, STATE_CYCLE } from "../tab-state"
 
 describe("tab-state", () => {
   it("defaults to auto (themed-by-default)", () => {
-    expect(DEFAULT_TAB_STATE).toBe("legacy")
+    expect(DEFAULT_TAB_STATE).toBe("auto")
   })
 
   it("cycles legacy → auto → off → legacy", () => {

--- a/extensions/some-filter/src/lib/content/__tests__/color.test.ts
+++ b/extensions/some-filter/src/lib/content/__tests__/color.test.ts
@@ -52,6 +52,56 @@ describe("parseColor", () => {
     expect(c).not.toBeNull()
     expect(c![3]).toBeCloseTo(0.05)
   })
+
+  it("parses a 6-digit hex color (the swatch registry's own format)", () => {
+    const c = parseColor("#0d1117")
+    expect(c).not.toBeNull()
+    expect(c![0]).toBeCloseTo(0x0d / 255)
+    expect(c![1]).toBeCloseTo(0x11 / 255)
+    expect(c![2]).toBeCloseTo(0x17 / 255)
+    expect(c![3]).toBe(1)
+  })
+
+  it("parses a 6-digit hex color case-insensitively", () => {
+    expect(parseColor("#0D1117")).toEqual(parseColor("#0d1117"))
+  })
+
+  it("parses a 3-digit shorthand hex color", () => {
+    const c = parseColor("#fff")
+    expect(c).not.toBeNull()
+    expect(c![0]).toBeCloseTo(1)
+    expect(c![1]).toBeCloseTo(1)
+    expect(c![2]).toBeCloseTo(1)
+    expect(c![3]).toBe(1)
+  })
+
+  it("parses an 8-digit hex color with alpha", () => {
+    const c = parseColor("#ffffff80")
+    expect(c).not.toBeNull()
+    expect(c![3]).toBeCloseTo(0x80 / 255, 2)
+  })
+
+  it("parses a 4-digit shorthand hex color with alpha", () => {
+    const c = parseColor("#ffff")
+    expect(c).not.toBeNull()
+    expect(c![3]).toBeCloseTo(1)
+  })
+
+  it("returns null for hex alpha below the 0.05 floor", () => {
+    expect(parseColor("#ffffff05")).toBeNull()
+  })
+
+  it("returns null for a malformed hex string", () => {
+    expect(parseColor("#zzz")).toBeNull()
+    expect(parseColor("#12345")).toBeNull()
+  })
+
+  it("every SWATCHES bg0 hex value parses to the same rgb it renders as", async () => {
+    const { SWATCHES } = await import("../../../adapter/swatches")
+    for (const swatch of Object.values(SWATCHES)) {
+      expect(parseColor(swatch.bg0)).not.toBeNull()
+    }
+  })
 })
 
 describe("relativeLuminance", () => {

--- a/extensions/some-filter/src/lib/content/__tests__/prepaint.test.ts
+++ b/extensions/some-filter/src/lib/content/__tests__/prepaint.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   commitVisualState,
@@ -93,6 +93,55 @@ describe("commitVisualState", () => {
     // vitest.setup.ts stubs rAF to execute synchronously,
     // so both nested rAFs fire immediately.
     expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+  })
+
+  it("removes the veil via the timer fallback when rAF never fires", () => {
+    // rAF is paused in occluded/background tabs. Simulate that by making it a
+    // no-op so only the setTimeout fallback can lift the veil.
+    vi.useFakeTimers()
+    const rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation(() => 0)
+    try {
+      enablePrepaint()
+      commitVisualState()
+
+      // rAF stubbed out — the veil is still up until the timer fires.
+      expect(document.getElementById(PREPAINT_VEIL_ID)).not.toBeNull()
+
+      vi.advanceTimersByTime(200)
+
+      expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+    } finally {
+      rafSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("tears the veil down exactly once — a stale fallback timer is a no-op", () => {
+    // Under fake timers rAF is modeled as firing at ~16ms frames while the
+    // fallback timer is at 100ms, so advancing 50ms fires the rAF pair (which
+    // lifts the veil) but leaves the fallback timer still pending. The
+    // `dropped` guard must keep that stale timer from tearing down a *later*
+    // veil once it eventually fires.
+    vi.useFakeTimers()
+    try {
+      enablePrepaint()
+      commitVisualState()
+
+      vi.advanceTimersByTime(50)
+      // rAF pair has lifted the veil; the 100ms fallback is still pending.
+      expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+
+      // A fresh veil goes up before the stale fallback fires.
+      enablePrepaint()
+      vi.advanceTimersByTime(100)
+
+      // The stale timer's drop() was guarded — the new veil survives.
+      expect(document.getElementById(PREPAINT_VEIL_ID)).not.toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/extensions/some-filter/src/lib/content/__tests__/theme-apply.test.ts
+++ b/extensions/some-filter/src/lib/content/__tests__/theme-apply.test.ts
@@ -1,51 +1,19 @@
 import { afterEach, describe, expect, it } from "vitest"
 
-import { parseColor, relativeLuminance } from "../color"
 import {
   applyTheme,
   DARK_THEME_ATTR,
   injectDarkTheme,
   removeDarkTheme,
-  repatchPage,
   restoreVendor,
 } from "../theme-apply"
 
 const STYLE_ID = "__sw_dark_theme"
-const DYNAMIC_STYLE_ID = "__sw_dark_dynamic"
 const LEGACY_STYLE_ID = "__sw_legacy_filter"
 
 afterEach(() => {
   restoreVendor()
 })
-
-/** Read the generated background-color a patcher token maps to, or null. */
-function colorForToken(token: string): string | null {
-  const text = document.getElementById(DYNAMIC_STYLE_ID)?.textContent ?? ""
-  const m = text.match(
-    new RegExp(
-      `\\[data-sw-patched="${token}"\\][^{]*\\{background-color:([^!]+)!important`
-    )
-  )
-  return m?.[1]?.trim() ?? null
-}
-
-function luminanceForToken(token: string): number {
-  const css = colorForToken(token)
-  expect(css).not.toBeNull()
-
-  if (typeof css !== "string") {
-    throw new Error("CSS color string not found")
-  }
-
-  const c = parseColor(css)
-  expect(c).not.toBeNull()
-
-  if (!c) {
-    throw new Error("Failed to parse color")
-  }
-
-  return relativeLuminance(c[0], c[1], c[2])
-}
 
 describe("DARK_THEME_ATTR", () => {
   it("is the expected attribute name", () => {
@@ -68,170 +36,29 @@ describe("injectDarkTheme", () => {
     expect(document.querySelectorAll(`#${STYLE_ID}`)).toHaveLength(1)
   })
 
-  it("tags a light background with a token mapped to a dark, hue-preserving color", () => {
+  it("does not write data-sw-patched anywhere — that is the actuator's job now", () => {
     const div = document.createElement("div")
     div.style.backgroundColor = "rgb(255, 255, 255)"
     document.body.appendChild(div)
 
     injectDarkTheme()
 
-    const token = div.dataset.swPatched
-    expect(token).toMatch(/^c\d+$/)
-
-    if (typeof token === "string") {
-      expect(luminanceForToken(token)).toBeLessThan(0.3)
-    }
-  })
-
-  it("preserves hue when darkening a colored surface", () => {
-    // A light-blue panel should become a dark *blue* surface, not grey.
-    const div = document.createElement("div")
-    div.style.backgroundColor = "rgb(200, 220, 255)" // light blue
-    document.body.appendChild(div)
-
-    injectDarkTheme()
-
-    const token = div.dataset.swPatched
-    if (typeof token === "string") {
-      const css = colorForToken(token)
-      if (typeof css === "string") {
-        const c = parseColor(css)
-        expect(c).not.toBeNull()
-        if (c) {
-          // blue channel dominant → hue preserved
-          expect(c[2]).toBeGreaterThan(c[0])
-          expect(c[2]).toBeGreaterThan(c[1])
-        }
-      }
-    }
-  })
-
-  it("uses one token for repeated identical backgrounds", () => {
-    const a = document.createElement("div")
-    const b = document.createElement("div")
-    a.style.backgroundColor = "rgb(255, 255, 255)"
-    b.style.backgroundColor = "rgb(255, 255, 255)"
-    document.body.append(a, b)
-
-    injectDarkTheme()
-
-    expect(a.dataset.swPatched).toBe(b.dataset.swPatched)
-  })
-
-  it("tags near-black elements as 'preserve' (lum < 0.06)", () => {
-    const div = document.createElement("div")
-    div.style.backgroundColor = "rgb(30, 30, 30)"
-    document.body.appendChild(div)
-
-    injectDarkTheme()
-
-    expect(div.dataset.swPatched).toBe("preserve")
-  })
-
-  it("does not patch elements with near-transparent backgrounds (alpha < 0.1)", () => {
-    const div = document.createElement("div")
-    div.style.backgroundColor = "rgba(255, 255, 255, 0.08)"
-    document.body.appendChild(div)
-
-    injectDarkTheme()
-
     expect(div.dataset.swPatched).toBeUndefined()
-  })
-
-  it("does not patch elements owned by the extension (data-my-ext)", () => {
-    const div = document.createElement("div")
-    div.setAttribute("data-my-ext", "")
-    div.style.backgroundColor = "rgb(255, 255, 255)"
-    document.body.appendChild(div)
-
-    injectDarkTheme()
-
-    expect(div.dataset.swPatched).toBeUndefined()
-  })
-
-  it("does not patch descendants of extension-owned nodes", () => {
-    const parent = document.createElement("div")
-    parent.setAttribute("data-my-ext", "")
-    const child = document.createElement("div")
-    child.style.backgroundColor = "rgb(255, 255, 255)"
-    parent.appendChild(child)
-    document.body.appendChild(parent)
-
-    injectDarkTheme()
-
-    expect(child.dataset.swPatched).toBeUndefined()
-  })
-
-  it("skips SCRIPT and STYLE tags", () => {
-    const style = document.createElement("style")
-    style.textContent = "body { color: red }"
-    document.head.appendChild(style)
-
-    injectDarkTheme()
-
-    expect(style.dataset.swPatched).toBeUndefined()
-  })
-
-  it("skips IMG and VIDEO tags", () => {
-    const img = document.createElement("img")
-    const video = document.createElement("video")
-    document.body.append(img, video)
-
-    injectDarkTheme()
-
-    expect(img.dataset.swPatched).toBeUndefined()
-    expect(video.dataset.swPatched).toBeUndefined()
   })
 })
 
 describe("removeDarkTheme", () => {
-  it("removes the base and dynamic style elements", () => {
-    const div = document.createElement("div")
-    div.style.backgroundColor = "rgb(255, 255, 255)"
-    document.body.appendChild(div)
+  it("removes the base style element", () => {
     injectDarkTheme()
     expect(document.getElementById(STYLE_ID)).not.toBeNull()
-    expect(document.getElementById(DYNAMIC_STYLE_ID)).not.toBeNull()
 
     removeDarkTheme()
 
     expect(document.getElementById(STYLE_ID)).toBeNull()
-    expect(document.getElementById(DYNAMIC_STYLE_ID)).toBeNull()
-  })
-
-  it("clears all data-sw-patched attributes", () => {
-    const div = document.createElement("div")
-    div.style.backgroundColor = "rgb(255, 255, 255)"
-    document.body.appendChild(div)
-    injectDarkTheme()
-    expect(div.dataset.swPatched).toBeDefined()
-
-    removeDarkTheme()
-
-    expect(div.dataset.swPatched).toBeUndefined()
-    expect(document.querySelectorAll("[data-sw-patched]")).toHaveLength(0)
   })
 
   it("is safe to call when no theme has been injected", () => {
     expect(() => removeDarkTheme()).not.toThrow()
-  })
-})
-
-describe("repatchPage", () => {
-  it("tags elements that gained a background after initial injection", () => {
-    const div = document.createElement("div")
-    document.body.appendChild(div)
-    injectDarkTheme()
-    expect(div.dataset.swPatched).toBeUndefined() // no bg yet
-
-    div.style.backgroundColor = "rgb(255, 255, 255)"
-    repatchPage()
-
-    const token = div.dataset.swPatched
-    expect(token).toMatch(/^c\d+$/)
-    if (typeof token === "string") {
-      expect(luminanceForToken(token)).toBeLessThan(0.3)
-    }
   })
 })
 
@@ -275,18 +102,13 @@ describe("applyTheme", () => {
 })
 
 describe("restoreVendor", () => {
-  it("removes dark theme (attr + styles + patched attrs)", () => {
-    const div = document.createElement("div")
-    div.style.backgroundColor = "rgb(255, 255, 255)"
-    document.body.appendChild(div)
+  it("removes dark theme (attr + style)", () => {
     applyTheme("dark")
 
     restoreVendor()
 
     expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(false)
     expect(document.getElementById(STYLE_ID)).toBeNull()
-    expect(document.getElementById(DYNAMIC_STYLE_ID)).toBeNull()
-    expect(document.querySelectorAll("[data-sw-patched]")).toHaveLength(0)
   })
 
   it("removes the legacy filter style", () => {
@@ -302,20 +124,13 @@ describe("restoreVendor", () => {
     expect(() => restoreVendor()).not.toThrow()
   })
 
-  it("leaves vendor DOM byte-identical after apply + restore", () => {
-    // #236 invariant: the patcher is attribute-only, so apply + restore must
-    // leave the vendor subtree exactly as it was (no inline-style clobbering,
-    // no leftover data-sw-patched attrs).
+  it("never writes inline styles or data-sw-patched — this module only ever touches its own style elements and DARK_THEME_ATTR", () => {
     document.body.innerHTML =
       '<div style="background-color: rgb(255, 255, 255)">' +
       '<p style="background-color: rgb(200, 200, 200)">hi</p></div>'
     const before = document.body.innerHTML
 
     applyTheme("dark")
-    expect(
-      document.querySelectorAll("[data-sw-patched]").length
-    ).toBeGreaterThan(0)
-
     restoreVendor()
 
     expect(document.body.innerHTML).toBe(before)

--- a/extensions/some-filter/src/lib/content/color.ts
+++ b/extensions/some-filter/src/lib/content/color.ts
@@ -10,6 +10,55 @@
 export type RGBA = [number, number, number, number]
 
 /**
+ * Parses #rgb/#rgba/#rrggbb/#rrggbbaa. getComputedStyle never returns this
+ * format (browsers always normalize to rgb()/rgba()), but the swatch
+ * registry (swatches.ts) stores its canonical colors as hex literals, and
+ * anything comparing a computed style against a swatch color needs both
+ * forms to parse to the same representation.
+ */
+function parseHexColor(css: string): RGBA | null {
+  const match = css.match(
+    /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+  )
+  if (match === null) {
+    return null
+  }
+
+  const hex = match[1]
+  if (hex === undefined) {
+    return null
+  }
+
+  // charAt() always returns `string` (empty string past the end), unlike
+  // indexed access, which is `string | undefined` under
+  // noUncheckedIndexedAccess — avoids a run of non-null assertions here.
+  const expand = (short: string): string => short + short
+  const isShort = hex.length === 3 || hex.length === 4
+  const rHex = isShort ? expand(hex.charAt(0)) : hex.slice(0, 2)
+  const gHex = isShort ? expand(hex.charAt(1)) : hex.slice(2, 4)
+  const bHex = isShort ? expand(hex.charAt(2)) : hex.slice(4, 6)
+  const aHex =
+    hex.length === 4
+      ? expand(hex.charAt(3))
+      : hex.length === 8
+        ? hex.slice(6, 8)
+        : undefined
+
+  const a = aHex === undefined ? 1 : Number.parseInt(aHex, 16) / 255
+
+  if (a < 0.05) {
+    return null
+  }
+
+  return [
+    Number.parseInt(rHex, 16) / 255,
+    Number.parseInt(gHex, 16) / 255,
+    Number.parseInt(bHex, 16) / 255,
+    a,
+  ]
+}
+
+/**
  * Parse any CSS color string to [r, g, b, a] in 0–1 range.
  * Returns null for unparseable values.
  */
@@ -21,6 +70,10 @@ export function parseColor(css: string): RGBA | null {
     css === "rgba(0, 0, 0, 0)"
   ) {
     return null
+  }
+
+  if (css.startsWith("#")) {
+    return parseHexColor(css)
   }
 
   const match = css.match(

--- a/extensions/some-filter/src/lib/content/prepaint.ts
+++ b/extensions/some-filter/src/lib/content/prepaint.ts
@@ -128,11 +128,27 @@ export function withPrepaintSuppressed<T>(fn: () => T): T {
   the veil is lifted, the dark CSS is already in the cascade and there is no
   intermediate native-substrate frame. Two rAFs ensure the theme has painted at
   least once under the veil before it is removed (atomic swap).
+
+  Timer fallback: requestAnimationFrame is paused entirely in tabs the browser
+  considers non-foreground (a page loaded in a background tab, or — in headed
+  automation — a page that is occluded by another). Relying on rAF alone leaves
+  the veil up indefinitely in exactly those cases, stranding the page under a
+  dark cover forever. setTimeout continues to fire (throttled) in occluded tabs,
+  so it guarantees teardown. Whichever fires first wins; `dropped` makes the
+  loser a no-op so the veil is never torn down twice. On a visible tab the rAF
+  pair resolves in ~1 frame, well before the timer, preserving the atomic swap.
 */
+const COMMIT_FALLBACK_MS = 100
+
 export function commitVisualState(): void {
+  let dropped = false
+  const drop = (): void => {
+    if (dropped) return
+    dropped = true
+    disablePrepaint()
+  }
   requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      disablePrepaint()
-    })
+    requestAnimationFrame(drop)
   })
+  setTimeout(drop, COMMIT_FALLBACK_MS)
 }

--- a/extensions/some-filter/src/lib/content/theme-apply.ts
+++ b/extensions/some-filter/src/lib/content/theme-apply.ts
@@ -1,24 +1,25 @@
 /**
- * Theme applier — owns every DOM write involved in theming a page.
- *
- * Two strategies live here behind one surface:
- *   - dark theme: a static CSS layer (buildDarkThemeCSS) plus a JS luminance
- *     patcher (patchAll + MutationObserver) that tags vendor backgrounds.
+ * Theme applier — the static half of theming a page (S5, #690, split this
+ * module in two). Owns exactly:
+ *   - dark theme: the static CSS layer (buildDarkThemeCSS), a page-wide
+ *     binary switch (data-sw-dark + the token stylesheet), realized by
+ *     `src/adapter/actuator.ts`'s `activate-theme`/`restore-native` actions.
  *   - legacy filter: a single global root `filter: invert(...)` rule.
+ *     Untouched by S5 — no transport concept maps onto it yet.
+ *
+ * The per-element JS luminance patcher (classifyElement, colorTokens,
+ * patchAll, the MutationObserver) that used to live here has moved: its
+ * classification math is `adapter/theme-adapter.ts`'s `decide` (S3, pure,
+ * no DOM), its DOM writes are `adapter/actuator.ts` (S5, the *only* module
+ * that writes `data-sw-patched` now), and its sensing is
+ * `adapter/pipeline.ts` (S5, the Sensor + Estimator + Scheduler wiring).
+ * This module never writes `data-sw-patched` or the dynamic-color
+ * stylesheet — only the attribute and stylesheet the static layer owns.
  *
  * Public surface:
- *   - applyTheme(mode, config?) — apply the dark theme or the legacy filter.
- *   - restoreVendor()           — remove all theming, returning to native styles.
- * The granular dark-theme exports (injectDarkTheme/removeDarkTheme/repatchPage)
- * are retained for the SPA re-patch path and unit tests.
- *
- * Part A — CSS layer (static rules):
- *   Scoped to body (and html) with :not([data-my-ext]) / :not([data-my-ext] *)
- *   guards on rules that could bleed into extension-owned subtrees.
- *
- * Part B — JS luminance patcher (dynamic):
- *   Walks document.body, skips [data-my-ext] nodes and their descendants via
- *   shouldSkip(). Vendor DOM is left in place; extension nodes self-exclude.
+ *   - applyTheme(mode, config?, swatch?) — apply the dark theme or the legacy filter.
+ *   - restoreVendor()                    — remove all theming, returning to native styles.
+ * injectDarkTheme/removeDarkTheme are retained for the actuator and unit tests.
  */
 
 import {
@@ -28,8 +29,6 @@ import {
 } from "@filter/adapter/swatches"
 import type { FilterConfig } from "@filter/types/config"
 
-import { parseColor, relativeLuminance } from "./color"
-import { modifyBackgroundColor, rgbaToCss } from "./modify-colors"
 import { commitVisualState } from "./prepaint"
 
 export const DARK_THEME_ATTR = "data-sw-dark"
@@ -69,7 +68,8 @@ function swatchTokens(swatch: Swatch): string {
 // Guard: never apply theme rules inside extension-owned subtrees.
 // :not([data-my-ext] *)  — excludes descendants of marked nodes
 // :not([data-my-ext])    — excludes the marked node itself
-const EXT_GUARD = ":not([data-my-ext]):not([data-my-ext] *)"
+// Exported so adapter/actuator.ts's dynamic per-surface rules use the same guard.
+export const EXT_GUARD = ":not([data-my-ext]):not([data-my-ext] *)"
 
 export function buildDarkThemeCSS(
   swatch: Swatch = SWATCHES[DEFAULT_SWATCH_ID]
@@ -196,11 +196,12 @@ body${EXT_GUARD} {
   fill: var(--sw-text-1) !important;
 }
 
-/* ── JS luminance patcher targets ───────────────────────────────────────── */
+/* ── Actuator targets (adapter/actuator.ts) ────────────────────────────── */
 
-/* Light backgrounds are tagged with a generated token (c0, c1, …) whose
-   hue-preserving dark color is emitted into the dynamic stylesheet by the
-   patcher (see tokenForBackground). Near-black backgrounds are preserved. */
+/* Light backgrounds are tagged with their own canonical color as the
+   attribute value; the matching hue-preserving dark rule is appended to a
+   separate dynamic stylesheet by the actuator's emit-surface-color action.
+   Near-black backgrounds are tagged "preserve" and revert here. */
 
 [data-sw-patched="preserve"]${EXT_GUARD} {
   background-color: revert !important;
@@ -209,160 +210,13 @@ body${EXT_GUARD} {
 `
 }
 
-// ── JS luminance patcher ──────────────────────────────────────────────────────
-
-const LIGHT_THRESHOLD = 0.3
-
-// ── Dynamic per-element color registry ──────────────────────────────────────────
-// Light backgrounds get a hue-preserving dark color computed via modify-colors.
-// To keep the patcher attribute-only (so restoreVendor is byte-identical — no
-// inline-style clobbering of vendor nodes), each distinct modified color is
-// assigned a token and a matching `[data-sw-patched="<token>"]` rule is appended
-// to a dynamic stylesheet. Elements only ever receive a data attribute.
-
-const DYNAMIC_STYLE_ID = "__sw_dark_dynamic"
-const colorTokens = new Map<string, string>()
-let colorTokenSeq = 0
-
-function dynamicStyleEl(): HTMLStyleElement {
-  const existing = document.getElementById(DYNAMIC_STYLE_ID)
-  if (existing instanceof HTMLStyleElement) return existing
-  const style = document.createElement("style")
-  style.id = DYNAMIC_STYLE_ID
-  document.head.appendChild(style)
-  return style
-}
-
-function tokenForBackground(modifiedCss: string): string {
-  const cached = colorTokens.get(modifiedCss)
-  if (cached !== undefined) return cached
-
-  const token = `c${colorTokenSeq++}`
-  colorTokens.set(modifiedCss, token)
-  dynamicStyleEl().textContent += `[data-sw-patched="${token}"]${EXT_GUARD}{background-color:${modifiedCss}!important}\n`
-  return token
-}
-
-function clearDynamicColors(): void {
-  document.getElementById(DYNAMIC_STYLE_ID)?.remove()
-  colorTokens.clear()
-  colorTokenSeq = 0
-}
-
-function classifyElement(el: Element): string | null {
-  const bg = getComputedStyle(el).backgroundColor
-  const c = parseColor(bg)
-
-  if (!c) return null
-
-  // Near-transparent elements are glass layers over the dark body canvas.
-  // Tagging them would revert/repaint their background once the transition or
-  // opacity settles, permanently leaking white.
-  if (c[3] < 0.1) return null
-
-  const lum = relativeLuminance(c[0], c[1], c[2])
-
-  if (lum > LIGHT_THRESHOLD) {
-    // Hue-preserving dark surface instead of a flat grey bucket.
-    return tokenForBackground(rgbaToCss(modifyBackgroundColor(c)))
-  }
-
-  if (lum < 0.06) return "preserve"
-
-  return null
-}
-
-const SKIP_TAGS = new Set([
-  "SCRIPT",
-  "STYLE",
-  "LINK",
-  "META",
-  "NOSCRIPT",
-  "IMG",
-  "VIDEO",
-  "CANVAS",
-  "AUDIO",
-  "PICTURE",
-  "EMBED",
-  "OBJECT",
-  "SVG",
-  "IFRAME",
-])
-
-function shouldSkip(el: Element): boolean {
-  if (SKIP_TAGS.has(el.tagName)) return true
-  if (el.id === "__sw_overlay_root") return true
-  // Skip extension-owned nodes and their descendants.
-  // The attribute check on el covers the root; the closest() check covers
-  // descendants that don't carry the attr themselves.
-  if (el.hasAttribute("data-my-ext")) return true
-  if (el.closest("[data-my-ext]")) return true
-  return false
-}
-
-function patchElement(el: Element): void {
-  if (!(el instanceof HTMLElement)) return
-  if (shouldSkip(el)) return
-
-  const token = classifyElement(el)
-  if (token !== null) {
-    el.dataset.swPatched = token
-  }
-}
-
-function patchAll(root: Element): void {
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
-  let node: Node | null = walker.nextNode()
-  while (node !== null) {
-    if (node instanceof Element) {
-      patchElement(node)
-    }
-    node = walker.nextNode()
-  }
-}
-
-let patchObserver: MutationObserver | null = null
-
-function startPatchObserver(root: Element): void {
-  if (patchObserver) return
-
-  patchObserver = new MutationObserver((mutations) => {
-    for (const mutation of mutations) {
-      if (mutation.type === "childList") {
-        for (const node of mutation.addedNodes) {
-          if (node instanceof Element) {
-            patchElement(node)
-            patchAll(node)
-          }
-        }
-      } else if (mutation.type === "attributes") {
-        // Re-evaluate when class/style changes — the element's background
-        // may have changed during SPA re-renders or dynamic theming.
-        if (mutation.target instanceof Element) {
-          patchElement(mutation.target)
-        }
-      }
-    }
-  })
-
-  patchObserver.observe(root, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ["class", "style"],
-  })
-}
-
-function stopPatchObserver(): void {
-  patchObserver?.disconnect()
-  patchObserver = null
-}
-
-// ── Dark theme injection ────────────────────────────────────────────────────────
+// ── Dark theme injection (static layer only) ───────────────────────────────────
 
 const STYLE_ID = "__sw_dark_theme"
 
-export function injectDarkTheme(): void {
+export function injectDarkTheme(
+  swatch: Swatch = SWATCHES[DEFAULT_SWATCH_ID]
+): void {
   const existing = document.getElementById(STYLE_ID)
   const style: HTMLStyleElement =
     existing instanceof HTMLStyleElement
@@ -372,34 +226,17 @@ export function injectDarkTheme(): void {
     style.id = STYLE_ID
     document.head.appendChild(style)
   }
-  style.textContent = buildDarkThemeCSS()
-
-  // Walk from body — patcher already skips [data-my-ext] nodes.
-  patchAll(document.body)
-  startPatchObserver(document.body)
-  // Veil removal is the caller's responsibility: inject theme first,
-  // then call commitVisualState() so the dark CSS is in the cascade
-  // before the veil's invert filter is lifted (atomic swap, F1).
+  style.textContent = buildDarkThemeCSS(swatch)
+  // Per-surface tagging and the dynamic color stylesheet are the actuator's
+  // job now (adapter/actuator.ts), driven by decide()'s returned actions —
+  // not this function's. Veil removal is the caller's responsibility: inject
+  // theme first, then call commitVisualState() so the dark CSS is in the
+  // cascade before the veil is lifted (atomic swap, F1).
 }
 
 export function removeDarkTheme(): void {
   document.getElementById(STYLE_ID)?.remove()
-  clearDynamicColors()
-  stopPatchObserver()
-
-  document.querySelectorAll("[data-sw-patched]").forEach((el) => {
-    el.removeAttribute("data-sw-patched")
-  })
   // Veil removal is the caller's responsibility.
-}
-
-/**
- * Re-run the luminance patcher over the full document body.
- * Used after SPA navigation (e.g. YouTube pushState swaps) to catch
- * subtrees that were re-rendered without being re-added via childList.
- */
-export function repatchPage(): void {
-  patchAll(document.body)
 }
 
 // ── Legacy filter ─────────────────────────────────────────────────────────────
@@ -457,9 +294,9 @@ function removeLegacyFilter(): void {
 
 // ── Dark theme activation (internal) ────────────────────────────────────────────
 
-function activateDarkTheme(): void {
+function activateDarkTheme(swatch: Swatch): void {
   document.documentElement.setAttribute(DARK_THEME_ATTR, "")
-  injectDarkTheme()
+  injectDarkTheme(swatch)
 }
 
 function deactivateDarkTheme(): void {
@@ -472,18 +309,23 @@ function deactivateDarkTheme(): void {
 export type ThemeMode = "dark" | "legacy"
 
 /**
- * Apply a theme. `dark` injects the dark-theme CSS layer + patcher; `legacy`
- * installs the global invert filter (pass `config` for legacy — omitted/undefined
- * is a no-op). Does not clear the other mode — the orchestrator calls
- * restoreVendor() first when switching.
+ * Apply a theme. `dark` injects the static dark-theme CSS layer only (the
+ * per-surface patcher is `adapter/actuator.ts`'s job now — this is just the
+ * page-wide switch); `legacy` installs the global invert filter (pass
+ * `config` for legacy — omitted/undefined is a no-op). Does not clear the
+ * other mode — the orchestrator calls restoreVendor() first when switching.
  */
-export function applyTheme(mode: ThemeMode, config?: FilterConfig): void {
+export function applyTheme(
+  mode: ThemeMode,
+  config?: FilterConfig,
+  swatch: Swatch = SWATCHES[DEFAULT_SWATCH_ID]
+): void {
   try {
     if (mode === "legacy") {
       if (config !== undefined) applyLegacyFilter(config)
       return
     }
-    activateDarkTheme()
+    activateDarkTheme(swatch)
   } finally {
     commitVisualState()
   }

--- a/extensions/some-filter/src/lib/tab-state.ts
+++ b/extensions/some-filter/src/lib/tab-state.ts
@@ -17,7 +17,7 @@ import type { TabState } from "@filter/types/tab"
  *   - "off"    — explicit opt-out (no theming at all).
  */
 
-export const DEFAULT_TAB_STATE: TabState = "legacy"
+export const DEFAULT_TAB_STATE: TabState = "auto"
 
 /** Keybind cycle order: auto → legacy → off → auto. */
 export const STATE_CYCLE: Record<TabState, TabState> = {

--- a/extensions/some-filter/tests/e2e/fixture.ts
+++ b/extensions/some-filter/tests/e2e/fixture.ts
@@ -16,6 +16,8 @@
  *   (done automatically by `nix develop .#playwright`).
  */
 
+import fs from "fs"
+import os from "os"
 import path from "path"
 import { fileURLToPath } from "url"
 import {
@@ -28,7 +30,6 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const DIST = path.resolve(__dirname, "../../dist")
 const FIXTURE_DIR = path.resolve(__dirname, "fixtures")
-const USER_DATA_DIR = path.resolve(__dirname, ".chromium-user-data")
 
 // ── Debug snapshot ────────────────────────────────────────────────────────────
 
@@ -69,11 +70,45 @@ export async function waitForClassification(
   //     forever even though the attribute is already present. setTimeout still
   //     fires (throttled) in occluded tabs, so timed polling always observes
   //     it. This mirrors the veil-teardown timer fallback in prepaint.ts.
-  await page.waitForFunction(
-    () => document.body.dataset["swThemeApplied"] !== undefined,
-    undefined,
-    { timeout, polling: 100 }
-  )
+  try {
+    await page.waitForFunction(
+      () => document.body.dataset["swThemeApplied"] !== undefined,
+      undefined,
+      { timeout, polling: 100 }
+    )
+  } catch (error) {
+    // A bare timeout here only ever said "5000ms exceeded" — useless on its
+    // own, since it cannot distinguish "content script never ran" from "tab
+    // is stuck in legacy/off mode" from "pipeline threw before onFire" from
+    // any other stage. Dump the tab's actual state into the failure message
+    // so the *first* failing run is diagnosable without re-instrumenting by
+    // hand. (Best-effort: if the page/context is already gone, report that
+    // instead of masking the original timeout with a second error.)
+    let diagnostic = "(page unavailable for diagnostic snapshot)"
+    try {
+      const snapshot = await page.evaluate(() => ({
+        bodyDataset: { ...document.body.dataset },
+        htmlDataset: { ...document.documentElement.dataset },
+        readyState: document.readyState,
+        hasVeil: document.getElementById("__sw_prepaint_veil") !== null,
+      }))
+      diagnostic = JSON.stringify(snapshot, null, 2)
+    } catch {
+      // page/context already closed — original error is diagnostic enough
+    }
+    // `cause` is an ES2022 Error feature; this project's lib target is
+    // ES2020, so the two-arg constructor overload isn't typed. Declaring the
+    // variable with the wider structural type (rather than casting) lets the
+    // assignment through without `any` — it still works at runtime (Node and
+    // every evergreen browser have supported Error.cause for years) and
+    // preserves the original error for anything that reads it.
+    const wrapped: Error & { cause?: unknown } = new Error(
+      `waitForClassification timed out after ${timeout}ms. Tab state at ` +
+        `failure:\n${diagnostic}\n\nOriginal error: ${String(error)}`
+    )
+    wrapped.cause = error
+    throw wrapped
+  }
 
   return page.evaluate((): FilterDebug => {
     return {
@@ -115,7 +150,22 @@ export const test = base.extend<FilterFixtures & { page: Page }>({
     const needsVirtualDisplay =
       !process.env["DISPLAY"] && !process.env["WAYLAND_DISPLAY"]
 
-    const context = await chromium.launchPersistentContext(USER_DATA_DIR, {
+    // A fresh profile dir per run, not a fixed committed path. --load-extension
+    // requires a *persistent* context (Playwright has no other API for loading
+    // unsigned extensions), but "persistent" here must mean "for the lifetime
+    // of this one launch," never "reused across separate `playwright test`
+    // invocations." A fixed, reused directory lets chrome.storage.local's
+    // filteredTabIds/tabStates (background.ts, keyed by raw tab ID) accumulate
+    // across runs; Chromium assigns tab IDs freshly per process, typically from
+    // the same small integers each launch, so a stale entry from an old run can
+    // collide with a brand-new tab's ID and misclassify it as filter-enabled
+    // ("legacy") before the extension ever gets a chance to run auto mode —
+    // silently skipping the entire dark-theme pipeline with no throw anywhere
+    // to explain it. A disposable directory makes every run start from the
+    // same clean slate CI already gets from its fresh checkout.
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "sw-filter-e2e-"))
+
+    const context = await chromium.launchPersistentContext(userDataDir, {
       executablePath,
       headless: false,
       args: [
@@ -130,6 +180,7 @@ export const test = base.extend<FilterFixtures & { page: Page }>({
     // eslint-disable-next-line react-hooks/rules-of-hooks
     await use(context)
     await context.close()
+    fs.rmSync(userDataDir, { recursive: true, force: true })
   },
 
   page: async ({ context }, use) => {

--- a/extensions/some-filter/tests/e2e/fixture.ts
+++ b/extensions/some-filter/tests/e2e/fixture.ts
@@ -55,9 +55,24 @@ export async function waitForClassification(
   page: Page,
   timeout = 5_000
 ): Promise<FilterDebug> {
+  // Two things matter here:
+  //  1. `{ timeout }` MUST be the third (options) argument. Playwright's
+  //     signature is waitForFunction(pageFunction, arg, options) — passed as
+  //     the second argument it is silently treated as `arg` (handed to the
+  //     page function, which ignores it), leaving the real timeout at its
+  //     30s default. That is the "everything times out at 30s" symptom.
+  //  2. `polling: <number>` (timed) rather than the default `'raf'`. The attr
+  //     is set synchronously by the pipeline's onFire hook, but rAF is paused
+  //     in tabs the browser treats as non-foreground (headed automation opens
+  //     a second page, so the fixture page is frequently occluded). With raf
+  //     polling the predicate is never re-evaluated there and the wait hangs
+  //     forever even though the attribute is already present. setTimeout still
+  //     fires (throttled) in occluded tabs, so timed polling always observes
+  //     it. This mirrors the veil-teardown timer fallback in prepaint.ts.
   await page.waitForFunction(
     () => document.body.dataset["swThemeApplied"] !== undefined,
-    { timeout }
+    undefined,
+    { timeout, polling: 100 }
   )
 
   return page.evaluate((): FilterDebug => {

--- a/extensions/some-filter/tests/e2e/fixtures/dark-hostile-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/dark-hostile-page.html
@@ -6,6 +6,14 @@
   never in doubt — the point of this fixture is to churn a page that must
   be exonerated (restored to native styling, never held) and never falsely
   themed, not to probe the light/dark boundary itself.
+
+  At least MIN_EVIDENCE_FOR_DARK_VERDICT (theme-adapter.ts) *distinct* dark
+  colors, not merely elements: #card shares main's own key, so the original
+  two-color fixture (main/#card's shared key + #panel's) evidenced only 2
+  distinct keys — below the page-level verdict's minimum-evidence guard,
+  which exists specifically to distrust a sample this sparse. #strip adds a
+  third, distinct dark key so this fixture legitimately clears the guard
+  like a real, fully-rendered dark page would.
 -->
 <html style="background-color: rgb(30, 30, 30)">
   <head>
@@ -27,6 +35,9 @@
         </div>
         <div id="panel" style="background-color: rgb(20, 25, 35); padding: 8px">
           dark blue panel
+        </div>
+        <div id="strip" style="background-color: rgb(15, 15, 15); padding: 8px">
+          dark strip
         </div>
       </div>
     </main>

--- a/extensions/some-filter/tests/e2e/fixtures/dark-hostile-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/dark-hostile-page.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<!--
+  Genuinely-dark hostile-page fixture (S6, #691, Leg A — exoneration
+  soundness). Matching dark-page.html's own convention: uniform, unambiguous
+  dark backgrounds throughout, so the classifier's already-dark verdict is
+  never in doubt — the point of this fixture is to churn a page that must
+  be exonerated (restored to native styling, never held) and never falsely
+  themed, not to probe the light/dark boundary itself.
+-->
+<html style="background-color: rgb(30, 30, 30)">
+  <head>
+    <meta charset="utf-8" />
+    <title>Dark Hostile Page Fixture</title>
+  </head>
+  <body
+    style="
+      background-color: rgb(30, 30, 30);
+      margin: 0;
+      color: rgb(220, 220, 220);
+    "
+  >
+    <main style="background-color: rgb(30, 30, 30)">
+      <h1>Dark Hostile Page Fixture</h1>
+      <div id="content-root">
+        <div
+          id="card"
+          style="background-color: rgb(30, 30, 30); padding: 8px"
+        >
+          dark card
+        </div>
+        <div
+          id="panel"
+          style="background-color: rgb(20, 25, 35); padding: 8px"
+        >
+          dark blue panel
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/extensions/some-filter/tests/e2e/fixtures/dark-hostile-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/dark-hostile-page.html
@@ -22,16 +22,10 @@
     <main style="background-color: rgb(30, 30, 30)">
       <h1>Dark Hostile Page Fixture</h1>
       <div id="content-root">
-        <div
-          id="card"
-          style="background-color: rgb(30, 30, 30); padding: 8px"
-        >
+        <div id="card" style="background-color: rgb(30, 30, 30); padding: 8px">
           dark card
         </div>
-        <div
-          id="panel"
-          style="background-color: rgb(20, 25, 35); padding: 8px"
-        >
+        <div id="panel" style="background-color: rgb(20, 25, 35); padding: 8px">
           dark blue panel
         </div>
       </div>

--- a/extensions/some-filter/tests/e2e/fixtures/dark-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/dark-page.html
@@ -9,6 +9,13 @@
   This distinguishes a real dark page from a prepaint-poisoned white page:
   both produce themeApplied="none", but only the poisoned case has luminance ≈ 0.005
   on what should be a white page.
+
+  Three distinct dark-colored descendants (main/header/footer), not one: the
+  page-level verdict (theme-adapter.ts's pageAlreadyDark) requires at least
+  MIN_EVIDENCE_FOR_DARK_VERDICT evidenced keys before trusting a dark mean —
+  a single evidenced element is exactly the sparse-sample case that guard
+  exists to distrust, so this fixture needs to legitimately clear it like a
+  real, fully-rendered dark page would.
 -->
 <html style="background-color: rgb(30, 30, 30)">
   <head>
@@ -22,9 +29,14 @@
       color: rgb(220, 220, 220);
     "
   >
-    <main style="background-color: rgb(30, 30, 30)">
+    <header style="background-color: rgb(25, 25, 25)">
       <h1>Dark Page Fixture</h1>
+    </header>
+    <main style="background-color: rgb(30, 30, 30)">
       <p>Dark background — dark theme should NOT be applied.</p>
     </main>
+    <footer style="background-color: rgb(20, 20, 20)">
+      <p>footer</p>
+    </footer>
   </body>
 </html>

--- a/extensions/some-filter/tests/e2e/fixtures/exogenous-reload-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/exogenous-reload-page.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!--
+  Exogenous self-reload fixture — reproduces a real-world pattern reported
+  from live YouTube: the page loads, paints once, then the page's OWN script
+  triggers a full reload shortly after (exact vendor trigger unconfirmed).
+  The content script gets a second document_start/document_end cycle on a
+  fresh document. Reported symptom: prepaint covers correctly on both loads,
+  but the FINAL settled state after the second load shows the native
+  (light) background instead of the extension's dark theme — "it settles to
+  white after the second document_end."
+
+  This fixture drives exactly that shape without needing a live, unstable
+  vendor page: a plain light page whose own inline script reloads itself
+  once (sessionStorage-gated, so it doesn't loop) a short delay after load.
+  The correctness bar: whatever happens transiently during/around the
+  reload, the extension must land on its themed dark canvas once the SECOND
+  load's content script settles — not strand the user on native white.
+-->
+<html style="background-color: rgb(255, 255, 255)">
+  <head>
+    <meta charset="utf-8" />
+    <title>Exogenous Reload Fixture</title>
+    <script>
+      // Same-tab reload, gated so it fires exactly once. sessionStorage is
+      // the right primitive here, not a URL param: it's scoped to this
+      // tab's session for this origin and, unlike an in-memory JS flag,
+      // survives the very reload it's guarding against looping on.
+      if (!sessionStorage.getItem("__sw_test_reloaded")) {
+        sessionStorage.setItem("__sw_test_reloaded", "1")
+        setTimeout(function () {
+          location.reload()
+        }, 200)
+      }
+    </script>
+  </head>
+  <body style="background-color: rgb(255, 255, 255); margin: 0">
+    <main style="background-color: rgb(255, 255, 255)">
+      <h1>Exogenous Reload Fixture</h1>
+      <div id="card" style="background-color: rgb(255, 255, 255); padding: 8px">
+        white card
+      </div>
+      <div
+        id="panel"
+        style="background-color: rgb(200, 220, 255); padding: 8px"
+      >
+        light blue panel
+      </div>
+    </main>
+  </body>
+</html>

--- a/extensions/some-filter/tests/e2e/fixtures/hostile-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/hostile-page.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<!--
+  Hostile-page fixture (S6, #691) — a genuinely light page (unambiguous,
+  matching light-page.html's own convention) carrying several distinct
+  background surfaces so churn has something worth re-classifying: a plain
+  white card, a light-blue panel (hue-preservation target), and a
+  near-black strip (preserve-band target). #content-root is the churn
+  script's mutation target (hostile-page.ts's sustainedMutation/
+  virtualizedRecycle).
+-->
+<html style="background-color: rgb(255, 255, 255)">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hostile Page Fixture</title>
+  </head>
+  <body style="background-color: rgb(255, 255, 255); margin: 0">
+    <main style="background-color: rgb(255, 255, 255)">
+      <h1>Hostile Page Fixture</h1>
+      <div id="content-root">
+        <div
+          id="card"
+          style="background-color: rgb(255, 255, 255); padding: 8px"
+        >
+          white card
+        </div>
+        <div
+          id="panel"
+          style="background-color: rgb(200, 220, 255); padding: 8px"
+        >
+          light blue panel
+        </div>
+        <div
+          id="strip"
+          style="background-color: rgb(13, 17, 23); padding: 8px"
+        >
+          near-black strip
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/extensions/some-filter/tests/e2e/fixtures/hostile-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/hostile-page.html
@@ -29,10 +29,7 @@
         >
           light blue panel
         </div>
-        <div
-          id="strip"
-          style="background-color: rgb(13, 17, 23); padding: 8px"
-        >
+        <div id="strip" style="background-color: rgb(13, 17, 23); padding: 8px">
           near-black strip
         </div>
       </div>

--- a/extensions/some-filter/tests/e2e/fixtures/hostile-page.ts
+++ b/extensions/some-filter/tests/e2e/fixtures/hostile-page.ts
@@ -1,0 +1,167 @@
+/**
+ * Hostile-page churn fixture — vendored from
+ * `extensions/transport/tests/e2e/fixtures/hostile-page.ts` (#618's S11
+ * conformance fixture), per S6's own task list ("import or vendor
+ * hostile-page.ts"). Vendored rather than imported: transport's package
+ * exports map (`"./*": "./src/*.ts"`) only covers `src/`, not `tests/`, and
+ * these churn steps are property-agnostic by design — none of them touch
+ * CSS or a domain concept, so copying introduces no drift risk the
+ * original didn't already guard against. No assertion lives here: it only
+ * drives the page. See `specs/swatch-oracle.spec.ts` for the proof.
+ */
+
+import type { Page } from "@playwright/test"
+
+export const churn = {
+  async blank(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      document.body.innerHTML = ""
+    })
+  },
+
+  async themeFlip(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      document.documentElement.classList.toggle("dark")
+      document.documentElement.classList.toggle("light")
+    })
+  },
+
+  async bodyHeadReplace(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      const newHead = document.createElement("head")
+      const newBody = document.createElement("body")
+      newBody.innerHTML = '<div id="content-root"></div>'
+      document.documentElement.replaceChild(newHead, document.head)
+      document.documentElement.replaceChild(newBody, document.body)
+    })
+  },
+
+  async styleChurn(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      const style = document.createElement("style")
+      style.textContent = "body { background: black; }"
+      document.head.appendChild(style)
+      style.remove()
+    })
+  },
+
+  async spaNavigate(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      try {
+        history.pushState({}, "", "/route-2")
+      } catch {
+        // A real content-script origin permits this; a null-origin
+        // synthetic page does not — the popstate dispatch below is the
+        // actually-observable signal a router-detection heuristic keys on,
+        // and always fires regardless.
+      }
+      window.dispatchEvent(new PopStateEvent("popstate"))
+    })
+  },
+
+  async rootReplace(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      const newRoot = document.createElement("html")
+      newRoot.innerHTML = document.documentElement.innerHTML
+      while (document.documentElement.firstChild !== null) {
+        document.documentElement.removeChild(
+          document.documentElement.firstChild
+        )
+      }
+      while (newRoot.firstChild !== null) {
+        document.documentElement.appendChild(newRoot.firstChild)
+      }
+    })
+  },
+
+  async virtualizedRecycle(
+    page: Page,
+    selector: string,
+    key: string,
+    value: number
+  ): Promise<void> {
+    await page.evaluate(
+      ({ selector, key, value }) => {
+        const root = document.querySelector(selector)
+        if (root === null) return
+        let el = root.querySelector("[data-recycled-node]")
+        if (el === null) {
+          el = document.createElement("div")
+          el.setAttribute("data-recycled-node", "")
+          root.appendChild(el)
+        }
+        el.setAttribute("data-key", key)
+        el.setAttribute("data-value", String(value))
+      },
+      { selector, key, value }
+    )
+  },
+
+  async extensionDomRemoval(page: Page, selector: string): Promise<void> {
+    await page.evaluate((selector) => {
+      for (const el of Array.from(document.querySelectorAll(selector))) {
+        el.remove()
+      }
+    }, selector)
+  },
+
+  async sustainedMutation(
+    page: Page,
+    durationMs: number,
+    targetRate = 1000
+  ): Promise<void> {
+    await page.evaluate(
+      ({ durationMs, targetRate }) => {
+        return new Promise<void>((resolve) => {
+          const root = document.querySelector("#content-root") ?? document.body
+          const start = performance.now()
+          let count = 0
+          const perTick = Math.max(1, Math.round(targetRate / 100))
+          function tick(): void {
+            for (let i = 0; i < perTick; i++) {
+              const el = document.createElement("div")
+              el.setAttribute("data-key", `churn-${count % 20}`)
+              el.setAttribute("data-value", String(count))
+              root.appendChild(el)
+              const oldest = root.firstElementChild
+              if (root.children.length > 50 && oldest !== null) {
+                root.removeChild(oldest)
+              }
+              count++
+            }
+            if (performance.now() - start < durationMs) {
+              setTimeout(tick, 10)
+            } else {
+              resolve()
+            }
+          }
+          tick()
+        })
+      },
+      { durationMs, targetRate }
+    )
+  },
+
+  /**
+   * Not present in transport's original fixture: some-filter-specific
+   * churn exercising the per-surface path directly — a vendor script
+   * mutating an *existing* element's background color in place (Remark
+   * 2.6's endogenous coupling; the attributeFilter: ["class", "style"]
+   * case classifyElement/decide was written for).
+   */
+  async recolorInPlace(
+    page: Page,
+    selector: string,
+    css: string
+  ): Promise<void> {
+    await page.evaluate(
+      ({ selector, css }) => {
+        const el = document.querySelector(selector)
+        if (el instanceof HTMLElement) {
+          el.style.backgroundColor = css
+        }
+      },
+      { selector, css }
+    )
+  },
+}

--- a/extensions/some-filter/tests/e2e/specs/exogenous-reload.spec.ts
+++ b/extensions/some-filter/tests/e2e/specs/exogenous-reload.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Exogenous self-reload resilience — reproduces a real-world pattern
+ * reported from live YouTube (exact vendor trigger unconfirmed, no network
+ * access to youtube.com from this suite): the page loads and paints once,
+ * then the page's OWN script fires a full reload shortly after, giving the
+ * content script a second document_start/document_end cycle on a fresh
+ * document. Reported symptom: prepaint covers correctly on both loads, but
+ * the settled state after the SECOND load shows native (light) background
+ * instead of the extension's dark theme.
+ *
+ * fixtures/exogenous-reload-page.html drives exactly that shape (a plain
+ * light page that reloads itself once, sessionStorage-gated). This can't
+ * confirm what YouTube itself is doing internally — only that our pipeline
+ * correctly recovers from the general "a page reloads itself shortly after
+ * initial paint" pattern, which is the useful, reproducible proxy for it.
+ */
+
+import { expect, test, waitForClassification } from "@filter/playwright/fixture"
+
+test.describe("exogenous self-reload resilience", () => {
+  test("settles to the themed dark canvas after the page reloads itself shortly after initial paint", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("exogenous-reload-page")
+
+    // fixture.goto() already waited out the *first* load internally (via
+    // page.goto()'s own default waitUntil). Set up this listener immediately
+    // after it returns — well within the fixture's own 200ms reload delay —
+    // so it can only match the second, self-triggered load, never race with
+    // the one goto() already consumed.
+    await page.waitForEvent("load")
+
+    const snap = await waitForClassification(page)
+
+    expect(snap.themeApplied).toBe("dark")
+    expect(snap.hasDarkAttr).toBe(true)
+    expect(snap.hasPrepaintVeil).toBe(false)
+  })
+})

--- a/extensions/some-filter/tests/e2e/specs/swatch-oracle.spec.ts
+++ b/extensions/some-filter/tests/e2e/specs/swatch-oracle.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * Swatch-oracle hostile-page e2e — S6 (#691) of the some-filter-on-transport
+ * epic. Mirrors #618's hostile-page conformance proof (transport's own
+ * `tests/e2e/specs/*`, asserted against protocol state and the null
+ * adapter) with its domain-output counterpart: same class of hostile churn,
+ * but now asserting the *real* adapter actually lands the page on a chosen
+ * swatch, never leaks native luminance, exonerates soundly, and is
+ * comfortable — not just dark — once settled.
+ *
+ * Scope note (read before extending): every spec here runs against
+ * `SWATCHES.default` — the only swatch reachable through the shipped
+ * pipeline today. `content.ts`'s auto-mode content session hardcodes
+ * `SWATCHES[DEFAULT_SWATCH_ID]` (S5, #690); no swatch-selection mechanism
+ * exists yet to drive the other six registry entries through the real
+ * extension (S2, #687's own non-goal: "No user-facing picker UI ... a
+ * separate follow-on"). Once that selector exists, the convergence/comfort
+ * specs below should be parameterized over `Object.values(SWATCHES)`
+ * exactly as their acceptance criteria describe; until then, asserting a
+ * swatch this pipeline can never actually select would be testing a
+ * capability that doesn't exist.
+ */
+
+import {
+  DEFAULT_SWATCH_ID,
+  satisfiesComfort,
+  SWATCHES,
+} from "@filter/adapter/swatches"
+import { parseColor } from "@filter/lib/content/color"
+import { expect, test, waitForClassification } from "@filter/playwright/fixture"
+import type { Page } from "@playwright/test"
+
+import { churn } from "../fixtures/hostile-page"
+
+const swatch = SWATCHES[DEFAULT_SWATCH_ID]
+const COLOR_TOLERANCE = 0.08 // 0..1 per-channel budget; generous for AA/rounding
+
+function colorsClose(
+  a: string,
+  b: string,
+  tolerance = COLOR_TOLERANCE
+): boolean {
+  const ca = parseColor(a)
+  const cb = parseColor(b)
+  if (ca === null || cb === null) return false
+  const distance = Math.sqrt(
+    (ca[0] - cb[0]) ** 2 + (ca[1] - cb[1]) ** 2 + (ca[2] - cb[2]) ** 2
+  )
+  return distance <= tolerance
+}
+
+async function runFullChurnSequence(page: Page): Promise<void> {
+  await churn.blank(page)
+  await churn.themeFlip(page)
+  await churn.bodyHeadReplace(page)
+  await churn.styleChurn(page)
+  await churn.spaNavigate(page)
+  await churn.rootReplace(page)
+  await churn.virtualizedRecycle(page, "#content-root", "k1", 1)
+  await churn.extensionDomRemoval(page, "[data-my-ext]")
+  await churn.sustainedMutation(page, 500)
+}
+
+test.describe("swatch-oracle: convergence (positive proof)", () => {
+  test("per-surface classification lands on the default swatch's tokens before any churn", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("hostile-page")
+    await waitForClassification(page)
+    // The coalescer's reconcile window (50ms) plus a margin for the round
+    // to actually settle and realize.
+    await page.waitForTimeout(300)
+
+    const rendered = await page.evaluate(() => ({
+      card: getComputedStyle(document.getElementById("card")!).backgroundColor,
+      strip: getComputedStyle(document.getElementById("strip")!)
+        .backgroundColor,
+      cardPatched: document.getElementById("card")?.dataset["swPatched"],
+      stripPatched: document.getElementById("strip")?.dataset["swPatched"],
+    }))
+
+    // #card (white) is a light surface: tagged, and darkened hue-preserving.
+    expect(rendered.cardPatched).toBeDefined()
+    expect(colorsClose(rendered.card, "rgb(255, 255, 255)")).toBe(false)
+
+    // #strip (near-black, matches today's bg-0) is preserve-band: tagged
+    // "preserve", left alone by the CSS revert rule.
+    expect(rendered.stripPatched).toBe("preserve")
+  })
+
+  test("the page still wears the default swatch's canvas after the full hostile churn sequence", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("hostile-page")
+    await waitForClassification(page)
+
+    await runFullChurnSequence(page)
+
+    // Settle: the coalescer's window plus margin for the final round.
+    await page.waitForTimeout(300)
+
+    const rendered = await page.evaluate(() => ({
+      hasDarkAttr: document.documentElement.hasAttribute("data-sw-dark"),
+      bodyBg: getComputedStyle(document.body).backgroundColor,
+    }))
+
+    expect(rendered.hasDarkAttr).toBe(true)
+    expect(colorsClose(rendered.bodyBg, swatch.bg0)).toBe(true)
+  })
+})
+
+test.describe("swatch-oracle: leak (Δt_eval = 0, §9.2/Thm C.1)", () => {
+  test("no sampled frame across the full churn reads native (light) luminance", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("hostile-page")
+    await waitForClassification(page)
+
+    const samples: Array<{ luminance: number; visible: boolean }> = []
+
+    async function sample(): Promise<void> {
+      const result = await page.evaluate(() => {
+        const veil = document.getElementById("__sw_prepaint_veil")
+        const veilUp = veil?.isConnected ?? false
+        const bg = getComputedStyle(document.body).backgroundColor
+        return { bg, veilUp }
+      })
+      const c = parseColor(result.bg)
+      const luminance =
+        c === null ? 0 : 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2] // coarse, sampling-only
+      // "Visible" native luminance means: the veil is down AND the sampled
+      // background reads light — i.e. the vendor's true (unthemed) canvas
+      // would be showing right now.
+      samples.push({ luminance, visible: !result.veilUp && luminance > 0.5 })
+    }
+
+    await sample()
+    await churn.blank(page)
+    await sample()
+    await churn.themeFlip(page)
+    await sample()
+    await churn.bodyHeadReplace(page)
+    await sample()
+    await churn.styleChurn(page)
+    await sample()
+    await churn.spaNavigate(page)
+    await sample()
+    await churn.rootReplace(page)
+    await sample()
+    await churn.virtualizedRecycle(page, "#content-root", "k1", 1)
+    await sample()
+    await churn.extensionDomRemoval(page, "[data-my-ext]")
+    await sample()
+
+    const leaked = samples.filter((s) => s.visible)
+    expect(leaked).toEqual([])
+  })
+})
+
+test.describe("swatch-oracle: exoneration soundness (Leg A — gates S7)", () => {
+  test("a genuinely-dark hostile page is exonerated (restored to native styling), never held", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("dark-hostile-page")
+    await waitForClassification(page)
+
+    await runFullChurnSequence(page)
+    await page.waitForTimeout(300)
+
+    const rendered = await page.evaluate(() => ({
+      themeApplied: document.body.dataset["swThemeApplied"],
+      hasDarkAttr: document.documentElement.hasAttribute("data-sw-dark"),
+      patchedCount: document.querySelectorAll("[data-sw-patched]").length,
+    }))
+
+    expect(rendered.themeApplied).toBe("none")
+    expect(rendered.hasDarkAttr).toBe(false)
+    expect(rendered.patchedCount).toBe(0)
+  })
+
+  test("a genuinely-light hostile page is never exonerated, even under sustained churn", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("hostile-page")
+    await waitForClassification(page)
+
+    await runFullChurnSequence(page)
+    await page.waitForTimeout(300)
+
+    const themeApplied = await page.evaluate(
+      () => document.body.dataset["swThemeApplied"]
+    )
+    expect(themeApplied).toBe("dark")
+  })
+})
+
+test.describe("swatch-oracle: comfort (Leg B — Φ_comfort on rendered output)", () => {
+  test("the settled page's rendered bg/text satisfy Φ_comfort, not just 'is dark'", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("hostile-page")
+    await waitForClassification(page)
+    await page.waitForTimeout(300)
+
+    const rendered = await page.evaluate(() => ({
+      bg: getComputedStyle(document.body).backgroundColor,
+    }))
+
+    // Φ_comfort is defined over the swatch's own (bg0, text0) hex pair
+    // (registry-time, S2). Re-running it here against the *rendered* body
+    // background is Leg B's whole point: the same predicate, now checked
+    // against live computed style rather than static registry data. The
+    // registry-time predicate itself is re-asserted for the active swatch
+    // as the anchor this comparison depends on (already covered
+    // exhaustively for every registry entry by `swatches.test.ts`, S2).
+    expect(colorsClose(rendered.bg, swatch.bg0)).toBe(true)
+    expect(satisfiesComfort(swatch)).toBe(true)
+  })
+})

--- a/extensions/some-filter/tests/e2e/specs/swatch-oracle.spec.ts
+++ b/extensions/some-filter/tests/e2e/specs/swatch-oracle.spec.ts
@@ -48,16 +48,61 @@ function colorsClose(
   return distance <= tolerance
 }
 
+// ── Churn step table ──────────────────────────────────────────────────────────
+// One named, self-contained transition per entry. Every recovery test below is
+// built from this table so a failure localizes to a specific primitive (or to
+// the accumulated history leading into it) instead of a single opaque 30s
+// timeout at the end of a nine-operation script.
+
+type ChurnStep = {
+  readonly name: string
+  readonly run: (p: Page) => Promise<void>
+}
+
+const CHURN_STEPS: ReadonlyArray<ChurnStep> = [
+  { name: "blank", run: (p) => churn.blank(p) },
+  { name: "themeFlip", run: (p) => churn.themeFlip(p) },
+  { name: "bodyHeadReplace", run: (p) => churn.bodyHeadReplace(p) },
+  { name: "styleChurn", run: (p) => churn.styleChurn(p) },
+  { name: "spaNavigate", run: (p) => churn.spaNavigate(p) },
+  { name: "rootReplace", run: (p) => churn.rootReplace(p) },
+  {
+    name: "virtualizedRecycle",
+    run: (p) => churn.virtualizedRecycle(p, "#content-root", "k1", 1),
+  },
+  {
+    name: "extensionDomRemoval",
+    run: (p) => churn.extensionDomRemoval(p, "[data-my-ext]"),
+  },
+  { name: "sustainedMutation", run: (p) => churn.sustainedMutation(p, 500) },
+]
+
+// Runs the whole sequence, each primitive wrapped in a test.step so the
+// Playwright report shows exactly which one was running when a hang/throw hit.
 async function runFullChurnSequence(page: Page): Promise<void> {
-  await churn.blank(page)
-  await churn.themeFlip(page)
-  await churn.bodyHeadReplace(page)
-  await churn.styleChurn(page)
-  await churn.spaNavigate(page)
-  await churn.rootReplace(page)
-  await churn.virtualizedRecycle(page, "#content-root", "k1", 1)
-  await churn.extensionDomRemoval(page, "[data-my-ext]")
-  await churn.sustainedMutation(page, 500)
+  for (const step of CHURN_STEPS) {
+    await test.step(step.name, async () => {
+      await step.run(page)
+    })
+  }
+}
+
+// A single falsifiable transition assertion: after whatever just happened, the
+// light hostile page must (re)settle onto the default swatch's dark canvas.
+// waitForClassification is the recovery signal (the pipeline re-stamps
+// swThemeApplied); the 300ms margin lets the coalescer's reconcile window plus
+// realize() land before the computed style is read.
+async function expectConverged(page: Page): Promise<void> {
+  await waitForClassification(page)
+  await page.waitForTimeout(300)
+
+  const rendered = await page.evaluate(() => ({
+    hasDarkAttr: document.documentElement.hasAttribute("data-sw-dark"),
+    bodyBg: getComputedStyle(document.body).backgroundColor,
+  }))
+
+  expect(rendered.hasDarkAttr).toBe(true)
+  expect(colorsClose(rendered.bodyBg, swatch.bg0)).toBe(true)
 }
 
 test.describe("swatch-oracle: convergence (positive proof)", () => {
@@ -87,24 +132,64 @@ test.describe("swatch-oracle: convergence (positive proof)", () => {
     expect(rendered.stripPatched).toBe("preserve")
   })
 
-  test("the page still wears the default swatch's canvas after the full hostile churn sequence", async ({
+  test("the page wears the default swatch's canvas the moment it settles, before any churn", async ({
     fixture,
   }) => {
     const page = await fixture.goto("hostile-page")
-    await waitForClassification(page)
+    await expectConverged(page)
+  })
+})
 
-    await runFullChurnSequence(page)
+// Each test owns exactly one transition: converge from a clean load, apply a
+// single churn primitive, then require the page to re-converge. A failure here
+// names the primitive that breaks recovery *in isolation* (independent of any
+// accumulated history), so it is separable from an order/history effect.
+test.describe("swatch-oracle: single-primitive recovery (isolation)", () => {
+  for (const step of CHURN_STEPS) {
+    test(`re-converges after ${step.name}()`, async ({ fixture }) => {
+      const page = await fixture.goto("hostile-page")
+      await test.step("initial converge", async () => {
+        await expectConverged(page)
+      })
+      await test.step(step.name, async () => {
+        await step.run(page)
+      })
+      await test.step("re-converge", async () => {
+        await expectConverged(page)
+      })
+    })
+  }
+})
 
-    // Settle: the coalescer's window plus margin for the final round.
-    await page.waitForTimeout(300)
-
-    const rendered = await page.evaluate(() => ({
-      hasDarkAttr: document.documentElement.hasAttribute("data-sw-dark"),
-      bodyBg: getComputedStyle(document.body).backgroundColor,
-    }))
-
-    expect(rendered.hasDarkAttr).toBe(true)
-    expect(colorsClose(rendered.bodyBg, swatch.bg0)).toBe(true)
+// The cumulative counterpart: one page walked through the whole sequence, with
+// a convergence gate after every primitive. Because it is interleaved and
+// history-preserving, the Playwright report reads as
+//
+//   ✓ blank        ✓ converge after blank
+//   ✓ themeFlip    ✓ converge after themeFlip
+//   ✗ converge after bodyHeadReplace   (timeout)
+//
+// which names the *first operation, given the full history before it*, after
+// which the pipeline stops recovering — the single most useful signal for an
+// observer-based system. Given up to nine 5s convergence gates, the default
+// 30s test budget is not enough even on the happy path, so raise it.
+test.describe("swatch-oracle: cumulative recovery (history-preserving)", () => {
+  test("re-converges after every prefix of the full hostile sequence", async ({
+    fixture,
+  }) => {
+    test.setTimeout(120_000)
+    const page = await fixture.goto("hostile-page")
+    await test.step("baseline converge", async () => {
+      await expectConverged(page)
+    })
+    for (const step of CHURN_STEPS) {
+      await test.step(step.name, async () => {
+        await step.run(page)
+      })
+      await test.step(`converge after ${step.name}`, async () => {
+        await expectConverged(page)
+      })
+    }
   })
 })
 


### PR DESCRIPTION
## Description

Lands S5 and S6 of the `some-filter`-on-`transport` epic (#685), milestone [metamathematics. (M16)](https://github.com/paulgsc/some-ui/milestone/16). Based directly on `main` (S1–S4 already merged via #704, #706).

### S5 (#690) — Pipeline migration

`content.ts`'s auto-mode theming now runs on `@some-extension/transport`'s Sensor → Estimator → Scheduler → Adapter → Actuator, replacing `theme-apply.ts`'s hand-rolled `patchObserver`/`patchAll`/`tokenForBackground`/`colorTokens` (all deleted):

- **`src/adapter/pipeline.ts`** — the Sensor (`scan()` walks exactly where `patchAll` used to, same skip rules) + Estimator (one `update()` per distinct key per scan) + Scheduler (a single declared reconcile policy — Definition 7.2's `R`) wiring.
- **`src/adapter/actuator.ts`** — the only module that writes `data-sw-patched`, the dynamic per-surface stylesheet, or (via `theme-apply.ts`'s exported primitives) the static layer and `data-sw-dark`. Rebuilds the dynamic stylesheet from the current action list every call (idempotence, Theorem 7.2) instead of incrementally appending.
- **`theme-apply.ts`** trimmed to the static CSS layer + legacy filter only.
- **`content.ts`**'s `runAutoTheme()` no longer does its own apply-then-detect branching — `decide()` (S3) settles that internally now.
- **Gap found while wiring this in**: `decide()` needed a new `ActivateThemeAction` (extending S1/S3's action alphabet) — the static dark layer must activate even with zero per-surface evidence (the `transparent-page` fixture has no element anywhere with an explicit background). Added, with `theme-adapter.test.ts` updated accordingly.

**142 unit tests** (24 new), including a structural test asserting DOM-mutating calls for the dark-theme path exist only in `actuator.ts`, coalescing (burst of N mutations → exactly one `decide` invocation), and a byte-exact `restoreVendor()` check.

**e2e verification finding, please read**: I built the extension and tried to run the existing Playwright `smoke.spec.ts` against it. It failed — but I confirmed this is a **pre-existing environment limitation, not a regression**: running the identical check against the unmodified `main` baseline fails identically (extensions can't get file:// access in this sandbox without more setup than `--load-extension` alone provides). Full unit-test coverage stands in for that missing live-browser confirmation here.

### S6 (#691) — Swatch-oracle hostile-page e2e suite

The positive-proof counterpart to transport's own #618 hostile-page conformance suite — same class of hostile churn, now asserting **domain output** (does the classifier actually land the chosen swatch?) instead of protocol state.

- `tests/e2e/fixtures/hostile-page.ts` — the churn sequence vendored from transport's own fixture (package exports only cover `src/`, not `tests/`; vendoring is explicitly sanctioned by the issue's own task list).
- `tests/e2e/fixtures/hostile-page.html` / `dark-hostile-page.html` — light and genuinely-dark hostile fixtures.
- `tests/e2e/specs/swatch-oracle.spec.ts` — **convergence** (pre-churn per-surface classification, post-churn canvas convergence), **leak** (samples luminance + veil state after every churn step — no native-luminance frame ever visible), **exoneration soundness / Leg A** (a dark page is always restored; a light page is never exonerated even under churn — this is S7's gate), **comfort / Leg B** (`Φ_comfort` re-asserted against rendered computed style, not just registry data).

**Two things to flag honestly:**
1. **Scope**: every spec runs against `SWATCHES.default` only — `content.ts`'s session hardcodes it (S5), and no swatch-picker exists yet to drive the other six registry entries through the real extension (S2's own explicit non-goal). Full per-registry parameterization is blocked on that follow-on; the spec file's header comment says so.
2. **Unverified**: for the same environment reason as S5, **this suite could not be run against a live browser in this session**. It typechecks and lints cleanly (`tsconfig.json`'s `"tests"` include covers it) — real but partial verification. It needs a real run (e.g. the project's `nix develop .#playwright` shell) before merging, and should be expected to need the normal iteration any first e2e pass needs against real failures.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change — internal only: `theme-apply.ts`'s per-element patcher API (`patchAll`, `repatchPage`, etc.) is removed; nothing outside this package imported it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] e2e tests pass locally — **could not be verified in this environment; see above**

## Test plan

- `pnpm --filter @some-extension/filter typecheck` — passes (covers `src` and `tests`)
- `pnpm --filter @some-extension/filter lint:js` — passes
- `pnpm --filter @some-extension/filter test` — 142/142 passing
- `pnpm --filter @some-extension/filter build:chromium` — builds cleanly
- `pnpm --filter @some-extension/transport typecheck` / `test` — unaffected, still passing (136/136)
- Playwright e2e (`smoke.spec.ts`, `swatch-oracle.spec.ts`) — **not runnable in this sandbox** (confirmed pre-existing, unrelated to this change); needs a real run before merge

Closes #690
Closes #691


---
_Generated by [Claude Code](https://claude.ai/code/session_01LavqbpL6aDeWXX3Kqe9Fgw)_