### PR TITLE
Add LLM-generated Hangul vocabulary override for local dev

### DIFF
--- a/apps/www/.gitignore
+++ b/apps/www/.gitignore
@@ -12,4 +12,5 @@ count.txt
 /public/sfx
 # assets of unknown size
 /public/code-samples
+/public/hangul
 /public/resume.pdf

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -28,6 +28,8 @@
     "@radix-ui/react-accordion": "^1.2.7",
     "@some-ui/content-registry": "workspace:*",
     "@some-ui/content": "workspace:*",
+    "@some-ui/fetch-kit": "workspace:*",
+    "@some-ui/honeycomb": "workspace:*",
     "@some-ui/styles": "workspace:*",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-devtools": "^0.2.2",

--- a/apps/www/scripts/link-content-assets.js
+++ b/apps/www/scripts/link-content-assets.js
@@ -1,19 +1,25 @@
-// honeycomb's sfx and leetype's code samples live in packages/some-content
-// (see apps/www/.gitignore) and aren't checked into this app's public/ dir.
-// CI's Pages build (pages.yml) copies them into public/ at build time; for
-// local `vite dev` this symlinks them instead, so the dev server serves the
-// real files straight out of packages/some-content, live, with no rebuild
-// needed. Run manually via `pnpm run content:link` when you have the actual
-// asset files locally - deliberately NOT wired into a pre/postinstall or
-// pre<script> hook, since auto-executing Node on install/dev is a footgun
-// (surprise side effects, supply-chain scanner flags on the lifecycle
-// script itself). vite.config.ts warns at dev-server startup instead if
-// these are missing, pointing back at this command.
+// honeycomb's sfx, leetype's code samples, and (optionally) an LLM-generated
+// hangul vocab file all live in packages/some-content (see
+// apps/www/.gitignore) and aren't checked into this app's public/ dir. CI's
+// Pages build (pages.yml) copies sfx/code-samples into public/ at build
+// time - hangul is deliberately NOT part of that copy step, since the
+// static GitHub Pages build has no companion data at all (see
+// src/lib/hangul-vocab). For local `vite dev` this symlinks all three
+// instead, so the dev server serves the real files straight out of
+// packages/some-content, live, with no rebuild needed. Run manually via
+// `pnpm run content:link` when you have the actual asset files locally -
+// deliberately NOT wired into a pre/postinstall or pre<script> hook, since
+// auto-executing Node on install/dev is a footgun (surprise side effects,
+// supply-chain scanner flags on the lifecycle script itself). vite.config.ts
+// warns at dev-server startup if sfx/code-samples are missing, pointing back
+// at this command - hangul is excluded from that warning since, unlike
+// those two, its absence is expected/harmless (HangulHexGrid's bundled demo
+// seed covers it).
 //
 // No-op for any subdir that doesn't exist locally: these assets are
 // curated/gitignored, not part of a fresh checkout, so a machine without
-// them just runs without honeycomb sound / leetype samples rather than
-// failing.
+// them just runs without honeycomb sound / leetype samples / custom hangul
+// vocab rather than failing.
 import {
   existsSync,
   lstatSync,
@@ -31,7 +37,7 @@ const contentPublicDir = resolve(
   "../../../packages/some-content/public"
 )
 
-for (const name of ["sfx", "code-samples"]) {
+for (const name of ["sfx", "code-samples", "hangul"]) {
   const src = resolve(contentPublicDir, name)
   const dest = resolve(appPublicDir, name)
 

--- a/apps/www/src/components/player/session-viewport.tsx
+++ b/apps/www/src/components/player/session-viewport.tsx
@@ -10,6 +10,7 @@ import {
 } from "some-ui-utils"
 import { LiveEditOverlay, OrchestratedYouTubeViewport } from "wireframes"
 
+import { useHangulVocab } from "@/lib/hangul-vocab"
 import type { SessionRecord } from "@/lib/tenant"
 
 import { useLiveLayoutEditor } from "./use-live-layout-editor"
@@ -53,10 +54,19 @@ export const SessionViewport = ({
 
   const sessionKey = useSessionKey()
   const suspended = useSuspended()
+  // Only HangulHexGrid declares a `words` prop; every other registry
+  // component ignores it the same way it already ignores sessionKey/
+  // suspended when it doesn't need them (see extraProps' own doc comment
+  // below and RegistryEntry<P = any> in @some-ui/types).
+  const hangulWords = useHangulVocab()
 
   const extraProps = useMemo(
-    () => ({ sessionKey: sessionKey ?? undefined, suspended }),
-    [sessionKey, suspended]
+    () => ({
+      sessionKey: sessionKey ?? undefined,
+      suspended,
+      words: hangulWords,
+    }),
+    [sessionKey, suspended, hangulWords]
   )
 
   return (

--- a/apps/www/src/lib/hangul-vocab/index.ts
+++ b/apps/www/src/lib/hangul-vocab/index.ts
@@ -1,0 +1,92 @@
+import { useEffect } from "react"
+import { ApiError, createDataSource } from "@some-ui/fetch-kit"
+import type { WordEntry } from "@some-ui/honeycomb"
+
+import { HangulVocabFileSchema } from "./schema"
+
+export const DEFAULT_HANGUL_VOCAB_TOPIC = "vocab"
+
+type HangulVocabParams = { topic: string }
+
+/**
+ * Same relative path for both modes - `/hangul/words/<topic>.json`, served
+ * from whatever's mounted/symlinked at `public/hangul/words` (see
+ * infra/compose/www.yml and scripts/link-content-assets.js). The two-locator
+ * shape only matters for `useHangulVocab`'s mode gate below: a genuine
+ * bundled-static fallback would diverge this from `server`, but today there
+ * isn't one - the GitHub Pages build ships no companion data at all, and
+ * `HangulHexGrid`'s own bundled demo seed is the whole story there.
+ */
+function locateVocabFile({ topic }: HangulVocabParams): URL {
+  return new URL(`/hangul/words/${topic}.json`, window.location.origin)
+}
+
+const hangulVocabSource = createDataSource<HangulVocabParams, Array<WordEntry>>(
+  { static: locateVocabFile, server: locateVocabFile },
+  {
+    // Docker/local dev is also reachable over the LAN mDNS hostname
+    // vite.config.ts allows (`nixos.local`, for the HTTPS/getUserMedia
+    // path) - widen fetch-kit's hostname heuristic to match, so that host
+    // resolves to "server" the same as plain localhost does.
+    serverHostnames: ["localhost", "127.0.0.1", "[::1]", "nixos.local"],
+  }
+)
+
+/**
+ * The apps/www-only half of the "real vocab locally, demo vocab on GitHub
+ * Pages" split (see hangul-words.ts's own header comment for the demo
+ * seed's provenance rationale). `@some-ui/honeycomb` stays fetch-free and
+ * ships only the bundled demo `WordEntry[]`; this hook is where a host app
+ * opts into something else.
+ *
+ * - **GitHub Pages / any non-server host**: `hangulVocabSource.mode` resolves
+ *   to `"static"`, the query is `enabled: false`, and no request is ever
+ *   issued - there is no companion server and no `public/hangul/words` dir
+ *   in that build to fetch from anyway.
+ * - **localhost / Docker / LAN dev**: fetches
+ *   `/hangul/words/<topic>.json` (gitignored, developer-populated - see
+ *   `packages/some-content/public/hangul/words`). A 404 (the common case on
+ *   a fresh checkout, before anyone has generated a file) resolves quietly
+ *   to `undefined`. Any other failure (malformed JSON, a schema mismatch -
+ *   most likely a hand/LLM-authored `answerKeys`/`answerGlyphs` mistake) is
+ *   also non-fatal to the caller, but is logged loudly so it doesn't read as
+ *   "the feature silently doesn't work."
+ *
+ * Either way the caller gets back `Array<WordEntry> | undefined`; `undefined`
+ * means "no override" - pass it straight through to `HangulHexGrid`'s
+ * `words` prop, whose own default (`HANGUL_WORDS`) takes over.
+ *
+ * `topic` is forward-looking, not load-bearing today: the shim's one user
+ * story is "one active LLM-generated file," so every caller currently omits
+ * it and gets `vocab.json`. A future topic-picker UI (part of the eventual
+ * adaptive-learning design, not this stub) can thread a real topic id
+ * through without this hook's shape changing.
+ */
+export function useHangulVocab(
+  topic: string = DEFAULT_HANGUL_VOCAB_TOPIC
+): Array<WordEntry> | undefined {
+  const { data, error, isError } = hangulVocabSource.useResource(
+    ["hangul-vocab", topic],
+    { topic },
+    HangulVocabFileSchema,
+    {
+      enabled: hangulVocabSource.mode === "server",
+      retry: false,
+    }
+  )
+
+  useEffect(() => {
+    if (!isError) return
+    // A missing file is steady state (nobody's generated one yet, or this
+    // topic doesn't have one) - only warn about failures that mean a file
+    // exists but this app couldn't use it.
+    if (error instanceof ApiError && error.status === 404) return
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[hangul-vocab] Failed to load "${topic}.json" - falling back to the bundled demo seed.`,
+      error
+    )
+  }, [isError, error, topic])
+
+  return data
+}

--- a/apps/www/src/lib/hangul-vocab/schema.test.ts
+++ b/apps/www/src/lib/hangul-vocab/schema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import { HangulVocabFileSchema, WordEntrySchema } from "./schema"
+
+const validEntry = {
+  id: "one",
+  word: "하나",
+  romanization: "hana",
+  answerKeys: ["g", "k", "s", "k"],
+  answerGlyphs: ["ㅎ", "ㅏ", "ㄴ", "ㅏ"],
+  icon: "1️⃣",
+  ttsText: "하나",
+  category: "numbers",
+}
+
+describe("WordEntrySchema", () => {
+  it("accepts a well-formed entry with a free-form category", () => {
+    expect(WordEntrySchema.safeParse(validEntry).success).toBe(true)
+  })
+
+  it("rejects a mismatched answerKeys/answerGlyphs length - the most likely LLM-authoring mistake", () => {
+    const result = WordEntrySchema.safeParse({
+      ...validEntry,
+      answerKeys: ["g", "k", "s"],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects an entry missing a required field", () => {
+    const { id: _id, ...withoutId } = validEntry
+    expect(WordEntrySchema.safeParse(withoutId).success).toBe(false)
+  })
+})
+
+describe("HangulVocabFileSchema", () => {
+  it("accepts a non-empty array of valid entries", () => {
+    const result = HangulVocabFileSchema.safeParse([validEntry])
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects an empty array - an empty vocab file has nothing to challenge with", () => {
+    expect(HangulVocabFileSchema.safeParse([]).success).toBe(false)
+  })
+})

--- a/apps/www/src/lib/hangul-vocab/schema.ts
+++ b/apps/www/src/lib/hangul-vocab/schema.ts
@@ -10,13 +10,14 @@ import { z } from "zod"
  * component; `z.infer` below stays structurally assignable to `WordEntry`
  * because the field types match exactly.
  *
- * Same open-syllable constraint as the bundled demo seed applies here too:
  * `answerKeys`/`answerGlyphs` must be hand-verified (or LLM-verified) against
  * the dubeolsik QWERTY mapping table
- * (`packages/ui/honeycomb/src/utils/hangul-keyboard-mapping`) - the engine
- * only maps lead consonants + vowels, not batchim/final consonants, so a
- * word like 사람 (batchim ㅁ) has no valid `answerKeys` encoding. Prefer
- * words whose every syllable block is lead-consonant + vowel only.
+ * (`packages/ui/honeycomb/src/utils/hangul-keyboard-mapping`) - every jamo in
+ * the word, in order, including batchim (there is no open-syllable
+ * restriction: the mapping table is position-agnostic, and the engine never
+ * re-derives these from `word` at runtime - see hangul-words.ts's header
+ * comment and crates/hangul-game-core/src/internal/engine.rs's
+ * `batchim_word_completes_like_any_other_multi_token_challenge` test).
  */
 export const WordEntrySchema = z
   .object({

--- a/apps/www/src/lib/hangul-vocab/schema.ts
+++ b/apps/www/src/lib/hangul-vocab/schema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+/**
+ * Mirrors `@some-ui/honeycomb`'s `WordEntry`
+ * (packages/ui/honeycomb/src/data/hangul-words.ts) - this is the contract an
+ * LLM-generated vocab file must satisfy to be usable as a `HangulHexGrid`
+ * `words` override. Kept as an independent schema (not imported from
+ * honeycomb, which has no zod dependency of its own for this type) so
+ * `apps/www` can validate the fetched JSON before it ever reaches the
+ * component; `z.infer` below stays structurally assignable to `WordEntry`
+ * because the field types match exactly.
+ *
+ * Same open-syllable constraint as the bundled demo seed applies here too:
+ * `answerKeys`/`answerGlyphs` must be hand-verified (or LLM-verified) against
+ * the dubeolsik QWERTY mapping table
+ * (`packages/ui/honeycomb/src/utils/hangul-keyboard-mapping`) - the engine
+ * only maps lead consonants + vowels, not batchim/final consonants, so a
+ * word like 사람 (batchim ㅁ) has no valid `answerKeys` encoding. Prefer
+ * words whose every syllable block is lead-consonant + vowel only.
+ */
+export const WordEntrySchema = z
+  .object({
+    id: z.string().min(1),
+    word: z.string().min(1),
+    romanization: z.string().min(1),
+    answerKeys: z.array(z.string().min(1)).min(1),
+    answerGlyphs: z.array(z.string().min(1)).min(1),
+    icon: z.string().min(1),
+    ttsText: z.string().min(1),
+    /** Free-form topic label (e.g. "numbers", "calendar") - not a closed enum. */
+    category: z.string().min(1),
+  })
+  .refine((entry) => entry.answerKeys.length === entry.answerGlyphs.length, {
+    message:
+      "answerKeys and answerGlyphs must be the same length - one QWERTY key per glyph, in order",
+    path: ["answerGlyphs"],
+  })
+
+export const HangulVocabFileSchema = z.array(WordEntrySchema).min(1)
+
+export type HangulVocabFile = z.infer<typeof HangulVocabFileSchema>

--- a/crates/hangul-game-core/src/internal/engine.rs
+++ b/crates/hangul-game-core/src/internal/engine.rs
@@ -1066,4 +1066,60 @@ mod tests {
 
         assert!(matches!(batch.primary, Some(PrimaryEvent::BoardFull)));
     }
+
+    #[test]
+    fn batchim_word_completes_like_any_other_multi_token_challenge() {
+        // Regression coverage for a false constraint that briefly lived in a
+        // seed-data comment (fixed alongside this test): 사람 (saram,
+        // "person") has two batchim (ㄹ after ㅏ, ㅁ after ㅏ). The engine has
+        // no concept of "batchim" anywhere in this file or in
+        // content_domain/korean.rs - process_input just matches
+        // answer_keys[cursor] against typed input, so a batchim jamo (ㄹ/ㅁ
+        // here) is matched exactly the same way any onset jamo would be.
+        // `Korean::key_for` isn't even called for word-mode challenges (see
+        // VocabularyMode::get_next_challenge) - answer_keys/answer_glyphs
+        // arrive pre-built from the seed and are used verbatim.
+        let mut engine = engine_with("endless");
+        push_word_challenge(
+            &mut engine,
+            &["cell-0", "cell-1", "cell-2", "cell-3", "cell-4"],
+            &["ㅅ", "ㅏ", "ㄹ", "ㅏ", "ㅁ"],
+            &["t", "k", "f", "k", "a"],
+            0,
+        );
+
+        for key in ["t", "k", "f", "k"] {
+            let batch = engine.process_input(key.to_string(), 100);
+            assert!(batch.primary.is_none(), "expected progress, not completion, on {key}");
+        }
+        let final_batch = engine.process_input("a".to_string(), 100);
+        match final_batch.primary {
+            Some(PrimaryEvent::MatchFound { hangul, .. }) => assert_eq!(hangul, "ㅅㅏㄹㅏㅁ"),
+            other => panic!("expected MatchFound, got {other:?}"),
+        }
+        assert_eq!(engine.get_active_count(), 0);
+    }
+
+    #[test]
+    fn compound_batchim_as_one_glyph_with_a_combined_key_completes_too() {
+        // 닭 (dalg, "chicken"): batchim ㄺ is a compound (ㄹ+ㄱ). Korean::key_for
+        // has no table entry for "ㄺ" as one character, but nothing in
+        // process_input requires answer_keys[i] to be a single QWERTY
+        // character or to come from key_for at all for vocabulary-mode
+        // challenges - this mirrors exactly how composite vowels like ㅘ
+        // already work (one glyph slot, a 2-char key "hk").
+        let mut engine = engine_with("endless");
+        push_word_challenge(&mut engine, &["cell-0", "cell-1", "cell-2"], &["ㄷ", "ㅏ", "ㄺ"], &["e", "k", "fr"], 0);
+
+        engine.process_input("e".to_string(), 100);
+        engine.process_input("k".to_string(), 100);
+        // "f" alone should be a partial/prefix match (ambiguity/extension), not a miss.
+        let partial = engine.process_input("f".to_string(), 100);
+        assert!(partial.primary.is_none(), "expected a partial-match hint, not a miss, got {partial:?}");
+        let complete = engine.process_input("r".to_string(), 100);
+        match complete.primary {
+            Some(PrimaryEvent::MatchFound { hangul, .. }) => assert_eq!(hangul, "ㄷㅏㄺ"),
+            other => panic!("expected MatchFound, got {other:?}"),
+        }
+    }
 }

--- a/infra/compose/www.yml
+++ b/infra/compose/www.yml
@@ -21,6 +21,16 @@
 # `docker compose up www` working out of the box against this repo's own
 # (mostly empty/gitignored) copies.
 #
+# packages/some-content/public/hangul is the same story with one difference:
+# it's optional, not load-bearing. HangulHexGrid's own bundled demo seed
+# (@some-ui/honeycomb) always works with nothing mounted here at all - this
+# volume only matters if you've asked an LLM to generate a
+# hangul/words/vocab.json (see apps/www/src/lib/hangul-vocab) and want this
+# container to serve it instead of the demo words. Unlike sfx/code-samples,
+# the GitHub Pages build never bakes this in either way: there's no
+# companion data there, by design (apps/www resolves to "static" mode and
+# never fetches it).
+#
 # REPO_ROOT must actually be exported (e.g. `export REPO_ROOT=$(pwd)` from
 # repo root) before running docker compose. The root docker-compose.yml
 # includes this file via `include:`, and Compose resolves any relative
@@ -42,6 +52,7 @@ services:
       - ${REPO_ROOT:-.}/certs:/etc/nginx/certs:ro
       - ${WWW_SFX_ASSETS_PATH:-${REPO_ROOT:-.}/packages/some-content/public/sfx}:/usr/share/nginx/html/sfx:ro
       - ${WWW_CODE_SAMPLES_PATH:-${REPO_ROOT:-.}/packages/some-content/public/code-samples}:/usr/share/nginx/html/code-samples:ro
+      - ${WWW_HANGUL_ASSETS_PATH:-${REPO_ROOT:-.}/packages/some-content/public/hangul}:/usr/share/nginx/html/hangul:ro
     networks:
       - some-ui-network
     # Dockerfile bakes in the same wget-spider HEALTHCHECK as a baseline for

--- a/packages/eslint/src/configs/base.config.ts
+++ b/packages/eslint/src/configs/base.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(
       "**/dist/**",
       "**/package.json",
       "**/package-lock.json",
+      "**/public/**",
       "**/fixtures/**",
       "**/coverage/**",
       "**/__snapshots__/**",

--- a/packages/some-content/prompts/hangul-vocab-generator/index.md
+++ b/packages/some-content/prompts/hangul-vocab-generator/index.md
@@ -60,44 +60,45 @@ The file itself is a JSON array of these, with **at least one entry**.
 
 ---
 
-## Hard Constraint: Open-Syllable Words Only
+## Decomposition: Batchim Is Fine, Compound Batchim Needs One Extra Step
 
-**This is the constraint most likely to be violated, and a violation silently
-produces an unplayable word - read this section before generating anything.**
+**There is no open-syllable restriction. Batchim (받침, final consonants)
+decompose and play correctly** - the game engine has no concept of syllable
+position at all; it just matches an ordered list of jamo tokens against
+typed input, and a batchim jamo is matched the exact same way an onset jamo
+is. (This is empirically verified, not just asserted - see
+`batchim_word_completes_like_any_other_multi_token_challenge` in
+`crates/hangul-game-core/src/internal/engine.rs`.) Do not avoid batchim
+words or prefer loanwords to route around them - decompose the whole word,
+in reading order, every jamo including any batchim.
 
-The game engine (`Korean::key_for`,
-`crates/hangul-game-core/src/internal/content_domain/korean.rs`) maps
-**only** the 19 lead consonants and 21 vowels to QWERTY keys. It has **no
-mapping for batchim (받침, final/trailing consonants)**. Every syllable
-block in every word must therefore be exactly **lead consonant + vowel**,
-nothing after the vowel.
+- 사람 (saram, "person") -> ㅅ, ㅏ, ㄹ, ㅏ, ㅁ -> keys `t`, `k`, `f`, `k`, `a`
+- 달 (dal, "moon") -> ㄷ, ㅏ, ㄹ -> keys `e`, `k`, `f`
 
-- ✅ 사과 (ㅅ+ㅏ, ㄱ+ㅘ) - two blocks, each lead+vowel only
-- ✅ 우유 (ㅇ+ㅜ, ㅇ+ㅠ)
-- ❌ 사람 (ㅅ+ㅏ, ㄹ+ㅏ+**ㅁ**) - final ㅁ has no key mapping
-- ❌ 하나**둘** (둘 = ㄷ+ㅜ+**ㄹ**) - final ㄹ has no key mapping
+**The one real wrinkle: compound batchim.** Eleven jamo characters
+(ㄳ/ㄵ/ㄶ/ㄺ/ㄻ/ㄼ/ㄽ/ㄾ/ㄿ/ㅀ/ㅄ) are themselves a fusion of two basic
+consonants and have no entry in the engine's key-mapping table as a single
+character. Represent one as **one glyph slot with its two component keys
+concatenated** - the exact same convention the mapping table below already
+uses for composite vowels (ㅘ is one glyph, key `hk`):
 
-This rules out a large fraction of "natural" vocabulary in almost every
-topic - e.g. most native-Korean counting words (둘, 셋, 넷, 다섯, ...) and
-most Sino-Korean tens (십, 이십, 삼십, ...) have batchim and are **not**
-usable as-is. Do not force a topic's canonical word list; select only the
-subset of words for that topic that happen to be open-syllable, and prefer
-loanwords/simpler forms where they help (e.g. 커피 for "coffee" over a
-batchim-bearing native alternative). A shorter, fully-valid list is strictly
-better than a longer list with unplayable entries.
+- 닭 (dalg, "chicken") -> ㄷ, ㅏ, ㄺ -> keys `e`, `k`, `fr` (ㄺ = ㄹ`f` + ㄱ`r`)
+- 값 (gap, "price") -> ㄱ, ㅏ, ㅄ -> keys `r`, `k`, `qt` (ㅄ = ㅂ`q` + ㅅ`t`)
 
-If a topic genuinely has too few open-syllable words to reach the requested
-count, generate fewer and say so in one line before the JSON block, rather
-than including a batchim word to hit the count.
+This is also empirically verified end to end, not inferred - see
+`compound_batchim_as_one_glyph_with_a_combined_key_completes_too`, same
+file. If a topic's most natural word has a compound batchim, use it; don't
+substitute a less natural word to avoid this.
 
 ---
 
 ## Dubeolsik (두벌식) QWERTY Mapping Table
 
-Use this table to derive `answerKeys`/`answerGlyphs` - decompose each
-syllable block into its lead consonant and vowel, then look each up here, in
-the order they appear in the word (consonant, then vowel, per block, left to
-right through the whole word). This is the same table
+Use this table to derive `answerKeys`/`answerGlyphs` - decompose the whole
+word into its individual jamo, in reading order (every consonant and vowel a
+syllable block contains, including any batchim), then look each one up here.
+The table is position-agnostic: the same row applies whether a consonant is
+a syllable's onset or its batchim. This is the same table
 `packages/ui/honeycomb/src/utils/hangul-keyboard-mapping` uses at runtime -
 keep this list in sync with that file if it ever changes.
 
@@ -153,18 +154,20 @@ keep this list in sync with that file if it ever changes.
 
 Every entry above is a real, verified `WordEntry` from the bundled demo
 seed (`packages/ui/honeycomb/src/data/hangul-words.ts`) - use those 20
-entries as additional worked examples if any of the above is ambiguous.
+entries as additional worked examples if any of the above is ambiguous. That
+seed happens to be all open-syllable words, but that reflects when it was
+written, not a real constraint - see "Decomposition" above.
 
 ---
 
-## Worked Example
+## Worked Examples
 
-Word: 포도 ("grape")
+Word: 포도 ("grape") - no batchim, for the basic case:
 
-| Block | Lead consonant | Vowel  | answerKeys | answerGlyphs |
-| ----- | -------------- | ------ | ---------- | ------------ |
-| 포    | ㅍ (v)         | ㅗ (h) | `v`, `h`   | `ㅍ`, `ㅗ`   |
-| 도    | ㄷ (e)         | ㅗ (h) | `e`, `h`   | `ㄷ`, `ㅗ`   |
+| Block | Jamo, in order | answerKeys | answerGlyphs |
+| ----- | -------------- | ---------- | ------------ |
+| 포    | ㅍ (v), ㅗ (h) | `v`, `h`   | `ㅍ`, `ㅗ`   |
+| 도    | ㄷ (e), ㅗ (h) | `e`, `h`   | `ㄷ`, `ㅗ`   |
 
 ```json
 {
@@ -179,15 +182,37 @@ Word: 포도 ("grape")
 }
 ```
 
+Word: 달 ("moon") - a single batchim, decomposed like any other jamo:
+
+| Block | Jamo, in order         | answerKeys    | answerGlyphs     |
+| ----- | ---------------------- | ------------- | ---------------- |
+| 달    | ㄷ (e), ㅏ (k), ㄹ (f) | `e`, `k`, `f` | `ㄷ`, `ㅏ`, `ㄹ` |
+
+```json
+{
+  "id": "moon",
+  "word": "달",
+  "romanization": "dal",
+  "answerKeys": ["e", "k", "f"],
+  "answerGlyphs": ["ㄷ", "ㅏ", "ㄹ"],
+  "icon": "🌙",
+  "ttsText": "달",
+  "category": "nature"
+}
+```
+
 Diphthong vowels (ㅘ, ㅙ, ㅚ, ㅝ, ㅞ, ㅟ, ㅢ) are still **one** array slot
 each, even though their QWERTY token is two characters (`hk`, `nj`, ...) -
-one token/glyph pair per jamo, not per keystroke.
+one token/glyph pair per jamo, not per keystroke. Compound batchim
+(ㄳ/ㄵ/ㄶ/ㄺ/ㄻ/ㄼ/ㄽ/ㄾ/ㄿ/ㅀ/ㅄ) follow the identical pattern: one glyph
+slot, its two component consonants' keys concatenated (see "Decomposition"
+above).
 
 ---
 
 ## Self-Check Before Returning the File
 
-- [ ] Every syllable block in every word is lead-consonant + vowel only - no batchim, anywhere
+- [ ] Every word is fully decomposed into its jamo, in reading order, including any batchim
 - [ ] `answerKeys.length === answerGlyphs.length` for every entry
 - [ ] Every `answerKeys`/`answerGlyphs` pair was derived from the mapping table above, block by block, left to right
 - [ ] Every `id` is unique, kebab-case, ASCII

--- a/packages/some-content/prompts/hangul-vocab-generator/index.md
+++ b/packages/some-content/prompts/hangul-vocab-generator/index.md
@@ -1,0 +1,226 @@
+# Hangul Vocab Generator
+
+Prompt template for generating a `HangulHexGrid` challenge-seed file: a
+TOPIK 1/2-level vocabulary set on one topic (numbers, calendar, household
+items, colors, family, ...), used in place of the bundled demo seed when
+running `apps/www` against `localhost` or Docker (see
+`apps/www/src/lib/hangul-vocab`). Not used by the GitHub Pages build, which
+always plays the bundled demo seed instead.
+
+---
+
+## Usage Example Header
+
+```
+Topic: [TOPIK 1/2 topic, e.g. "numbers", "calendar", "household items"]
+Count: [how many words, e.g. 8]
+T: [Apply Hangul Vocab Generator v1.0]
+```
+
+The generator then produces one JSON array following the schema and
+constraints below, and nothing else - no prose, no markdown fences beyond
+the single ```json block, no comments or trailing commas (this is parsed as
+plain JSON, not JSON5).
+
+---
+
+## Output Destination
+
+Write the result to:
+
+```
+packages/some-content/public/hangul/words/vocab.json
+```
+
+This path is gitignored (`packages/**/public` in the repo root's
+`.gitignore`) - it is expected to be regenerated locally, never committed.
+Overwrite the whole file each time; there is currently one active file, not
+one per topic (see "Multiple topics" below).
+
+---
+
+## Schema
+
+Each array element (a `WordEntry`) must match exactly:
+
+```ts
+{
+  id: string          // stable slug, kebab-case ASCII, unique within the file
+  word: string         // the Hangul word, e.g. "사과"
+  romanization: string // revised romanization, e.g. "sagwa"
+  answerKeys: string[]   // one dubeolsik QWERTY token per glyph, in order
+  answerGlyphs: string[] // one jamo glyph per token, in order - same length as answerKeys
+  icon: string         // a single Unicode emoji - no bundled image asset (provenance discipline, ADR 0001 §5)
+  ttsText: string      // usually == word; spoken via the Web Speech API at runtime
+  category: string     // free-form topic label, e.g. "numbers" - not a closed enum
+}
+```
+
+The file itself is a JSON array of these, with **at least one entry**.
+
+---
+
+## Hard Constraint: Open-Syllable Words Only
+
+**This is the constraint most likely to be violated, and a violation silently
+produces an unplayable word - read this section before generating anything.**
+
+The game engine (`Korean::key_for`,
+`crates/hangul-game-core/src/internal/content_domain/korean.rs`) maps
+**only** the 19 lead consonants and 21 vowels to QWERTY keys. It has **no
+mapping for batchim (받침, final/trailing consonants)**. Every syllable
+block in every word must therefore be exactly **lead consonant + vowel**,
+nothing after the vowel.
+
+- ✅ 사과 (ㅅ+ㅏ, ㄱ+ㅘ) - two blocks, each lead+vowel only
+- ✅ 우유 (ㅇ+ㅜ, ㅇ+ㅠ)
+- ❌ 사람 (ㅅ+ㅏ, ㄹ+ㅏ+**ㅁ**) - final ㅁ has no key mapping
+- ❌ 하나**둘** (둘 = ㄷ+ㅜ+**ㄹ**) - final ㄹ has no key mapping
+
+This rules out a large fraction of "natural" vocabulary in almost every
+topic - e.g. most native-Korean counting words (둘, 셋, 넷, 다섯, ...) and
+most Sino-Korean tens (십, 이십, 삼십, ...) have batchim and are **not**
+usable as-is. Do not force a topic's canonical word list; select only the
+subset of words for that topic that happen to be open-syllable, and prefer
+loanwords/simpler forms where they help (e.g. 커피 for "coffee" over a
+batchim-bearing native alternative). A shorter, fully-valid list is strictly
+better than a longer list with unplayable entries.
+
+If a topic genuinely has too few open-syllable words to reach the requested
+count, generate fewer and say so in one line before the JSON block, rather
+than including a batchim word to hit the count.
+
+---
+
+## Dubeolsik (두벌식) QWERTY Mapping Table
+
+Use this table to derive `answerKeys`/`answerGlyphs` - decompose each
+syllable block into its lead consonant and vowel, then look each up here, in
+the order they appear in the word (consonant, then vowel, per block, left to
+right through the whole word). This is the same table
+`packages/ui/honeycomb/src/utils/hangul-keyboard-mapping` uses at runtime -
+keep this list in sync with that file if it ever changes.
+
+**Consonants (자음)**
+
+| QWERTY | Hangul | Romanization |
+| ------ | ------ | ------------ |
+| r      | ㄱ     | g/k          |
+| R      | ㄲ     | kk           |
+| s      | ㄴ     | n            |
+| e      | ㄷ     | d/t          |
+| E      | ㄸ     | tt           |
+| f      | ㄹ     | r/l          |
+| a      | ㅁ     | m            |
+| q      | ㅂ     | b/p          |
+| Q      | ㅃ     | pp           |
+| t      | ㅅ     | s            |
+| T      | ㅆ     | ss           |
+| d      | ㅇ     | ng           |
+| w      | ㅈ     | j            |
+| W      | ㅉ     | jj           |
+| c      | ㅊ     | ch           |
+| z      | ㅋ     | k            |
+| x      | ㅌ     | t            |
+| v      | ㅍ     | p            |
+| g      | ㅎ     | h            |
+
+**Vowels (모음)**
+
+| QWERTY | Hangul | Romanization |
+| ------ | ------ | ------------ |
+| k      | ㅏ     | a            |
+| o      | ㅐ     | ae           |
+| i      | ㅑ     | ya           |
+| O      | ㅒ     | yae          |
+| j      | ㅓ     | eo           |
+| p      | ㅔ     | e            |
+| u      | ㅕ     | yeo          |
+| P      | ㅖ     | ye           |
+| h      | ㅗ     | o            |
+| hk     | ㅘ     | wa           |
+| ho     | ㅙ     | wae          |
+| hl     | ㅚ     | oe           |
+| y      | ㅛ     | yo           |
+| n      | ㅜ     | u            |
+| nj     | ㅝ     | wo           |
+| np     | ㅞ     | we           |
+| nl     | ㅟ     | wi           |
+| b      | ㅠ     | yu           |
+| m      | ㅡ     | eu           |
+| ml     | ㅢ     | ui           |
+| l      | ㅣ     | i            |
+
+Every entry above is a real, verified `WordEntry` from the bundled demo
+seed (`packages/ui/honeycomb/src/data/hangul-words.ts`) - use those 20
+entries as additional worked examples if any of the above is ambiguous.
+
+---
+
+## Worked Example
+
+Word: 포도 ("grape")
+
+| Block | Lead consonant | Vowel  | answerKeys | answerGlyphs |
+| ----- | -------------- | ------ | ---------- | ------------ |
+| 포    | ㅍ (v)         | ㅗ (h) | `v`, `h`   | `ㅍ`, `ㅗ`   |
+| 도    | ㄷ (e)         | ㅗ (h) | `e`, `h`   | `ㄷ`, `ㅗ`   |
+
+```json
+{
+  "id": "grape",
+  "word": "포도",
+  "romanization": "podo",
+  "answerKeys": ["v", "h", "e", "h"],
+  "answerGlyphs": ["ㅍ", "ㅗ", "ㄷ", "ㅗ"],
+  "icon": "🍇",
+  "ttsText": "포도",
+  "category": "food"
+}
+```
+
+Diphthong vowels (ㅘ, ㅙ, ㅚ, ㅝ, ㅞ, ㅟ, ㅢ) are still **one** array slot
+each, even though their QWERTY token is two characters (`hk`, `nj`, ...) -
+one token/glyph pair per jamo, not per keystroke.
+
+---
+
+## Self-Check Before Returning the File
+
+- [ ] Every syllable block in every word is lead-consonant + vowel only - no batchim, anywhere
+- [ ] `answerKeys.length === answerGlyphs.length` for every entry
+- [ ] Every `answerKeys`/`answerGlyphs` pair was derived from the mapping table above, block by block, left to right
+- [ ] Every `id` is unique, kebab-case, ASCII
+- [ ] Every `icon` is exactly one Unicode emoji, no bundled/attributed image
+- [ ] `ttsText` is the Korean word (not romanization, not English)
+- [ ] `category` is the topic string, e.g. `"numbers"`, not one of the demo set's `"food"/"animal"/"object"/"nature"` labels unless the topic actually is one of those
+- [ ] Output is a bare JSON array - no comments, no trailing commas, no surrounding prose
+
+---
+
+## Multiple Topics (Forward-Looking, Not Today's Shape)
+
+`useHangulVocab` already accepts a `topic` parameter and resolves it to
+`/hangul/words/<topic>.json`, but every caller today omits it and gets the
+default `vocab.json`. To generate a second topic without overwriting the
+first, save it as `packages/some-content/public/hangul/words/<topic>.json`
+instead (e.g. `numbers.json`) - the file will simply sit unused until a host
+app actually threads a `topic` value through to `useHangulVocab`, which is
+out of scope for this stub.
+
+---
+
+## After Generating
+
+- **Docker** (`docker compose up www`): picked up automatically, nothing to
+  run - `infra/compose/www.yml` volume-mounts
+  `packages/some-content/public/hangul` straight through.
+- **`vite dev` (no Docker)**: run `pnpm run content:link` once (from
+  `apps/www`) to symlink `packages/some-content/public/hangul` into
+  `apps/www/public/hangul`.
+- Either way, a **full browser reload** (not just an in-app navigation) is
+  needed to see a freshly (re)generated file - the query client caches a
+  successful fetch for a while and won't refetch on remount.
+- If nothing shows up, open devtools: a 404 falls back to the bundled demo
+  seed silently (expected before you've generated anything); anything else
+  logs a `[hangul-vocab]` console warning.

--- a/packages/ui/honeycomb/src/components/hangul-hex-grid/overlay/index.tsx
+++ b/packages/ui/honeycomb/src/components/hangul-hex-grid/overlay/index.tsx
@@ -14,6 +14,8 @@ import { PromptStation } from "@honeycomb/components/hangul-hex-grid/prompt-stat
 import { StatsPanel } from "@honeycomb/components/hangul-hex-grid/stats-panel"
 import { SuccessFeedback } from "@honeycomb/components/hangul-hex-grid/success-feedback"
 import { HexGrid } from "@honeycomb/components/hex-grid"
+import { HANGUL_WORDS, toChallengeSeed } from "@honeycomb/data"
+import type { WordEntry } from "@honeycomb/data"
 import { useGameAudio } from "@honeycomb/hooks/use-game-audio"
 import { useGameLoop } from "@honeycomb/hooks/use-game-loop"
 import { useGameTimer } from "@honeycomb/hooks/use-game-timer"
@@ -66,6 +68,18 @@ type HangulHexGridProps = {
    * Omit if the host has no such concept.
    */
   suspended?: boolean
+  /**
+   * The word pool for "vocabulary"/"vocabulary-endless" modes (ignored by
+   * every other mode) - defaults to the bundled demo seed
+   * (`@honeycomb/data`'s `HANGUL_WORDS`), same as before this prop existed.
+   * This is the seam a host app uses to swap in its own challenge seed
+   * (e.g. an LLM-generated, environment-specific vocab set fetched at
+   * runtime) without this package knowing or caring where the words came
+   * from - it only ever sees a plain `Array<WordEntry>`, matching
+   * `hangul-words.ts`'s own shape/constraints (open-syllable only, see that
+   * file's header comment).
+   */
+  words?: Array<WordEntry>
 }
 
 export const HangulHexGrid = ({
@@ -73,6 +87,7 @@ export const HangulHexGrid = ({
   difficulty,
   sessionKey,
   suspended = false,
+  words = HANGUL_WORDS,
 }: HangulHexGridProps): JSX.Element => {
   // Memoized so useHangulGameWasm's own [mode, config, wordPool]-keyed
   // initialize() callback stays referentially stable across re-renders that
@@ -81,6 +96,7 @@ export const HangulHexGrid = ({
     () => resolveDifficultyConfig(difficulty),
     [difficulty]
   )
+  const wordPool = useMemo(() => words.map(toChallengeSeed), [words])
   // The engine only reports whether romanization is *currently* shown
   // (TimingParams.showRomanization), not the streak threshold that governs
   // it - StatsPanel needs the actual configured number to display, which
@@ -136,6 +152,7 @@ export const HangulHexGrid = ({
     autoStart: true,
     mode,
     config,
+    wordPool,
     sessionKey,
   })
 
@@ -383,6 +400,7 @@ export const HangulHexGrid = ({
           stimulus={trackedCharacter?.stimulus ?? null}
           tier={promptTier}
           progress={wordProgress}
+          words={words}
         />
 
         <ControlButtons

--- a/packages/ui/honeycomb/src/components/hangul-hex-grid/prompt-station/index.tsx
+++ b/packages/ui/honeycomb/src/components/hangul-hex-grid/prompt-station/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react"
 import { HANGUL_WORDS } from "@honeycomb/data"
+import type { WordEntry } from "@honeycomb/data"
 import type { HintTier } from "@honeycomb/hooks/use-prompt-escalation"
 import { speak } from "@honeycomb/lib/hangul/speech"
 import type { Stimulus } from "@honeycomb/lib/hangul/wasm-game-bridge"
@@ -10,6 +11,13 @@ type PromptStationProps = {
   tier: HintTier
   /** The tracked word's masked-progress snapshot, shown alongside the icon. */
   progress: WordProgress | null
+  /**
+   * The word pool `stimulus.name` is looked up against - must be the same
+   * list HangulHexGrid seeded the WASM engine's `wordPool` from, or a
+   * mid-game stimulus id won't resolve to an entry here. Defaults to the
+   * bundled demo seed so direct/Storybook usage needs no wiring.
+   */
+  words?: Array<WordEntry>
 }
 
 /**
@@ -37,12 +45,13 @@ export const PromptStation = ({
   stimulus,
   tier,
   progress,
+  words = HANGUL_WORDS,
 }: PromptStationProps): React.JSX.Element | null => {
   const lastAutoPlayedTierRef = useRef<HintTier | null>(null)
 
   const entry =
     stimulus?.kind === "icon"
-      ? HANGUL_WORDS.find((word) => word.id === stimulus.name)
+      ? words.find((word) => word.id === stimulus.name)
       : undefined
 
   useEffect(() => {

--- a/packages/ui/honeycomb/src/data/hangul-words.ts
+++ b/packages/ui/honeycomb/src/data/hangul-words.ts
@@ -26,7 +26,15 @@ export type WordEntry = {
   answerGlyphs: Array<string>
   icon: string
   ttsText: string
-  category: "food" | "animal" | "object" | "nature"
+  /**
+   * Free-form grouping label - purely descriptive, never read by the engine
+   * or any component (grep confirms no `.category` reader exists outside
+   * this file). Deliberately `string`, not a closed union: the demo set
+   * below happens to use "food"/"animal"/"object"/"nature", but a
+   * host-supplied `words` override (HangulHexGrid's `words` prop) is free to
+   * use whatever topic labels it wants (e.g. "numbers", "calendar").
+   */
+  category: string
 }
 
 export const HANGUL_WORDS: Array<WordEntry> = [

--- a/packages/ui/honeycomb/src/data/hangul-words.ts
+++ b/packages/ui/honeycomb/src/data/hangul-words.ts
@@ -10,11 +10,20 @@
 // Every entry's stimulus is `Icon` - `ttsText`/`romanization` are additional enrichment the
 // Prompt/Concept Station (#762) escalates to on struggle, not separate stimulus kinds.
 //
-// Every word is open-syllable (no batchim/final-consonant jamo): `Korean::key_for`
-// (crates/hangul-game-core/src/internal/content_domain/korean.rs) only maps the 19 lead
-// consonants + 21 vowels, not final-position consonants, so `answerKeys`/`answerGlyphs` below are
-// hand-verified against that exact table - a batchim-bearing word would silently produce an
-// unmappable/unmatchable token.
+// `answerKeys`/`answerGlyphs` below are each word's full jamo stream in typing order, hand-verified
+// against `Korean::key_for`'s table (crates/hangul-game-core/src/internal/content_domain/korean.rs)
+// - not derived from `word` at runtime; the engine never calls `key_for` for vocabulary-mode
+// challenges (see `VocabularyMode::get_next_challenge`), it matches whatever token sequence a seed
+// supplies, verbatim. `key_for` is position-agnostic (19 consonants + 21 vowels, 7 of the vowels
+// composite), so batchim jamo decompose and play exactly like any other jamo - there is no
+// open-syllable restriction. (An earlier version of this comment claimed otherwise; disproven by
+// `batchim_word_completes_like_any_other_multi_token_challenge` in engine.rs's test module.) The
+// one real gap is `key_for` having no entry for a *compound* batchim as a single character
+// (ㄳ/ㄵ/ㄶ/ㄺ/ㄻ/ㄼ/ㄽ/ㄾ/ㄿ/ㅀ/ㅄ) - since nothing validates answerKeys against key_for at
+// runtime either, represent one as a single glyph slot with its two component keys concatenated
+// (e.g. 닭's ㄺ -> glyph "ㄺ", key "fr"), the same convention the composite vowels above already
+// use (e.g. ㅘ -> key "hk"). Verified working end to end by
+// `compound_batchim_as_one_glyph_with_a_combined_key_completes_too`, also in engine.rs.
 
 import type { ChallengeSeed } from "@honeycomb/lib/hangul/wasm-game-bridge"
 

--- a/packages/ui/honeycomb/src/index.ts
+++ b/packages/ui/honeycomb/src/index.ts
@@ -1,1 +1,2 @@
 export { HangulHexGrid } from "./components"
+export type { WordEntry } from "./data/hangul-words"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,12 @@ importers:
       '@some-ui/content-registry':
         specifier: workspace:*
         version: link:../../packages/some-content-registry
+      '@some-ui/fetch-kit':
+        specifier: workspace:*
+        version: link:../../packages/fetch-kit
+      '@some-ui/honeycomb':
+        specifier: workspace:*
+        version: link:../../packages/ui/honeycomb
       '@some-ui/interview':
         specifier: workspace:*
         version: link:../../packages/ui/interview


### PR DESCRIPTION
## Description

This PR adds infrastructure for developers to generate and use custom Hangul vocabulary sets locally, while preserving the bundled demo seed for the GitHub Pages build. The feature enables swapping in LLM-generated TOPIK 1/2-level word lists on specific topics (numbers, calendar, household items, etc.) during local development and Docker runs, without affecting the static build.

### Key Changes

1. **Prompt Template & Documentation** (`packages/some-content/prompts/hangul-vocab-generator/index.md`)
   - Comprehensive guide for generating vocabulary JSON files via LLM
   - Detailed dubeolsik QWERTY mapping table for all jamo (consonants and vowels)
   - Worked examples showing decomposition of words with and without batchim
   - Self-check checklist for authors before submission
   - Clarifies that batchim (final consonants) and even compound batchim are fully supported

2. **Runtime Vocabulary Loading** (`apps/www/src/lib/hangul-vocab/`)
   - `useHangulVocab()` hook that fetches `/hangul/words/<topic>.json` in server mode (localhost/Docker)
   - Gracefully falls back to bundled demo seed on GitHub Pages (static mode) or when file is missing
   - Zod schema validation (`WordEntrySchema`, `HangulVocabFileSchema`) with helpful error messages
   - Comprehensive test coverage for schema validation and edge cases

3. **Component Integration**
   - `HangulHexGrid` now accepts optional `words` prop to override the default word pool
   - `PromptStation` receives the word pool to correctly resolve stimulus IDs
   - `SessionViewport` threads the fetched vocabulary through to the game component

4. **Engine Tests** (`crates/hangul-game-core/src/internal/engine.rs`)
   - Added `batchim_word_completes_like_any_other_multi_token_challenge` test proving batchim words work
   - Added `compound_batchim_as_one_glyph_with_a_combined_key_completes_too` test validating compound batchim handling
   - Both tests verify the engine has no position-based jamo restrictions

5. **Documentation Updates**
   - Updated `hangul-words.ts` header comment to clarify batchim support and remove outdated open-syllable-only constraint
   - Updated `link-content-assets.js` to include hangul directory in symlink step
   - Updated `infra/compose/www.yml` to document the optional hangul volume mount

6. **Build Configuration**
   - Added `packages/some-content/public/hangul` to `.gitignore` (developer-generated, not committed)
   - Updated `apps/www/package.json` to include `@some-ui/fetch-kit` and `@some-ui/honeycomb` dependencies
   - Exported `WordEntry` type from honeycomb for use in validation schemas

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Test Plan

- Engine tests verify batchim and compound batchim decomposition work correctly
- Schema validation tests confirm the Zod schemas properly validate well-formed entries and reject common mistakes (mismatched array lengths, missing fields, empty arrays)
- Local dev: Run `pnpm run content:link` to symlink assets, then generate a vocab file using the prompt template and verify it loads in the game
- Docker: `docker compose up www` automatically mounts the hangul directory if it exists
- GitHub Pages: Unaffected—continues using bundled demo seed with no companion data fetch

https://claude.ai/code/session_01PkZZCg6ohLPRPtFEdcmz1E