### PR TITLE
fix(ci): stop interpolating raw commit message into wasm-release shell script

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -41,6 +41,8 @@ jobs:
           fetch-depth: 0
       - name: Detect changed wasm crates
         id: detect
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
 
@@ -72,7 +74,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_only }}" = "true" ]; then
             is_release_commit=true
           elif [ "${{ github.event_name }}" != "workflow_dispatch" ] && \
-               [[ "${{ github.event.head_commit.message }}" == "${{ env.RELEASE_COMMIT_MESSAGE }}"* ]]; then
+               [[ "$HEAD_COMMIT_MESSAGE" == "$RELEASE_COMMIT_MESSAGE"* ]]; then
             is_release_commit=true
           fi
           echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

The `detect` job in `.github/workflows/wasm-release.yml` substituted `${{ github.event.head_commit.message }}` directly into a `run:` bash script:

```bash
elif [ "${{ github.event_name }}" != "workflow_dispatch" ] && \
     [[ "${{ github.event.head_commit.message }}" == "${{ env.RELEASE_COMMIT_MESSAGE }}"* ]]; then
```

GitHub Actions expression substitution is literal text replacement that happens before bash ever parses the script. PR #771's merge commit carried a large multi-line squashed commit message full of quotes, which broke the generated script's syntax once substituted (`conditional binary operator expected`, exit code 2): https://github.com/paulgsc/some-ui/actions/runs/30137884861/job/89625349249

This also meant arbitrary commit message text could become shell syntax — a script-injection risk, not just a formatting bug.

## Fix

Pass the commit message through `env:` and reference it as a shell variable (`$HEAD_COMMIT_MESSAGE`) instead of interpolating it directly into the script body. Verified locally that a multi-line message containing quotes/backticks/`$()` no longer breaks the script and the comparison still evaluates correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes (no test harness for this workflow; validated with `bash -n` plus a local repro of the failing shell script)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1S6pDEoaW39p2scnY6cgp)_