### PR TITLE
Bound the player route to a fixed V, document the overflow doctrine

### DIFF
--- a/apps/www/src/components/player/session-viewport.tsx
+++ b/apps/www/src/components/player/session-viewport.tsx
@@ -9,7 +9,7 @@ export const SessionViewport = (): JSX.Element => {
   const activeLifetimes = useSceneLifetimes()
 
   return (
-    <div className="bg-muted relative w-full flex-1 min-h-[680px] overflow-hidden rounded-lg border">
+    <div className="bg-muted relative w-full flex-1 min-h-0 overflow-hidden rounded-lg border">
       {activeLifetimes.length === 0 ? (
         <div className="absolute inset-0 flex items-center justify-center">
           <p className="text-muted-foreground text-sm">Press Play to begin</p>

--- a/apps/www/src/routes/_dashboard.tsx
+++ b/apps/www/src/routes/_dashboard.tsx
@@ -19,9 +19,23 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "some-ui-shared"
+import { cn } from "some-ui-utils"
 
 import { ThemeSwitcher } from "@/components/theme-switcher"
 import { Toaster } from "@/components/toaster"
+
+/**
+ * Matches only the session player route (/sessions/$sessionId), whose
+ * content owns a fixed viewport V (see docs/session-viewport) — the
+ * dashboard shell must not let the page scroll here, or V is never
+ * genuinely bounded. Every other route, including /sessions and
+ * /sessions/new, stays an ordinary scrolling document.
+ */
+const SESSION_PLAYER_PATH = /^\/sessions\/(?!new$)[^/]+$/
+
+function isViewportPath(pathname: string): boolean {
+  return SESSION_PLAYER_PATH.test(pathname)
+}
 
 type NavItem = {
   to: "/" | "/sessions" | "/profile" | "/settings"
@@ -45,9 +59,10 @@ const DashboardLayout = (): JSX.Element => {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   })
+  const isViewportRoute = isViewportPath(pathname)
 
   return (
-    <SidebarProvider>
+    <SidebarProvider className={cn(isViewportRoute && "h-svh overflow-hidden")}>
       <Sidebar>
         <SidebarHeader>
           <div className="text-gradient-accent px-2 py-1.5 text-sm font-semibold">
@@ -81,7 +96,12 @@ const DashboardLayout = (): JSX.Element => {
           <SidebarTrigger />
           <ThemeSwitcher />
         </header>
-        <div className="flex-1 overflow-auto p-6">
+        <div
+          className={cn(
+            "flex-1 p-6",
+            isViewportRoute ? "min-h-0 overflow-hidden" : "overflow-auto"
+          )}
+        >
           <Outlet />
         </div>
       </SidebarInset>

--- a/apps/www/tests/session-viewport/no-overflow-scroll.spec.ts
+++ b/apps/www/tests/session-viewport/no-overflow-scroll.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression coverage for #692, resolved by #695 (epic #693, story 2 - see
+ * docs/session-viewport/02-kill-the-cutoff.md): the player route must
+ * measure a fixed, bounded viewport V and clip content to it. The page must
+ * never grow to accommodate an oversized activity - that's the page-level
+ * `overflow-auto` scroll the epic explicitly forbids.
+ *
+ * This doesn't boot the real app (no dev server, no router/orchestrator
+ * state) - see tests/csp/csp.spec.ts for the established pattern this
+ * follows. It mirrors, as static CSS, the exact flex/overflow chain now
+ * shipped across:
+ *   - apps/www/src/routes/_dashboard.tsx        (wrapper + outlet)
+ *   - apps/www/src/components/player/live-player.tsx
+ *   - apps/www/src/components/player/session-viewport.tsx
+ * then drops in a deliberately oversized child (standing in for an activity
+ * like @some-ui/interview's InterviewApp, which assumes `min-h-screen` -
+ * logged in the doc above) to prove the chain clips instead of growing the
+ * page. The BEFORE fixture reproduces the pre-#695 classes so the AFTER
+ * assertions are pinned against a fixture that's known to fail without the
+ * fix (mirrors the CSP spec's own "sanity" test).
+ */
+
+import { expect, test, type Page } from "@playwright/test"
+
+const VIEWPORT = { width: 1280, height: 800 }
+const ACTIVITY_HEIGHT = 3000
+
+type ShellVariant = "before" | "after"
+
+function shellHtml(variant: ShellVariant): string {
+  const wrapperCss =
+    variant === "after"
+      ? "min-height: 100svh; height: 100svh; overflow: hidden;"
+      : "min-height: 100svh;"
+
+  const outletCss =
+    variant === "after"
+      ? "flex: 1 1 0%; min-height: 0; overflow: hidden; padding: 24px;"
+      : "flex: 1 1 0%; overflow: auto; padding: 24px;"
+
+  const sessionViewportCss =
+    variant === "after"
+      ? "flex: 1 1 0%; min-height: 0; overflow: hidden;"
+      : "flex: 1 1 0%; min-height: 680px; overflow: hidden;"
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+<style>
+  * { box-sizing: border-box; margin: 0; }
+  body { font-family: sans-serif; }
+  /* mirrors SidebarProvider's wrapper div (some-ui-shared/sidebar.tsx) */
+  .wrapper { display: flex; width: 100%; ${wrapperCss} }
+  .sidebar { width: 200px; flex-shrink: 0; background: #eee; }
+  /* mirrors SidebarInset's <main> */
+  main { display: flex; flex-direction: column; flex: 1 1 0%; min-height: 100svh; background: #fff; }
+  header { height: 56px; flex-shrink: 0; border-bottom: 1px solid #ccc; }
+  /* mirrors the outlet div in routes/_dashboard.tsx */
+  .outlet { ${outletCss} }
+  /* mirrors live-player.tsx's root div */
+  .live-player { display: flex; flex-direction: column; gap: 16px; width: 100%; height: 100%; min-height: 0; }
+  .now-next { flex-shrink: 0; height: 24px; }
+  .transport { flex-shrink: 0; height: 64px; border: 1px solid #ccc; }
+  /* mirrors session-viewport.tsx's root div */
+  .session-viewport { ${sessionViewportCss} border: 1px solid #999; position: relative; width: 100%; }
+  /* stand-in for an activity that assumes it owns the whole viewport
+     (e.g. InterviewApp's 'min-h-screen', VoiceAvatar's 'min-h-screen') */
+  .activity { min-height: ${ACTIVITY_HEIGHT}px; background: repeating-linear-gradient(45deg, #ddd, #ddd 10px, #eee 10px, #eee 20px); }
+</style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="sidebar"></div>
+    <main>
+      <header></header>
+      <div class="outlet">
+        <div class="live-player">
+          <div class="session-viewport" id="session-viewport">
+            <div class="activity" id="activity">tall activity content</div>
+          </div>
+          <div class="now-next"></div>
+          <div class="transport"></div>
+        </div>
+      </div>
+    </main>
+  </div>
+</body>
+</html>`
+}
+
+async function loadShell(page: Page, variant: ShellVariant): Promise<void> {
+  await page.route("**/*", (route) =>
+    route.fulfill({ body: shellHtml(variant), contentType: "text/html" })
+  )
+  await page.goto(
+    `https://localhost/__session-viewport-regression__/${variant}`
+  )
+}
+
+test.describe("session viewport never resolves overflow with page-level scroll", () => {
+  test.use({ viewport: VIEWPORT })
+
+  test("after #695: an oversized activity is clipped, the page does not grow", async ({
+    page,
+  }) => {
+    await loadShell(page, "after")
+
+    const pageScrollHeight = await page.evaluate(
+      () => document.documentElement.scrollHeight
+    )
+    expect(pageScrollHeight).toBeLessThanOrEqual(VIEWPORT.height)
+
+    const viewportBox = await page.locator("#session-viewport").boundingBox()
+    expect(viewportBox).not.toBeNull()
+    // Bounded well under the activity's natural size - V, not the
+    // activity's content, decided the rendered height.
+    expect(viewportBox!.height).toBeLessThan(ACTIVITY_HEIGHT / 2)
+
+    // The oversized activity is still there, just clipped by its bounded
+    // ancestor rather than pushing the page taller.
+    const activityHeight = await page.evaluate(
+      () => document.getElementById("activity")!.getBoundingClientRect().height
+    )
+    expect(activityHeight).toBeGreaterThan(viewportBox!.height)
+  })
+
+  test("before #695 (sanity): the same oversized activity grows the whole page", async ({
+    page,
+  }) => {
+    await loadShell(page, "before")
+
+    const pageScrollHeight = await page.evaluate(
+      () => document.documentElement.scrollHeight
+    )
+    // Proves the fixture is meaningful: without the fix, nothing in the
+    // ancestor chain has a definite height, so flex-grow never resolves
+    // against a fixed V - the whole document grows to fit the activity.
+    expect(pageScrollHeight).toBeGreaterThan(VIEWPORT.height)
+  })
+})

--- a/docs/session-viewport/01-overflow-doctrine-and-audit.md
+++ b/docs/session-viewport/01-overflow-doctrine-and-audit.md
@@ -1,0 +1,114 @@
+# The "never overflow-scroll" doctrine, and an audit of every current offender
+
+> Doctrine + audit for epic #693, story 1 (#694). Motivates #692. Read this
+> before touching the layout engine or the player - it defines the invariant
+> every later story in the epic is implementing or hardening, and lists
+> every place in the repo that currently violates it, with file:line.
+
+## The invariant
+
+> For every leaf rect `R` in `solve(Layout(t), V)`, the content bound to `R`
+> is rendered such that its painted box is `⊆ R`. If the content's natural
+> box exceeds `R`, the leaf MUST resolve it by a **sanctioned** strategy
+> (clip + focus, or temporal rotation - #693 §5), never by
+> `overflow: auto|scroll` on the leaf or any ancestor up to `V`.
+
+`V` (the session viewport's rect) is fixed. A leaf's content may have an
+arbitrary natural size. The forbidden resolution is letting that content
+grow the box past `R` and handing the user a scrollbar - whether on the
+leaf itself or on some ancestor between the leaf and `V`.
+
+### The escalation ladder (allowed resolutions, in priority order)
+
+1. **Spatial (cheap):** resize / refocus - grow the focused leaf, shrink
+   siblings, via the weighted solver + intents
+   (`packages/ui/wireframes/src/lib/layout-weighted.ts#solveLayoutWithFocus`).
+   Already built.
+2. **Temporal (when spatial isn't enough):** the leaf becomes a
+   time-multiplexed viewport - rotate through `[1, N)` content members
+   (`packages/ui/dice-card`, `packages/ui/slideshow`). Primitive already
+   built, not yet wired into the leaf renderer (story 6, #699).
+3. **Structural (exogenous):** keybindings mutate `Layout(t)` - toggle a
+   whole subtree in/out, or cycle a preset (stories 7-8, #700/#701).
+
+## Two decisions this story is responsible for recording
+
+### 1. The "focused leaf may scroll" nuance
+
+"Never scroll" is too strong for genuinely linear content (a long
+transcript, a chat log). The doctrine adopted here:
+
+> **An unfocused leaf must never scroll. A focused/maximized leaf may
+> scroll internally, because the user explicitly asked for that leaf to
+> take priority over the rest of `V`.**
+
+This is the honest reading of "never _unbounded_ scroll" - the invariant
+protects the _unattended_ layout from silently growing past its rect; it
+does not forbid a human-driven, single-leaf reading mode. Stories 6 and 7
+should treat a focused leaf's internal scroll as a legitimate fourth rung
+on the ladder, gated on focus, not as a doctrine violation.
+
+### 2. The overlay-plane exemption
+
+Toasts and any future command palette / modal are **not** part of
+`Layout(t)`. They live on a separate, ephemeral **overlay plane** that
+paints above `V` rather than tiling it. Evidence this is already the de
+facto model, not a new invention: `apps/www/src/components/toaster.tsx`
+mounts `ToastProvider`/`ToastViewport` as a sibling of `SidebarProvider`'s
+children in `routes/_dashboard.tsx`, not as a registry-bound leaf.
+
+Consequence named explicitly because stories 5 and 7 depend on it: "toggle
+sidebar via keybinding" is a **tree operation** (a command that mutates
+`Layout(t)`), while "open command palette" is an **overlay operation**
+(a command that mounts something on the overlay plane). They are two
+different mechanisms dispatched from the same command layer, not one.
+
+## The audit: every current overflow surface, file:line
+
+### Forbidden (page/ancestor-level scroll a leaf's content can trigger)
+
+| File:line                                                             | What it does                                                                                                                                                                                                              | Status                                                                                                                                                                                                                                    |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/www/src/routes/_dashboard.tsx:99-106` (was line 84 before #695) | Outlet wrapper: `overflow-auto` for every route, including the player route, with no bound on any ancestor above it (`SidebarProvider`/`SidebarInset` only set `min-h-svh`, never a definite `height`)                    | **Fixed by #695** for the player route only (`/sessions/$sessionId`) - see `02-kill-the-cutoff.md`. Still the correct, intentional behavior for the CRUD routes (profile/settings/sessions list), which are ordinary scrolling documents. |
+| `apps/www/src/components/player/session-viewport.tsx:12`              | `min-h-[680px]` - a magic floor decoupled from the activity's actual needs, so an activity taller than 680px overflowed _inside_ the (also `overflow-hidden`) box before the ancestor chain even had a chance to bound it | **Fixed by #695** - replaced with `min-h-0`, letting the flex chain give it the real available height.                                                                                                                                    |
+| `apps/www/src/components/player/live-player.tsx:81`                   | `flex h-full min-h-0 w-full flex-col gap-4` stacking `SessionViewport`/`NowNextStrip`/`TransportControls` with no bound reconciling them against `V`                                                                      | Structurally correct (`h-full` + `min-h-0`) but was inert before #695, because nothing above it in the ancestor chain had a _definite_ height for `h-full` to resolve against. Now load-bearing.                                          |
+
+### Sanctioned (the reference clip pattern)
+
+| File:line                                                          | What it does                                                                                                                                                                                               |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/ui/wireframes/src/components/render-solved/index.tsx:47` | Each solved leaf is `position: absolute` with an explicit pixel `width`/`height` and `overflow-hidden` - clip-to-rect, no scroll. **This is the pattern every future leaf-content strategy should match.** |
+
+### Out of scope of the invariant (not part of `Layout(t)`)
+
+| File:line                                                   | What it does                                                                                                                                                          | Why it's exempt                                                                                                                                                                                                                                                                                                                   |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/www/src/components/composer/arrangement-step.tsx:182` | `overflow-x-auto` wrapping `<LayoutEditor />` at a fixed `min-w-[1280px]`, inside a `Collapsible` explicitly labeled "exploration only, does not change your session" | This is an _authoring canvas_ in the composer wizard, not a rendered leaf of a live `V`. It's a design-time tool that happens to be wider than its container - ordinary editor-canvas scroll, not the invariant's target. Story 3 (#696) may give it a real destination; until then it's correctly out of scope, not a violation. |
+| `apps/www/src/components/toaster.tsx` (whole component)     | Mounts `ToastViewport` (a fixed-position overlay) as a `SidebarProvider` sibling                                                                                      | Overlay plane, per the decision above.                                                                                                                                                                                                                                                                                            |
+
+### Known offenders inside activity content (registry components)
+
+Not overflow-_surfaces_ in the layout-tree sense, but activity components
+bound into the leaf that assume they own the _entire_ viewport rather than
+a bounded rect handed to them - the concrete form "which activities assume
+unbounded height" takes. Full list and what it means for story 6 is in
+`02-kill-the-cutoff.md`; flagged here because it's the same grep sweep as
+the rest of this audit:
+
+- `packages/ui/interview/src/components/mock-interview/interview-app/index.tsx:34`
+  and 7 sibling files under `mock-interview/` - `min-h-screen`.
+- `packages/ui/honeycomb/src/components/hangul-hex-grid/{error,loading}-state/index.tsx`
+  and `song-hex-grid/song-overlay/index.tsx:220` - `h-screen`.
+- `packages/ui/umag/src/components/voice-ui/avatar/index.tsx:91` - `min-h-screen`.
+
+## What every downstream story can assume
+
+- The invariant text above is the thing to point a test at; #695's
+  `apps/www/tests/session-viewport/no-overflow-scroll.spec.ts` is the first
+  such test.
+- A leaf may scroll **iff** it is the focused/maximized leaf; an unfocused
+  leaf never may.
+- Toasts, command palettes, and modals are overlay-plane, never tree nodes
+  - stories 5/7 dispatch to two different mechanisms, not one.
+- The composer's `LayoutEditor` canvas scroll is intentionally out of
+  scope; it is not evidence of a doctrine violation.

--- a/docs/session-viewport/02-kill-the-cutoff.md
+++ b/docs/session-viewport/02-kill-the-cutoff.md
@@ -1,0 +1,107 @@
+# Kill the cutoff: findings from making the player route measure a real V
+
+> Findings for epic #693, story 2 (#695). Directly resolves the visible
+> symptom in #692. Read `01-overflow-doctrine-and-audit.md` first for the
+> invariant this story is the first real implementation of.
+
+## What changed
+
+The session viewport was rendering into an `overflow-hidden` box whose
+height came from a magic `min-h-[680px]`, sitting inside a dashboard shell
+that let the whole page scroll (`overflow-auto` on the route outlet, with
+no ancestor above it ever having a _definite_ `height` - only `min-h-svh`
+floors everywhere). An activity taller than 680px overflowed inside the
+box; an activity that also blew past its ancestors' `min-height` floors
+grew the entire page. Neither is `V` - `V` was never actually bounded.
+
+Three files now form one deliberate, definite-height flex chain from the
+sidebar shell down to the leaf, scoped to the player route only:
+
+- `apps/www/src/routes/_dashboard.tsx` - the outlet wrapper (and
+  `SidebarProvider` above it) get `h-svh overflow-hidden` /
+  `min-h-0 overflow-hidden` **only** when the active route is
+  `/_dashboard/sessions/$sessionId`. Every other route keeps its original
+  `overflow-auto`, unmodified.
+- `apps/www/src/components/player/live-player.tsx` - unchanged
+  (`h-full min-h-0 flex-col`); it was always structurally correct, just
+  starved of a definite ancestor height to resolve `h-full` against.
+- `apps/www/src/components/player/session-viewport.tsx` - the magic
+  `min-h-[680px]` floor is gone, replaced with `min-h-0` so the box takes
+  exactly whatever `V` actually is.
+
+`OrchestratedYouTubeViewport` already measured via `useContainerRect()`
+and already clipped via `RenderSolved` (`packages/ui/wireframes`) - the
+engine's own machinery needed no changes. The bug was entirely in the
+app's ancestor chain never giving that machinery a real, bounded rect to
+measure.
+
+Regression coverage:
+`apps/www/tests/session-viewport/no-overflow-scroll.spec.ts` mirrors this
+exact CSS chain as a static fixture (see the file header for why it's a
+mirror rather than a full app boot) and pins two things: an oversized
+activity is clipped without growing the page (the fix), and the same
+fixture _without_ the fix reproduces the page growing past `V` (proves the
+test is meaningful).
+
+## Decision: the route-scope split
+
+Removing page-level scroll unconditionally would have broken the CRUD
+routes (`/profile`, `/settings`, `/sessions`, `/`), which are legitimately
+ordinary scrolling documents - a long settings form or a long session list
+_should_ scroll the page. The fix is therefore route-scoped, not global:
+
+> **The player route (`/sessions/$sessionId`) is a fixed-`V` surface.
+> Every other route under `/_dashboard` remains an ordinary scrolling
+> document.**
+
+Implemented as `isViewportPath()` (a pathname regex matching
+`/sessions/<id>` but excluding `/sessions/new`) checked against
+`useRouterState`'s pathname selector, already read once per render for nav
+highlighting, in `_dashboard.tsx` - rather than a second route layout or a
+prop threaded through the tree. The shell has exactly one place that
+decides "does this route own `V`," and it's legible at a glance. Story 5
+(#698, chrome-as-layout-nodes) will likely want to move this decision into
+the layout tree itself (a shell-tree leaf's presence, not a pathname
+check); until that lands, this is the smallest correct version of the
+split.
+
+Loading/error states for the player route (`PlayerSkeleton`,
+`SessionNotFound`, `DraftGuard` in
+`apps/www/src/routes/_dashboard/sessions/$sessionId.tsx`) render inside
+the same bounded, non-scrolling box, since they share the route id. They're
+small, top-aligned cards, so this is a non-issue in practice - noted here
+so it isn't a surprise later.
+
+## Finding: which activity components assume unbounded height
+
+Story 2's honest deliverable is "content is now bounded and clipped," not
+"content now fits." Grepping every component reachable through
+`@some-ui/content-registry`'s `componentRegistry`
+(`packages/some-content-registry/src/registry/index.ts`) for
+`min-h-screen` / `h-screen` / `100vh` turned up real offenders - components
+that assume they own the _entire_ browser viewport, not the bounded rect
+`V` (or a leaf of it) actually hands them:
+
+- **`@some-ui/interview` → `InterviewApp`** (registry key `interview`).
+  `mock-interview/interview-app/index.tsx:34` (`min-h-screen`) and seven
+  sibling state screens (`welcome-screen`, `session-complete`,
+  `recording-phase`, `question-playback`, `review-phase` ×3,
+  `preparation-phase`) all use `min-h-screen` to center their content.
+  Inside a clipped leaf shorter than the viewport, these will be
+  vertically cropped rather than centered.
+- **`@some-ui/honeycomb` → `HangulHexGrid`** (registry key `hangul`).
+  `hangul-hex-grid/{error,loading}-state/index.tsx` and
+  `song-hex-grid/song-overlay/index.tsx:220` use `h-screen` (not even
+  `min-`) directly.
+- **`@some-ui/umag` → `VoiceAvatar`** (registry key `voice`).
+  `voice-ui/avatar/index.tsx:91` uses `min-h-screen`.
+
+This is exactly the "truncation is now visible/measurable" outcome story 2
+called out as the honest framing rather than overselling the fix: these
+three registry components will visibly crop today, in a way they didn't
+before (before, they just pushed the whole page taller, hiding the problem
+behind a scrollbar instead of showing it). That's the correct trade per
+the doctrine (clip, don't scroll) - the real fix is story 6 (#699, temporal
+overflow), which is exactly the story this finding was logged to feed.
+Not actioned here: story 2 is deliberately the wedge, not the resolution
+for these three components.


### PR DESCRIPTION
## Description

Recon + landing pass on epic #693 (`[1, 9)`). Of the eight stories under the epic, only **story 1** (#694, the doctrine + audit) and **story 2** (#695, kill the cutoff) are tractable to land independently right now — they were explicitly written as a paired wedge ("the smallest fix for #692"). Stories 3-8 (#696-#701) each require an architectural decision recorded as part of their own acceptance criteria (scene-owned vs session-owned layout trees, the slot-registry vocabulary, chrome-as-nodes, temporal overflow, keybindings, presets) and cascade off each other's decisions — none of them are landable as an isolated, reviewable diff without first resolving story 3's tree-ownership question. Left open for follow-up PRs once those decisions are made.

**What's in this PR:**

The session viewport never actually measured a bounded rect. `SessionViewport` had a magic `min-h-[680px]` floor, and the dashboard shell had a page-level `overflow-auto` with no ancestor above it ever given a *definite* height (only `min-h-svh` floors everywhere) — so a tall activity either overflowed inside the box, or blew past every `min-height` floor and grew the whole page. That's the `#692` symptom.

The player route (`/sessions/$sessionId`) now gets a definite-height, non-scrolling shell (`h-svh` + `overflow-hidden`, applied only on that route via a pathname check in `_dashboard.tsx`) so the layout engine's existing measure-and-clip machinery (`useContainerRect` + `RenderSolved`, both already in `packages/ui/wireframes`, unchanged) actually receives a real `V`. Every other route (`/`, `/sessions`, `/profile`, `/settings`) keeps its original scrolling-document behavior, unchanged.

Also lands the doctrine story: the "never overflow-scroll" invariant stated precisely, the escalation ladder, two recorded decisions (a focused leaf may scroll; toasts/palettes live on a separate overlay plane), a full audit of every current overflow surface with file:line, and findings on which registry activity components (`InterviewApp`, `HangulHexGrid`, `VoiceAvatar`) assume they own the entire browser viewport — feeding story 6's temporal-overflow work directly.

Docs: `docs/session-viewport/01-overflow-doctrine-and-audit.md`, `docs/session-viewport/02-kill-the-cutoff.md`.

Closes #694
Closes #695

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (typecheck + eslint clean)
- [x] I have added tests that prove my fix is effective (`apps/www/tests/session-viewport/no-overflow-scroll.spec.ts` — includes a "before" sanity case proving the fixture would have caught the original bug)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (n/a)

## Verification

Typecheck, eslint, and the full `vitest` suite (26 tests) pass. The new Playwright spec passes (2/2), including the sanity case that reproduces the pre-fix page-level scroll on the same fixture.

Also drove the **real app** end-to-end: started the dev server, walked the actual composer wizard to create and play an "Interview Prep" session (`InterviewApp`, one of the flagged `min-h-screen` offenders) — confirmed `document.documentElement.scrollHeight === window.innerHeight` (no page scroll) and that a CRUD route (`/sessions` list) still has `overflow: auto` on its outlet, unaffected.
