### PR TITLE
test(filter): prove #741's classifier and auto-theme defects with failing e2e tests

### DIFF
--- a/extensions/filter-classifier/package.json
+++ b/extensions/filter-classifier/package.json
@@ -33,6 +33,7 @@
     "lint": "pnpm lint:js && pnpm prettier && pnpm typecheck",
     "lint:js": "eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
     "prettier": "prettier \"**/*.{js,mjs,ts,tsx,md,mdx,json,yml,css}\" --ignore-path $(git rev-parse --show-toplevel)/.prettierignore --check --cache",
+    "test:claude:e2e": "bash scripts/claude-e2e.sh",
     "test:e2e": "playwright test --config playwright.config.ts",
     "test:e2e:headed": "playwright test --config playwright.config.ts --headed",
     "test:e2e:ui": "playwright test --config playwright.config.ts --ui",

--- a/extensions/filter-classifier/scripts/claude-e2e.sh
+++ b/extensions/filter-classifier/scripts/claude-e2e.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# playwright.config.ts only overrides executablePath when
+# PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH is set — otherwise Playwright resolves
+# its own managed browser for the installed @playwright/test version, which
+# in Claude Code's remote sandbox means a chrome-headless-shell revision that
+# was never downloaded (only a plain Chromium build is pre-installed there,
+# under $PLAYWRIGHT_BROWSERS_PATH). Point at that pre-installed Chromium
+# instead, so `pnpm test:claude:e2e` works there without touching the
+# `pnpm test:e2e` default every other environment already works with.
+
+if [ -n "${PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH:-}" ]; then
+  : # already set — respect it
+elif [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ -x "${PLAYWRIGHT_BROWSERS_PATH}/chromium" ]; then
+  export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="${PLAYWRIGHT_BROWSERS_PATH}/chromium"
+else
+  echo "[FILTER-CLASSIFIER] test:claude:e2e needs a pre-installed Chromium binary." >&2
+  echo "Set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH, or run this somewhere that" >&2
+  echo "exposes one via \$PLAYWRIGHT_BROWSERS_PATH/chromium (e.g. Claude" >&2
+  echo "Code's remote sandbox). Elsewhere, use:" >&2
+  echo "  pnpm test:e2e" >&2
+  exit 1
+fi
+
+exec playwright test --config playwright.config.ts "$@"

--- a/extensions/filter-classifier/src/comfort-lab/ComfortFixture.stories.tsx
+++ b/extensions/filter-classifier/src/comfort-lab/ComfortFixture.stories.tsx
@@ -107,3 +107,11 @@ export const TransparentAmbiguous: Story = {
 export const NeonTextModerateSurface: Story = {
   render: () => <ComfortLabStory fixtureId="neon-text-moderate-surface" />,
 }
+
+export const FilterInvertReadsDark: Story = {
+  render: () => <ComfortLabStory fixtureId="filter-invert-reads-dark" />,
+}
+
+export const FilterInvertReadsLight: Story = {
+  render: () => <ComfortLabStory fixtureId="filter-invert-reads-light" />,
+}

--- a/extensions/filter-classifier/tests/e2e/fixtures/corpus.ts
+++ b/extensions/filter-classifier/tests/e2e/fixtures/corpus.ts
@@ -57,6 +57,20 @@ export type HumanLabel =
   | "borderline"
   /** No explicit background anywhere — theme-detector.ts's own documented "unknown == probably light" bias applies. */
   | "ambiguous"
+  /**
+   * The page's true light/dark state is masked by a CSS `filter` (its own,
+   * or — in the live extension — some-filter's own "legacy" invert style)
+   * that inverts what a human sees without changing any `background-color`
+   * `detect()`/`classifyPage()`/`sampleBodyComfort()` read (#741). Declared
+   * colors say one thing; the rendered page says the opposite. Comfort is
+   * deliberately left unevaluated (`expectComfortable: null`) rather than
+   * guessed at: `sampleBodyComfort()` samples the same raw, un-inverted
+   * `getComputedStyle` pair `detect()` does, so it isn't judging the
+   * rendered page any more than `detect()` is — asserting a comfort verdict
+   * here would silently trade one filter-blind reading for another instead
+   * of naming the gap.
+   */
+  | "filter-masked"
 
 export type CorpusFixture = {
   readonly id: string
@@ -303,6 +317,91 @@ export const CORPUS: ReadonlyArray<CorpusFixture> = [
     <main style="background-color: rgb(28, 28, 32); padding: 16px">
       <h1>Changelog</h1>
       <p>Every line of body copy here is set in the same searing near-yellow — no badges, no accents, just paragraph after paragraph bright enough to read like a screen left on max brightness in the dark.</p>
+    </main>
+  </body>
+</html>`,
+  },
+
+  {
+    id: "filter-invert-reads-dark",
+    grammar: "filter-invert-light-canvas-reads-dark",
+    label: "filter-masked",
+    note:
+      "some-filter's own 'legacy' style (theme-apply.ts's applyLegacyFilter) " +
+      "themes a page by putting a global `filter: invert(...)` on <html> " +
+      "rather than recoloring anything — and real vendor pages use the exact " +
+      "same trick natively (an accessibility 'invert colours' toggle some " +
+      "sites ship themselves). This fixture is the plainest instance: a " +
+      "literal copy of 'plain-light-card' (rgb(255,255,255) canvas, " +
+      "rgb(17,24,39) text) with one line added — `html { filter: invert(1) " +
+      "}`. To a human looking at the rendered page (or a screenshot), the " +
+      "canvas is black and the text is off-white: a genuinely, comfortably " +
+      "dark page, needing no theming at all. `detect()`/`classifyPage()` " +
+      "(theme-detector.ts) never read `getComputedStyle(el).filter` — only " +
+      "raw `backgroundColor` — so today they report this fixture exactly as " +
+      "they report 'plain-light-card' itself: isLight=true, alreadyDark=" +
+      "false. #741's 'guilty until innocent': the classifier must presume " +
+      "correctly even under a global CSS filter it never inspects, not just " +
+      "on the un-filtered fixtures the corpus happened to start with.",
+    expectAlreadyDark: true,
+    expectComfortable: null,
+    html: () => `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Filter Invert Reads Dark</title>
+    <style>
+      html {
+        filter: invert(1);
+      }
+    </style>
+  </head>
+  <body style="background-color: rgb(255, 255, 255); color: rgb(17, 24, 39); margin: 0">
+    <main style="background-color: rgb(255, 255, 255); padding: 16px">
+      <h1>Looks dark to any human, or any screenshot</h1>
+      <p>Declared colors are the same plain light card — only a page-wide filter: invert(1) on &lt;html&gt; separates this from 'plain-light-card'.</p>
+    </main>
+  </body>
+</html>`,
+  },
+
+  {
+    id: "filter-invert-reads-light",
+    grammar: "filter-invert-dark-canvas-reads-light",
+    label: "filter-masked",
+    note:
+      "The inverse of 'filter-invert-reads-dark', and the sharper of the two " +
+      "cases: declared colors are a plain dark canvas (rgb(20,20,20) bg, " +
+      "rgb(230,230,230) text — the same shape 'dark-hostile-page' e2e fixture " +
+      "uses) wrapped in the same page-authored `html { filter: invert(1) }`. " +
+      "Inverting a near-black canvas with near-white text renders a near-" +
+      "white canvas with near-black text — an ordinary, unthemed-looking " +
+      "light page that genuinely needs theming, wearing dark *declared* " +
+      "colors purely as an artifact of the filter trick. `detect()` samples " +
+      "raw backgroundColor only, sees the dark declared value, and reports " +
+      "alreadyDark=true — exactly backwards. This is the classifier-level " +
+      "shape of the live pipeline's worse failure (extensions/some-filter's " +
+      "own filter-invert e2e spec, #741): if `alreadyDark` reports true for " +
+      "a page a human would call light, the live pipeline withholds theming " +
+      "entirely and the page's true (post-invert, bright) vendor background " +
+      "stays fully exposed — 'guilty' read as 'innocent'.",
+    expectAlreadyDark: false,
+    expectComfortable: null,
+    html: () => `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Filter Invert Reads Light</title>
+    <style>
+      html {
+        filter: invert(1);
+      }
+    </style>
+  </head>
+  <body style="background-color: rgb(20, 20, 20); color: rgb(230, 230, 230); margin: 0">
+    <main style="background-color: rgb(20, 20, 20); padding: 16px">
+      <h1>Looks light to any human, or any screenshot</h1>
+      <p>Declared colors are a plain dark canvas — only a page-wide filter: invert(1) on &lt;html&gt; separates this from an ordinary dark-hostile page, and it renders the opposite of what it declares.</p>
     </main>
   </body>
 </html>`,

--- a/extensions/some-filter/package.json
+++ b/extensions/some-filter/package.json
@@ -60,6 +60,7 @@
     "prettier": "prettier . --ignore-path $(git rev-parse --show-toplevel)/.prettierignore --check --cache",
     "prettier:fix": "prettier . --write",
     "test": "vitest",
+    "test:claude:e2e": "bash scripts/claude-e2e.sh",
     "test:e2e": "pnpm build:chromium && playwright test",
     "test:e2e:debug": "pnpm build:chromium && playwright test --debug",
     "test:e2e:headed": "pnpm build:chromium && playwright test --headed",

--- a/extensions/some-filter/scripts/claude-e2e.sh
+++ b/extensions/some-filter/scripts/claude-e2e.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# some-filter's e2e fixture (tests/e2e/fixture.ts) launches Chromium via
+# PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH, normally set by `nix develop
+# .#playwright` (nix/playwright/default.nix). Claude Code's remote sandbox
+# has no Nix shell, but it does pre-install its own Playwright browser cache
+# at $PLAYWRIGHT_BROWSERS_PATH. This script points the fixture at that
+# browser instead, so `pnpm test:claude:e2e` works there without touching
+# the Nix-gated `pnpm test:e2e` default the rest of the team uses.
+
+if [ -n "${PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH:-}" ]; then
+  : # already set (e.g. inside `nix develop .#playwright`) — respect it
+elif [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ -x "${PLAYWRIGHT_BROWSERS_PATH}/chromium" ]; then
+  export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="${PLAYWRIGHT_BROWSERS_PATH}/chromium"
+else
+  echo "[FILTER] test:claude:e2e needs a pre-installed Chromium binary." >&2
+  echo "Set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH, or run this somewhere" >&2
+  echo "that exposes one via \$PLAYWRIGHT_BROWSERS_PATH/chromium (e.g." >&2
+  echo "Claude Code's remote sandbox)." >&2
+  echo "" >&2
+  echo "For the human/Nix workflow, use instead:" >&2
+  echo "  nix develop .#playwright" >&2
+  echo "  pnpm test:e2e" >&2
+  exit 1
+fi
+
+pnpm build:chromium
+exec playwright test "$@"

--- a/extensions/some-filter/tests/e2e/fixtures/filter-invert-vendor-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/filter-invert-vendor-page.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<!--
+  Filter-invert vendor page (#741). Plain, ordinary light page — the exact
+  shape light-page.html already uses — with one line added: `html { filter:
+  invert(1) }`, the same trick some-filter's own "legacy" style
+  (theme-apply.ts's applyLegacyFilter) uses deliberately, and a pattern real
+  vendor sites ship natively as their own accessibility "invert colours"
+  toggle.
+
+  Auto mode never inspects a page's own `filter` — pipeline.ts's readAttr()
+  reads only raw getComputedStyle().backgroundColor. This page's *declared*
+  colors are plain light (rgb(255, 255, 255) bg), so the pipeline correctly
+  decides to theme it. But injectDarkTheme() only ever overrides *declared*
+  colors (`background-color: var(--sw-bg-0) !important` etc.) — it never
+  touches or removes a pre-existing vendor `filter`. The vendor's own
+  invert(1) stays active as an ancestor filter over the whole subtree, so
+  the *rendered* result is the dark theme's own tokens inverted right back
+  toward a bright canvas: the auto pipeline's own remedy is what defeats it.
+  See specs/issue-741-auto-defects.spec.ts for the proof.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Filter Invert Vendor Page Fixture</title>
+    <style>
+      html {
+        filter: invert(1);
+      }
+    </style>
+  </head>
+  <body style="background-color: rgb(255, 255, 255); margin: 0">
+    <main style="background-color: rgb(255, 255, 255); padding: 16px">
+      <h1>Vendor page with its own invert-based "dark mode"</h1>
+      <p>
+        No some-filter involvement here — just an ordinary light page wearing a
+        page-authored filter: invert(1) on &lt;html&gt;.
+      </p>
+    </main>
+  </body>
+</html>

--- a/extensions/some-filter/tests/e2e/fixtures/gradient-leak-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/gradient-leak-page.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<!--
+  Gradient-leak page (#741). A <div> themed entirely via `background-image`
+  (a light linear-gradient), with no `background-color` at all — an ordinary
+  vendor pattern (a hero banner, a card with a subtle sheen) that some-filter
+  has no path to ever see.
+
+  Both pipeline.ts's readAttr() (the live per-surface Sensor) and
+  theme-detector.ts's classifyPage() sample only
+  getComputedStyle(el).backgroundColor — neither reads backgroundImage.
+  #gradient-card's backgroundColor computes to "rgba(0, 0, 0, 0)" (nothing
+  declared), which color.ts's parseColor treats as no sample at all — the
+  exact same value an element with no background whatsoever would produce.
+  The element is invisible to classification: never becomes a SurfaceKey,
+  never gets `data-sw-patched`, never gets an emit-surface-color rule. Its
+  light gradient — fully opaque, so it fully covers whatever dark canvas
+  sits behind it — renders completely untouched, a bright rectangle on the
+  otherwise-dark page. See specs/issue-741-auto-defects.spec.ts for the
+  proof.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Gradient Leak Page Fixture</title>
+  </head>
+  <body style="background-color: rgb(255, 255, 255); margin: 0">
+    <main style="background-color: rgb(255, 255, 255); padding: 16px">
+      <h1>Ordinary page, one gradient banner</h1>
+      <div
+        id="gradient-card"
+        style="
+          background-color: transparent;
+          background-image: linear-gradient(
+            to bottom,
+            rgb(255, 255, 255),
+            rgb(238, 238, 238)
+          );
+          padding: 16px;
+        "
+      >
+        Banner styled with only a light background-image gradient — no
+        background-color anywhere on it.
+      </div>
+    </main>
+  </body>
+</html>

--- a/extensions/some-filter/tests/e2e/fixtures/text-contrast-gap-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/text-contrast-gap-page.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<!--
+  Text-contrast-gap page (#741). A light <div> card carrying its own inline
+  dark text color — a completely ordinary vendor pattern (a light card with
+  dark body copy), but on a tag buildDarkThemeCSS's text-color layer never
+  covers.
+
+  theme-apply.ts's buildDarkThemeCSS forces `color` on a fixed allowlist of
+  tags — h1-h6, p/span/label/caption/figcaption/blockquote/cite/li/dt/dd,
+  small/sub/sup/abbr/time, a, code/kbd/samp, pre, th/td, input/textarea/select,
+  dialog/[popover] — and nothing else. Plain <div> is not on that list, and
+  the actuator's own per-surface pipeline (adapter/contracts.ts's
+  FilterAction alphabet) has no foreground/text counterpart to
+  `emit-surface-color` at all — only backgrounds are ever recolored per
+  surface (adapter/actuator.ts's `realize`, theme-adapter.ts's `decide`).
+  `modifyForegroundColor` (lib/content/modify-colors.ts) exists and is unit
+  tested, but nothing in the live pipeline calls it.
+
+  #card's own background (rgb(255, 255, 255), luminance 1.0) clears
+  LIGHT_THRESHOLD (0.3, theme-adapter.ts) and gets tagged "surface" +
+  hue-preserving-darkened via modifyBackgroundColor — which, for an
+  achromatic white input (h=0, s=0, l=1), lands at HSL(0, 0%, 8%) ≈
+  rgb(20, 20, 20) (BG_DARK_MIN, modify-colors.ts). #card's own inline
+  `color: rgb(20, 20, 20)` — chosen to be readable against its *original*
+  white background — is left completely untouched. The two coincide exactly:
+  after theming, #card's background and its own text resolve to the same
+  literal rgb(20, 20, 20), a contrast ratio of 1:1 — not merely "hard to
+  read," but exactly the same pixel color as its background. See
+  specs/issue-741-auto-defects.spec.ts for the proof.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Text Contrast Gap Page Fixture</title>
+  </head>
+  <body style="background-color: rgb(255, 255, 255); margin: 0">
+    <main style="background-color: rgb(255, 255, 255); padding: 16px">
+      <h1>Ordinary page, one plain light card</h1>
+      <div
+        id="card"
+        style="
+          background-color: rgb(255, 255, 255);
+          color: rgb(20, 20, 20);
+          padding: 16px;
+        "
+      >
+        Body copy set directly on a &lt;div&gt;, dark-on-light as authored — no
+        p/span/label wrapper.
+      </div>
+    </main>
+  </body>
+</html>

--- a/extensions/some-filter/tests/e2e/specs/issue-741-auto-defects.spec.ts
+++ b/extensions/some-filter/tests/e2e/specs/issue-741-auto-defects.spec.ts
@@ -80,6 +80,89 @@ test.describe("auto theme under a vendor-authored filter: invert (#741)", () => 
   })
 })
 
+// ── prepaint veil poisoned by a previously-applied filter, across a new session ──
+
+test.describe("the prepaint veil under a previously-applied filter, across a new session (#741)", () => {
+  test("a second (SPA-navigation) session's anti-flash veil composites bright, not dark, while the page's own filter is still active", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("filter-invert-vendor-page")
+    await waitForClassification(page)
+    await page.waitForTimeout(300)
+
+    // Precondition: the first session already themed this page (established
+    // by the sibling test above) — autoWasApplied is exactly what gates
+    // content.ts's yt-navigate-finish handler below.
+    const firstSession = await page.evaluate(
+      () => document.body.dataset["swThemeApplied"]
+    )
+    expect(firstSession).toBe("dark")
+
+    // content.ts's yt-navigate-finish listener is a plain window event
+    // listener, not scoped to youtube.com — dispatching it here simulates an
+    // SPA-style re-navigation within the same document. It resets the
+    // content session's epoch (sessionLifecycle.resetContent(), the
+    // codebase's own "new session" boundary — Definition 5.4/Theorem D.1(a))
+    // and re-arms the veil via enablePrepaint(), synchronously followed by a
+    // fresh rescan()/decide()/realize() round. Everything here happens
+    // inside one page.evaluate() call so the veil's computed background is
+    // sampled before commitVisualState()'s requestAnimationFrame pair can
+    // tear it back down — the veil removal is scheduled, not synchronous.
+    const veil = await page.evaluate(() => {
+      window.dispatchEvent(new Event("yt-navigate-finish"))
+      const el = document.getElementById("__sw_prepaint_veil")
+      return {
+        present: el !== null,
+        bg: el ? getComputedStyle(el).backgroundColor : null,
+      }
+    })
+
+    expect(
+      veil.present,
+      "the new session should re-arm the anti-flash veil (enablePrepaint())"
+    ).toBe(true)
+
+    const veilBg = veil.bg ?? ""
+    const match = veilBg.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/)
+    if (match === null) {
+      throw new Error(`unparseable veil background: ${veilBg}`)
+    }
+    const [, rStr, gStr, bStr] = match
+    if (rStr === undefined || gStr === undefined || bStr === undefined) {
+      throw new Error(`unparseable veil background: ${veilBg}`)
+    }
+    const declared: [number, number, number] = [
+      Number(rStr) / 255,
+      Number(gStr) / 255,
+      Number(bStr) / 255,
+    ]
+    const asSeen: [number, number, number] = [
+      1 - declared[0],
+      1 - declared[1],
+      1 - declared[2],
+    ]
+    const asSeenLuminance = relativeLuminance(...asSeen)
+
+    // The veil exists purely to hold a dark, flash-free canvas while a
+    // session settles (prepaint.ts/prepaint.css). Its declared color is only
+    // ever adjusted for *our own* legacy filter (prepaint.css's
+    // `html[data-sw-legacy] #__sw_prepaint_veil` rule) — never for a page's
+    // own, independently-applied filter, which is exactly this fixture's
+    // condition and was already active before this second session started.
+    // Composited through it, the veil's dark declared color reads as bright
+    // — the anti-flash mechanism becomes the flash, for a session that
+    // starts *after* the page has already loaded and a human is far more
+    // likely to be looking at the screen than during the initial load.
+    expect(
+      asSeenLuminance,
+      `veil declared bg ${veilBg} is meant to hold a dark canvas, but ` +
+        `composited through the page's own, previously-applied filter: ` +
+        `invert(1) it reads as luminance ${asSeenLuminance.toFixed(3)} — ` +
+        "bright, not dark"
+    ).toBeLessThan(0.3)
+  })
+})
+
 // ── per-surface darkening with no matching per-surface text adjustment ──────
 
 test.describe("auto theme's per-surface darkening leaves untargeted text unreadable (#741)", () => {

--- a/extensions/some-filter/tests/e2e/specs/issue-741-auto-defects.spec.ts
+++ b/extensions/some-filter/tests/e2e/specs/issue-741-auto-defects.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * #741 ("guilty until innocent") — falsifiable proof, via the real
+ * --load-extension pipeline, of three concrete "auto is bad at applying the
+ * theme" claims from the issue. Deliberately not a fix for any of them: the
+ * issue asks to prove these first, so every test below asserts what
+ * *should* be true and is expected to fail against today's implementation.
+ * Each test.describe below cites the exact code path responsible — see each
+ * fixture's own header comment for the fuller trace.
+ *
+ * A companion classifier-level proof (the same filter-blindness root cause
+ * behind the first describe below, isolated at the classifyPage()/detect()
+ * level rather than the live pipeline) lives in
+ * extensions/filter-classifier's corpus (`filter-invert-reads-dark`/
+ * `filter-invert-reads-light`, tests/e2e/fixtures/corpus.ts).
+ */
+
+import { relativeLuminance } from "@filter/lib/content/color"
+import { expect, test, waitForClassification } from "@filter/playwright/fixture"
+
+// ── filter: invert — auto poisons its own remedy ────────────────────────────
+
+test.describe("auto theme under a vendor-authored filter: invert (#741)", () => {
+  test("the settled canvas still reads dark once the page's own invert filter is composited back in", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("filter-invert-vendor-page")
+    await waitForClassification(page)
+    await page.waitForTimeout(300)
+
+    const rendered = await page.evaluate(() => ({
+      themeApplied: document.body.dataset["swThemeApplied"],
+      hasDarkAttr: document.documentElement.hasAttribute("data-sw-dark"),
+      bg: getComputedStyle(document.body).backgroundColor,
+    }))
+
+    // The pipeline does correctly decide to theme this page (its declared
+    // colors are plain light) — the bug is entirely in what happens next.
+    expect(rendered.themeApplied).toBe("dark")
+    expect(rendered.hasDarkAttr).toBe(true)
+
+    const match = rendered.bg.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/)
+    if (match === null) {
+      throw new Error(`unparseable computed background: ${rendered.bg}`)
+    }
+    const [, rStr, gStr, bStr] = match
+    if (rStr === undefined || gStr === undefined || bStr === undefined) {
+      throw new Error(`unparseable computed background: ${rendered.bg}`)
+    }
+    const declared: [number, number, number] = [
+      Number(rStr) / 255,
+      Number(gStr) / 255,
+      Number(bStr) / 255,
+    ]
+
+    // getComputedStyle never reflects `filter` — it reports the dark theme's
+    // own token, undistorted. A human (or a screenshot) sees it composited
+    // through the vendor's still-active `invert(1)`, which theme-apply.ts
+    // never touches or removes. invert(1) is an exact per-channel
+    // complement (CSS Filter Effects Level 1) — replicate that here to get
+    // what actually reaches the screen.
+    const asSeen: [number, number, number] = [
+      1 - declared[0],
+      1 - declared[1],
+      1 - declared[2],
+    ]
+    const asSeenLuminance = relativeLuminance(...asSeen)
+
+    // A properly dark, settled canvas should still read dark once the
+    // page's own filter is accounted for — it does not: injecting our dark
+    // token under an active invert(1) composites back to a bright, near-
+    // white canvas, exactly the "auto removes the theme, revealing back the
+    // white vendor bg" symptom, self-inflicted by the theme's own
+    // application rather than any later event.
+    expect(
+      asSeenLuminance,
+      `declared computed bg ${rendered.bg} is a properly dark token, but ` +
+        `composited through the page's own filter: invert(1) it reads as ` +
+        `luminance ${asSeenLuminance.toFixed(3)} — bright, not dark`
+    ).toBeLessThan(0.3)
+  })
+})
+
+// ── per-surface darkening with no matching per-surface text adjustment ──────
+
+test.describe("auto theme's per-surface darkening leaves untargeted text unreadable (#741)", () => {
+  test("a <div> surface's own text stays dark after its background is darkened out from under it", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("text-contrast-gap-page")
+    await waitForClassification(page)
+    await page.waitForTimeout(300)
+
+    const rendered = await page.evaluate(() => {
+      const card = document.getElementById("card")
+      const style = card ? getComputedStyle(card) : null
+      return {
+        patched: card?.dataset["swPatched"],
+        bg: style?.backgroundColor,
+        text: style?.color,
+      }
+    })
+
+    // The surface was recognized and darkened — confirms the failure below
+    // isn't "nothing happened to this element at all".
+    expect(
+      rendered.patched,
+      "#card's light background should have been classified as a surface"
+    ).toBeDefined()
+
+    function luminanceOf(css: string | undefined): number {
+      const match = css?.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/)
+      if (!match) return Number.NaN
+      const [, r, g, b] = match
+      return relativeLuminance(
+        Number(r) / 255,
+        Number(g) / 255,
+        Number(b) / 255
+      )
+    }
+
+    function contrastRatio(a: number, b: number): number {
+      const [hi, lo] = a >= b ? [a, b] : [b, a]
+      return (hi + 0.05) / (lo + 0.05)
+    }
+
+    const bg = rendered.bg ?? "(none)"
+    const text = rendered.text ?? "(none)"
+    const bgLuminance = luminanceOf(rendered.bg)
+    const textLuminance = luminanceOf(rendered.text)
+    const contrast = contrastRatio(bgLuminance, textLuminance)
+
+    // WCAG AA's own floor for ordinary body text is 4.5:1. #card's
+    // background was hue-preserving-darkened (adapter/theme-adapter.ts,
+    // adapter/actuator.ts's emit-surface-color) while its own inline
+    // `color` — authored for readability against the *original* white
+    // background — was never touched: no per-surface foreground action
+    // exists in the FilterAction alphabet (adapter/contracts.ts), and
+    // buildDarkThemeCSS's static text-color rules don't cover bare <div>.
+    expect(
+      contrast,
+      `#card resolved to bg ${bg} / text ${text} — ` +
+        `contrast ${contrast.toFixed(2)}:1, below WCAG AA's 4.5:1 floor`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+})
+
+// ── background-image is invisible to classification ─────────────────────────
+
+test.describe("auto theme cannot see background-image, only background-color (#741)", () => {
+  test("a light-gradient surface is classified and no longer reads as a bright, untouched rectangle", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("gradient-leak-page")
+    await waitForClassification(page)
+    await page.waitForTimeout(300)
+
+    const rendered = await page.evaluate(() => {
+      const card = document.getElementById("gradient-card")
+      const style = card ? getComputedStyle(card) : null
+      return {
+        patched: card?.dataset["swPatched"],
+        backgroundImage: style?.backgroundImage ?? "",
+      }
+    })
+
+    // pipeline.ts's readAttr() and theme-detector.ts's classifyPage() both
+    // sample only getComputedStyle().backgroundColor — #gradient-card has
+    // none (only backgroundImage), so it is never scored, never becomes a
+    // SurfaceKey, and never receives a tag-surface/emit-surface-color
+    // action.
+    expect(
+      rendered.patched,
+      "the gradient surface should have been classified, like any other " +
+        "light surface on the page"
+    ).toBeDefined()
+
+    expect(
+      rendered.backgroundImage.includes("255, 255, 255"),
+      `background-image is untouched by any theme rule (still ` +
+        `"${rendered.backgroundImage}") — the light gradient renders exactly ` +
+        "as authored, a bright rectangle on an otherwise-dark page"
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description

Closes #741.

Per #741 ("guilty until innocent"), this proves the reported classifier/auto-theme bugs exist, deliberately without fixing them — the issue asks to prove these first. Every new test below asserts what *should* be true and currently fails against the shipped implementation.

**Sidecar (prerequisite for the above):** added a `test:claude:e2e` script to both `extensions/some-filter` and `extensions/filter-classifier` — a small wrapper that points `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` at a pre-installed Chromium when one is available via `$PLAYWRIGHT_BROWSERS_PATH`, instead of requiring `nix develop .#playwright`. The Nix-gated `test:e2e` default is untouched.

**`extensions/filter-classifier`** — two corpus fixtures show `classifyPage()`/`detect()` (`theme-detector.ts`) ignore CSS `filter` entirely, reading raw `background-color` only:
- `filter-invert-reads-dark`: a plain light page wrapped in `filter: invert(1)` (renders black-on-white → white-on-black to a human) — classifier reports `alreadyDark: false`, should be `true`.
- `filter-invert-reads-light`: the inverse — a plain dark page wrapped in the same filter (renders as an ordinary light page) — classifier reports `alreadyDark: true`, should be `false`.

**`extensions/some-filter`** — one real `--load-extension` e2e spec (`issue-741-auto-defects.spec.ts`) proves three live-pipeline symptoms from the issue, each traced to a specific gap in `pipeline.ts`/`theme-adapter.ts`/`actuator.ts`:
- *"auto removes the theme, revealing back the white vendor bg"* — the dark theme's own injected tokens get composited back to a bright, near-white canvas once a page's pre-existing `filter: invert(1)` is accounted for (declared bg luminance 0.011 → as-seen luminance 0.77). `theme-apply.ts` never touches a vendor's own `filter`.
- *"it darkens text so that it's not visible at all"* — a `<div>` surface's background gets hue-preserving-darkened (`modifyBackgroundColor`) while its own inline text color is left untouched (no per-surface foreground action exists in `FilterAction`, and `buildDarkThemeCSS`'s text-color selectors don't cover bare `<div>`) — contrast collapses to exactly 1:1.
- *"white gradients leak"* — a light `background-image` gradient with no `background-color` is invisible to both `readAttr()` (pipeline.ts) and `classifyPage()` (theme-detector.ts), which sample only `background-color` — the surface is never tagged and renders untouched.

Confirmed no regressions: all pre-existing tests still pass (19/19 in `some-filter`, 44/44 non-new in `filter-classifier`); typecheck/lint/prettier clean in both workspaces.

## Type of Change

- [x] This change requires a follow-up fix (tests are intentionally red, proving the bugs in #741 rather than fixing them)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (typecheck/lint/prettier all clean)
- [x] I have added tests that prove the bugs in #741 are real (deliberately failing — no fix included)
- [x] New and existing tests pass locally with my changes, except the new tests added specifically to prove #741 (by design)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Not applicable — these are e2e assertions over `getComputedStyle`/classifier output, not visual changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5DyiwkdEP6FQ5KGPjMLGN)_