### PR TITLE
fix(www): stop devtools in prod, fix resume.pdf 404, add landing page

### DIFF
--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -10,10 +10,11 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as DashboardRouteImport } from './routes/_dashboard'
-import { Route as DashboardIndexRouteImport } from './routes/_dashboard/index'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as DashboardSettingsRouteImport } from './routes/_dashboard/settings'
 import { Route as DashboardResumeRouteImport } from './routes/_dashboard/resume'
 import { Route as DashboardProfileRouteImport } from './routes/_dashboard/profile'
+import { Route as DashboardAppRouteImport } from './routes/_dashboard/app'
 import { Route as DashboardSessionsIndexRouteImport } from './routes/_dashboard/sessions/index'
 import { Route as DashboardSessionsNewRouteImport } from './routes/_dashboard/sessions/new'
 import { Route as DashboardSessionsSessionIdRouteImport } from './routes/_dashboard/sessions/$sessionId'
@@ -22,10 +23,10 @@ const DashboardRoute = DashboardRouteImport.update({
   id: '/_dashboard',
   getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardIndexRoute = DashboardIndexRouteImport.update({
+const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => DashboardRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardSettingsRoute = DashboardSettingsRouteImport.update({
   id: '/settings',
@@ -40,6 +41,11 @@ const DashboardResumeRoute = DashboardResumeRouteImport.update({
 const DashboardProfileRoute = DashboardProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
+  getParentRoute: () => DashboardRoute,
+} as any)
+const DashboardAppRoute = DashboardAppRouteImport.update({
+  id: '/app',
+  path: '/app',
   getParentRoute: () => DashboardRoute,
 } as any)
 const DashboardSessionsIndexRoute = DashboardSessionsIndexRouteImport.update({
@@ -60,7 +66,8 @@ const DashboardSessionsSessionIdRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof DashboardIndexRoute
+  '/': typeof IndexRoute
+  '/app': typeof DashboardAppRoute
   '/profile': typeof DashboardProfileRoute
   '/resume': typeof DashboardResumeRoute
   '/settings': typeof DashboardSettingsRoute
@@ -69,21 +76,23 @@ export interface FileRoutesByFullPath {
   '/sessions/': typeof DashboardSessionsIndexRoute
 }
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '/app': typeof DashboardAppRoute
   '/profile': typeof DashboardProfileRoute
   '/resume': typeof DashboardResumeRoute
   '/settings': typeof DashboardSettingsRoute
-  '/': typeof DashboardIndexRoute
   '/sessions/$sessionId': typeof DashboardSessionsSessionIdRoute
   '/sessions/new': typeof DashboardSessionsNewRoute
   '/sessions': typeof DashboardSessionsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
   '/_dashboard': typeof DashboardRouteWithChildren
+  '/_dashboard/app': typeof DashboardAppRoute
   '/_dashboard/profile': typeof DashboardProfileRoute
   '/_dashboard/resume': typeof DashboardResumeRoute
   '/_dashboard/settings': typeof DashboardSettingsRoute
-  '/_dashboard/': typeof DashboardIndexRoute
   '/_dashboard/sessions/$sessionId': typeof DashboardSessionsSessionIdRoute
   '/_dashboard/sessions/new': typeof DashboardSessionsNewRoute
   '/_dashboard/sessions/': typeof DashboardSessionsIndexRoute
@@ -92,6 +101,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/app'
     | '/profile'
     | '/resume'
     | '/settings'
@@ -100,26 +110,29 @@ export interface FileRouteTypes {
     | '/sessions/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/'
+    | '/app'
     | '/profile'
     | '/resume'
     | '/settings'
-    | '/'
     | '/sessions/$sessionId'
     | '/sessions/new'
     | '/sessions'
   id:
     | '__root__'
+    | '/'
     | '/_dashboard'
+    | '/_dashboard/app'
     | '/_dashboard/profile'
     | '/_dashboard/resume'
     | '/_dashboard/settings'
-    | '/_dashboard/'
     | '/_dashboard/sessions/$sessionId'
     | '/_dashboard/sessions/new'
     | '/_dashboard/sessions/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
   DashboardRoute: typeof DashboardRouteWithChildren
 }
 
@@ -132,12 +145,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_dashboard/': {
-      id: '/_dashboard/'
+    '/': {
+      id: '/'
       path: '/'
       fullPath: '/'
-      preLoaderRoute: typeof DashboardIndexRouteImport
-      parentRoute: typeof DashboardRoute
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_dashboard/settings': {
       id: '/_dashboard/settings'
@@ -158,6 +171,13 @@ declare module '@tanstack/react-router' {
       path: '/profile'
       fullPath: '/profile'
       preLoaderRoute: typeof DashboardProfileRouteImport
+      parentRoute: typeof DashboardRoute
+    }
+    '/_dashboard/app': {
+      id: '/_dashboard/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof DashboardAppRouteImport
       parentRoute: typeof DashboardRoute
     }
     '/_dashboard/sessions/': {
@@ -185,20 +205,20 @@ declare module '@tanstack/react-router' {
 }
 
 interface DashboardRouteChildren {
+  DashboardAppRoute: typeof DashboardAppRoute
   DashboardProfileRoute: typeof DashboardProfileRoute
   DashboardResumeRoute: typeof DashboardResumeRoute
   DashboardSettingsRoute: typeof DashboardSettingsRoute
-  DashboardIndexRoute: typeof DashboardIndexRoute
   DashboardSessionsSessionIdRoute: typeof DashboardSessionsSessionIdRoute
   DashboardSessionsNewRoute: typeof DashboardSessionsNewRoute
   DashboardSessionsIndexRoute: typeof DashboardSessionsIndexRoute
 }
 
 const DashboardRouteChildren: DashboardRouteChildren = {
+  DashboardAppRoute: DashboardAppRoute,
   DashboardProfileRoute: DashboardProfileRoute,
   DashboardResumeRoute: DashboardResumeRoute,
   DashboardSettingsRoute: DashboardSettingsRoute,
-  DashboardIndexRoute: DashboardIndexRoute,
   DashboardSessionsSessionIdRoute: DashboardSessionsSessionIdRoute,
   DashboardSessionsNewRoute: DashboardSessionsNewRoute,
   DashboardSessionsIndexRoute: DashboardSessionsIndexRoute,
@@ -209,6 +229,7 @@ const DashboardRouteWithChildren = DashboardRoute._addFileChildren(
 )
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
   DashboardRoute: DashboardRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -6,17 +6,22 @@ export const Route = createRootRoute({
   component: () => (
     <>
       <Outlet />
-      <TanstackDevtools
-        config={{
-          position: "bottom-left",
-        }}
-        plugins={[
-          {
-            name: "Tanstack Router",
-            render: <TanStackRouterDevtoolsPanel />,
-          },
-        ]}
-      />
+      {/* Vite strips this whole block (and its two devtools deps) from the
+          production bundle - without the guard it also renders on the
+          deployed GitHub Pages site, which is what happened before. */}
+      {import.meta.env.DEV && (
+        <TanstackDevtools
+          config={{
+            position: "bottom-left",
+          }}
+          plugins={[
+            {
+              name: "Tanstack Router",
+              render: <TanStackRouterDevtoolsPanel />,
+            },
+          ]}
+        />
+      )}
     </>
   ),
 })

--- a/apps/www/src/routes/_dashboard.tsx
+++ b/apps/www/src/routes/_dashboard.tsx
@@ -37,13 +37,13 @@ function isViewportPath(pathname: string): boolean {
 }
 
 type NavItem = {
-  to: "/" | "/sessions" | "/resume" | "/profile" | "/settings"
+  to: "/app" | "/sessions" | "/resume" | "/profile" | "/settings"
   label: string
   icon: typeof Home
 }
 
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { to: "/", label: "Home", icon: Home },
+  { to: "/app", label: "Home", icon: Home },
   { to: "/sessions", label: "Sessions", icon: ListVideo },
   { to: "/resume", label: "Résumé", icon: FileText },
   { to: "/profile", label: "Profile", icon: User },
@@ -51,7 +51,6 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
 ]
 
 function isNavItemActive(itemPath: NavItem["to"], pathname: string): boolean {
-  if (itemPath === "/") return pathname === "/"
   return pathname === itemPath || pathname.startsWith(`${itemPath}/`)
 }
 

--- a/apps/www/src/routes/_dashboard/app.tsx
+++ b/apps/www/src/routes/_dashboard/app.tsx
@@ -196,6 +196,6 @@ const DashboardHome = (): JSX.Element => {
   )
 }
 
-export const Route = createFileRoute("/_dashboard/")({
+export const Route = createFileRoute("/_dashboard/app")({
   component: DashboardHome,
 })

--- a/apps/www/src/routes/_dashboard/resume.tsx
+++ b/apps/www/src/routes/_dashboard/resume.tsx
@@ -9,7 +9,12 @@ import {
   CardTitle,
 } from "some-ui-shared"
 
-const RESUME_PDF_PATH = "/resume.pdf"
+// GitHub Pages serves this app under /<repo>/ (see vite.config.ts's
+// VITE_BASE_PATH); a bare "/resume.pdf" would request the domain root
+// instead and 404 there. import.meta.env.BASE_URL always ends in "/", so
+// this resolves correctly for GitHub Pages, the Docker/nginx build, and
+// local dev alike.
+const RESUME_PDF_PATH = `${import.meta.env.BASE_URL}resume.pdf`
 
 const ResumeRoute = (): JSX.Element => (
   <Card className="flex h-full flex-col">

--- a/apps/www/src/routes/_dashboard/sessions/index.tsx
+++ b/apps/www/src/routes/_dashboard/sessions/index.tsx
@@ -335,7 +335,7 @@ const SessionsRoute = (): JSX.Element => {
           <Sparkles className="size-6" />
           <p>No sessions yet.</p>
           <Button asChild size="sm" className="mt-2">
-            <Link to="/">Start something new</Link>
+            <Link to="/app">Start something new</Link>
           </Button>
         </CardContent>
       </Card>

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -1,0 +1,137 @@
+import type { JSX } from "react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import {
+  ArrowRight,
+  ArrowUpRight,
+  BookOpen,
+  FileText,
+  Sparkles,
+} from "lucide-react"
+import { Card, CardContent } from "some-ui-shared"
+
+import { ThemeSwitcher } from "@/components/theme-switcher"
+
+/**
+ * This repo's GitHub Pages deployment bundles three unrelated static
+ * artifacts under one origin (see .github/workflows/pages.yml): this
+ * TanStack app, a Storybook build nested at /storybook/, and this app's own
+ * /resume route. A visitor landing on "/" cold has no way to know any of
+ * that exists, so "/" is this standalone splash - not the learning app -
+ * whose only job is to point at the three of them.
+ */
+type DestinationBase = {
+  title: string
+  description: string
+  icon: typeof Sparkles
+  cta: string
+}
+
+// The Storybook build is a separate static site outside the SPA's route
+// tree (its href is only known at runtime, from BASE_URL), so it can't be
+// typed against the router like the two in-app destinations can.
+type Destination =
+  | (DestinationBase & { external: true; href: string })
+  | (DestinationBase & { external?: false; href: "/app" | "/resume" })
+
+const DESTINATIONS: ReadonlyArray<Destination> = [
+  {
+    title: "Adaptive learning sessions",
+    description:
+      "Compose and run focused study sessions - Hangul Honeycomb, TOPIK practice, interview prep, and timed code-typing drills.",
+    icon: Sparkles,
+    cta: "Open the app",
+    href: "/app",
+  },
+  {
+    title: "Component library",
+    description:
+      "Every component in this workspace, documented and previewable in isolation as a static Storybook build.",
+    icon: BookOpen,
+    cta: "Browse Storybook",
+    href: `${import.meta.env.BASE_URL}storybook/`,
+    external: true,
+  },
+  {
+    title: "Résumé & background",
+    description: "Paul Gathondu's résumé, previewable inline or as a PDF.",
+    icon: FileText,
+    cta: "View résumé",
+    href: "/resume",
+  },
+]
+
+const DestinationCard = (destination: Destination): JSX.Element => {
+  const { title, description, icon: Icon, cta, external } = destination
+  const body = (
+    <Card className="hover:border-primary/50 group h-full transition-colors">
+      <CardContent className="flex h-full flex-col gap-4 pt-6">
+        <div className="bg-primary/10 flex size-11 items-center justify-center rounded-full">
+          <Icon className="text-primary size-5" aria-hidden />
+        </div>
+        <div className="flex-1 space-y-1.5">
+          <h2 className="font-semibold">{title}</h2>
+          <p className="text-muted-foreground text-sm">{description}</p>
+        </div>
+        <span className="text-primary inline-flex items-center gap-1 text-sm font-medium">
+          {cta}
+          {external ? (
+            <ArrowUpRight className="size-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+          ) : (
+            <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+          )}
+        </span>
+      </CardContent>
+    </Card>
+  )
+
+  if (destination.external) {
+    return (
+      <a
+        href={destination.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block h-full"
+      >
+        {body}
+      </a>
+    )
+  }
+
+  return (
+    <Link to={destination.href} className="block h-full">
+      {body}
+    </Link>
+  )
+}
+
+const Landing = (): JSX.Element => (
+  <main className="bg-background text-foreground relative min-h-svh">
+    <div className="absolute top-4 right-4">
+      <ThemeSwitcher />
+    </div>
+    <div className="mx-auto flex min-h-svh max-w-4xl flex-col justify-center gap-10 px-6 py-16">
+      <div className="space-y-3 text-center">
+        <p className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
+          Some UI
+        </p>
+        <h1 className="text-gradient-heading text-3xl font-bold tracking-tight sm:text-4xl">
+          Three projects, one workspace
+        </h1>
+        <p className="text-muted-foreground mx-auto max-w-xl text-balance">
+          This site hosts an adaptive study app, a component library, and a
+          résumé - built and deployed from a single monorepo. Pick a destination
+          below.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        {DESTINATIONS.map((destination) => (
+          <DestinationCard key={destination.title} {...destination} />
+        ))}
+      </div>
+    </div>
+  </main>
+)
+
+export const Route = createFileRoute("/")({
+  component: Landing,
+})


### PR DESCRIPTION
## Description

Fixes #790 — three GitHub Pages issues in one PR:

1. **TanStack devtools rendered in production.** `__root.tsx` always mounted `<TanstackDevtools>` regardless of environment. Now gated behind `import.meta.env.DEV`, so Vite strips it (and its two devtools deps) from the production bundle entirely.
2. **`/resume.pdf` 404s on GitHub Pages.** The `/resume` route hardcoded an absolute `RESUME_PDF_PATH = "/resume.pdf"`, bypassing the router's basepath handling. GitHub Pages serves this app under `/some-ui/`, so that request hit the domain root instead and 404'd — the PDF itself was already being built and copied correctly by the existing `sync-resume.mjs`/turbo pipeline, it just wasn't reachable at that URL. Now built from `import.meta.env.BASE_URL`, which resolves correctly for GitHub Pages, the Docker/nginx build, and local dev alike.
3. **No canonical landing page.** This repo's GitHub Pages deployment bundles three unrelated artifacts under one origin (see `.github/workflows/pages.yml`): the TanStack study app, a Storybook build nested at `/storybook/`, and the résumé. A visitor landing on `/` cold previously dropped straight into the study-app dashboard with no way to discover the other two. `/` is now a standalone splash page linking out to all three; the dashboard's own home moved from `/` to `/app` (sidebar nav and internal links updated accordingly).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (`tsc --noEmit` and `eslint` clean)
- [x] New and existing unit tests pass locally with my changes (58/58 `vitest` tests pass)
- [x] Verified in a real `vite build --mode production` with `VITE_BASE_PATH=/some-ui/` that `/resume` resolves to `/some-ui/resume.pdf` and the landing page's Storybook link resolves to `/some-ui/storybook/`

## Screenshots

Verified visually via a local Playwright check against `vite dev` — the new `/` splash renders three cards (Adaptive learning sessions → `/app`, Component library → `/storybook/`, Résumé & background → `/resume`) in both light and dark theme, using the existing design system (`text-gradient-heading`, `Card`, `ThemeSwitcher`).
