### PR TITLE
fix(storybook): pin explicit build target to fix production build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -121,6 +121,18 @@ const config: StorybookConfig = {
       allowedHosts: ["nixos.local", "localhost", "127.0.0.1"],
     }
 
+    // Pin an explicit build target. vite-plugin-top-level-await (pulled in via
+    // the root vite.config.ts, which Storybook auto-loads from the workspace
+    // root) falls back to a hardcoded legacy target list — including
+    // "safari14" — whenever build.target is unset. esbuild 0.28.1 can no
+    // longer downlevel destructuring for that exact "safari14" marker
+    // (regression), which breaks `storybook build` repo-wide. Matches
+    // tsconfig.json's ES2022 target.
+    config.build = {
+      ...config.build,
+      target: "es2022",
+    }
+
     // UnoCSS preset utilities for the @some-ui/styles catalog. Scoped via
     // .storybook/uno.config.ts to the .storybook/ files only, so it adds the
     // catalog's utilities without altering how other stories render.


### PR DESCRIPTION
## Description

`pnpm build-storybook` (production Storybook build) failed repo-wide with:

```
[plugin vite-plugin-top-level-await]
Error: Transform failed with 13 errors:
:12:21: ERROR: Transforming destructuring to the configured
target environment ("chrome87", "edge88", "es2020", "firefox78",
"safari14") is not supported yet
```

**Root cause:** Storybook's `@storybook/builder-vite` auto-loads the workspace root's `vite.config.ts` (via `loadConfigFromFile`, since `.storybook`'s parent is the project root) and merges its plugins into the storybook build — including `vite-plugin-top-level-await`, which is really only meant for this repo's own library bundle output, not Storybook.

That plugin's `config()` hook falls back to a hardcoded legacy target list (`es2020, edge88, firefox78, chrome87, safari14`) whenever `build.target` isn't explicitly set, then re-transforms the final bundle down to that target with esbuild. I isolated the actual failure with a minimal repro: `esbuild@0.28.1` (the version resolved via `vite@8.1.4`'s peer range) can no longer downlevel-transform destructuring specifically for the `safari14` target marker — it works for `safari14.1`, `es2022`, and every other target tested. This is a version-compat regression between the two third-party packages, not application code.

**Fix:** explicitly pin `build.target` to `"es2022"` (matching this repo's `tsconfig.json` target) inside `.storybook/main.ts`'s `viteFinal`, so `vite-plugin-top-level-await` never falls back to the broken legacy list.

Fixes #732

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Verification

Reproduced the exact failure first, then confirmed the fix resolves it:
- `STORYBOOK_WORKSPACE=some-filter pnpm exec storybook build` — now succeeds
- `STORYBOOK_WORKSPACE=filter-classifier pnpm exec storybook build` — now succeeds
- Full repo-wide `pnpm exec storybook build` (all workspaces) — now succeeds
- `tsc --noEmit` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_017ENpDqjhdZHZLTHhvAJiqN)_