### PR TITLE
Add LeetType challenge corpus override support

### DIFF
--- a/apps/www/.gitignore
+++ b/apps/www/.gitignore
@@ -13,4 +13,5 @@ count.txt
 # assets of unknown size
 /public/code-samples
 /public/hangul
+/public/leetype
 /public/resume.pdf

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -30,6 +30,7 @@
     "@some-ui/content": "workspace:*",
     "@some-ui/fetch-kit": "workspace:*",
     "@some-ui/honeycomb": "workspace:*",
+    "@some-ui/leetype": "workspace:*",
     "@some-ui/styles": "workspace:*",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-devtools": "^0.2.2",

--- a/apps/www/scripts/link-content-assets.js
+++ b/apps/www/scripts/link-content-assets.js
@@ -1,10 +1,11 @@
-// honeycomb's sfx, leetype's code samples, and (optionally) an LLM-generated
-// hangul vocab file all live in packages/some-content (see
-// apps/www/.gitignore) and aren't checked into this app's public/ dir. CI's
-// Pages build (pages.yml) copies sfx/code-samples into public/ at build
-// time - hangul is deliberately NOT part of that copy step, since the
-// static GitHub Pages build has no companion data at all (see
-// src/lib/hangul-vocab). For local `vite dev` this symlinks all three
+// honeycomb's sfx, leetype's demo code samples, and (optionally) an
+// LLM-generated hangul vocab file or leetype challenge corpus all live in
+// packages/some-content (see apps/www/.gitignore) and aren't checked into
+// this app's public/ dir. CI's Pages build (pages.yml) copies sfx/
+// code-samples into public/ at build time - hangul/leetype are deliberately
+// NOT part of that copy step, since the static GitHub Pages build has no
+// companion data at all (see src/lib/hangul-vocab and
+// src/lib/leetype-challenges). For local `vite dev` this symlinks all four
 // instead, so the dev server serves the real files straight out of
 // packages/some-content, live, with no rebuild needed. Run manually via
 // `pnpm run content:link` when you have the actual asset files locally -
@@ -12,14 +13,14 @@
 // auto-executing Node on install/dev is a footgun (surprise side effects,
 // supply-chain scanner flags on the lifecycle script itself). vite.config.ts
 // warns at dev-server startup if sfx/code-samples are missing, pointing back
-// at this command - hangul is excluded from that warning since, unlike
-// those two, its absence is expected/harmless (HangulHexGrid's bundled demo
-// seed covers it).
+// at this command - hangul/leetype are excluded from that warning since,
+// unlike those two, their absence is expected/harmless (HangulHexGrid's and
+// Leetype's own bundled demo pools cover it).
 //
 // No-op for any subdir that doesn't exist locally: these assets are
 // curated/gitignored, not part of a fresh checkout, so a machine without
 // them just runs without honeycomb sound / leetype samples / custom hangul
-// vocab rather than failing.
+// vocab / custom leetype challenges rather than failing.
 import {
   existsSync,
   lstatSync,
@@ -37,7 +38,7 @@ const contentPublicDir = resolve(
   "../../../packages/some-content/public"
 )
 
-for (const name of ["sfx", "code-samples", "hangul"]) {
+for (const name of ["sfx", "code-samples", "hangul", "leetype"]) {
   const src = resolve(contentPublicDir, name)
   const dest = resolve(appPublicDir, name)
 

--- a/apps/www/src/components/player/session-viewport.tsx
+++ b/apps/www/src/components/player/session-viewport.tsx
@@ -11,6 +11,7 @@ import {
 import { LiveEditOverlay, OrchestratedYouTubeViewport } from "wireframes"
 
 import { useHangulVocab } from "@/lib/hangul-vocab"
+import { useLeetypeChallenges } from "@/lib/leetype-challenges"
 import type { SessionRecord } from "@/lib/tenant"
 
 import { useLiveLayoutEditor } from "./use-live-layout-editor"
@@ -54,19 +55,22 @@ export const SessionViewport = ({
 
   const sessionKey = useSessionKey()
   const suspended = useSuspended()
-  // Only HangulHexGrid declares a `words` prop; every other registry
-  // component ignores it the same way it already ignores sessionKey/
-  // suspended when it doesn't need them (see extraProps' own doc comment
-  // below and RegistryEntry<P = any> in @some-ui/types).
+  // Only HangulHexGrid declares a `words` prop and only Leetype declares a
+  // `challenges` prop; every other registry component ignores whichever one
+  // it doesn't need, the same way it already ignores sessionKey/suspended
+  // (see extraProps' own doc comment below and RegistryEntry<P = any> in
+  // @some-ui/types).
   const hangulWords = useHangulVocab()
+  const leetypeChallenges = useLeetypeChallenges()
 
   const extraProps = useMemo(
     () => ({
       sessionKey: sessionKey ?? undefined,
       suspended,
       words: hangulWords,
+      challenges: leetypeChallenges,
     }),
-    [sessionKey, suspended, hangulWords]
+    [sessionKey, suspended, hangulWords, leetypeChallenges]
   )
 
   return (

--- a/apps/www/src/lib/activity-catalog/catalog.ts
+++ b/apps/www/src/lib/activity-catalog/catalog.ts
@@ -1,4 +1,3 @@
-import { CHALLENGES } from "@some-ui/content"
 import { interviewQuestions } from "@some-ui/interview"
 import type { Question } from "@some-ui/interview"
 
@@ -22,21 +21,6 @@ function filterInterviewQuestions(
   if (byCategory.length > 0) return byCategory
 
   return interviewQuestions
-}
-
-/**
- * Resolves the composer's plain `difficulty` identifier into the actual
- * challenge (title/description/tags/codePaths) Leetype's component expects -
- * the "live player's job" this activity's `toSceneProps` previously deferred
- * (see ActivityDefinition.toSceneProps's own doc comment), leaving every
- * session's `path` empty and its loader permanently idle. Deterministic
- * (first match) rather than random, so replaying a session shows the same
- * challenge it did the first time.
- */
-function pickLeetypeChallenge(
-  difficulty: unknown
-): (typeof CHALLENGES)[number] {
-  return CHALLENGES.find((c) => c.difficulty === difficulty) ?? CHALLENGES[0]
 }
 
 const honeycomb: ActivityDefinition = {
@@ -229,8 +213,15 @@ const leetype: ActivityDefinition = {
     difficulty: "easy",
     durationMinutes: 10,
   },
+  // `difficulty` is passed through as the friendly label the player picked
+  // ("easy"/"medium"/"hard"), not resolved into a full Challenge here -
+  // Leetype (@some-ui/leetype) resolves it at render time against its own
+  // `challenges` pool (bundled CHALLENGES by default, optionally overridden
+  // with a local/Docker-fetched corpus - see
+  // apps/www/src/lib/leetype-challenges), the same way session-viewport
+  // already lets HangulHexGrid resolve its own word pool.
   toSceneProps: (config) => ({
-    challenge: pickLeetypeChallenge(config.difficulty),
+    difficulty: config.difficulty,
     initialLanguage: config.language,
   }),
 }

--- a/apps/www/src/lib/leetype-challenges/index.ts
+++ b/apps/www/src/lib/leetype-challenges/index.ts
@@ -1,0 +1,83 @@
+import { useEffect } from "react"
+import { ApiError, createDataSource } from "@some-ui/fetch-kit"
+import type { Challenge } from "@some-ui/leetype"
+
+import { LeetypeChallengesFileSchema } from "./schema"
+
+type LeetypeChallengesParams = Record<string, never>
+
+/**
+ * Same relative path in both modes - `/leetype/challenges.json`, served from
+ * whatever's mounted/symlinked at `public/leetype` (see
+ * infra/compose/www.yml and scripts/link-content-assets.js). The two-locator
+ * shape only matters for `useLeetypeChallenges`'s mode gate below: the
+ * GitHub Pages build ships no companion corpus at all - `Leetype`'s own
+ * bundled demo pool (`@some-ui/content`'s `CHALLENGES`) is the whole story
+ * there.
+ */
+function locateChallengesFile(_params: LeetypeChallengesParams): URL {
+  return new URL("/leetype/challenges.json", window.location.origin)
+}
+
+const leetypeChallengesSource = createDataSource<
+  LeetypeChallengesParams,
+  Array<Challenge>
+>(
+  { static: locateChallengesFile, server: locateChallengesFile },
+  {
+    // Docker/local dev is also reachable over the LAN mDNS hostname
+    // vite.config.ts allows (`nixos.local`, for the HTTPS/getUserMedia
+    // path) - widen fetch-kit's hostname heuristic to match, so that host
+    // resolves to "server" the same as plain localhost does.
+    serverHostnames: ["localhost", "127.0.0.1", "[::1]", "nixos.local"],
+  }
+)
+
+/**
+ * The apps/www-only half of the "real corpus locally, demo corpus on GitHub
+ * Pages" split (mirrors `useHangulVocab`/`hangul-vocab`). `@some-ui/leetype`
+ * stays fetch-free and ships only the bundled demo `CHALLENGES`; this hook
+ * is where a host app opts into something else.
+ *
+ * - **GitHub Pages / any non-server host**: `leetypeChallengesSource.mode`
+ *   resolves to `"static"`, the query is `enabled: false`, and no request is
+ *   ever issued - there is no companion server and no `public/leetype` dir
+ *   in that build to fetch from anyway.
+ * - **localhost / Docker / LAN dev**: fetches `/leetype/challenges.json`
+ *   (gitignored, developer-populated - see
+ *   `packages/some-content/public/leetype`). A 404 (the common case on a
+ *   fresh checkout, before anyone has generated a corpus) resolves quietly
+ *   to `undefined`. Any other failure (malformed JSON, a schema mismatch)
+ *   is also non-fatal to the caller, but is logged loudly so it doesn't
+ *   read as "the feature silently doesn't work."
+ *
+ * Either way the caller gets back `Array<Challenge> | undefined`;
+ * `undefined` means "no override" - pass it straight through to `Leetype`'s
+ * `challenges` prop, whose own default (bundled `CHALLENGES`) takes over.
+ */
+export function useLeetypeChallenges(): Array<Challenge> | undefined {
+  const { data, error, isError } = leetypeChallengesSource.useResource(
+    ["leetype-challenges"],
+    {},
+    LeetypeChallengesFileSchema,
+    {
+      enabled: leetypeChallengesSource.mode === "server",
+      retry: false,
+    }
+  )
+
+  useEffect(() => {
+    if (!isError) return
+    // A missing file is steady state (nobody's generated a corpus yet) -
+    // only warn about failures that mean a file exists but this app
+    // couldn't use it.
+    if (error instanceof ApiError && error.status === 404) return
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[leetype-challenges] Failed to load challenges.json - falling back to the bundled demo challenges.",
+      error
+    )
+  }, [isError, error])
+
+  return data
+}

--- a/apps/www/src/lib/leetype-challenges/schema.test.ts
+++ b/apps/www/src/lib/leetype-challenges/schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import { ChallengeSchema, LeetypeChallengesFileSchema } from "./schema"
+
+const validChallenge = {
+  id: "ds-stack",
+  title: "Stack",
+  description: "Implement a stack (LIFO) using an array backing store.",
+  difficulty: "easy",
+  mode: "data-structure",
+  tags: ["stack", "lifo", "array"],
+  codePaths: {
+    typescript: "/leetype/samples/ds-stack.ts",
+    rust: "/leetype/samples/ds-stack.rs",
+    cpp: "/leetype/samples/ds-stack.cpp",
+    c: "/leetype/samples/ds-stack.c",
+  },
+  levelRequired: 1,
+}
+
+describe("ChallengeSchema", () => {
+  it("accepts a well-formed challenge", () => {
+    expect(ChallengeSchema.safeParse(validChallenge).success).toBe(true)
+  })
+
+  it("rejects an entry missing a required field", () => {
+    const { id: _id, ...withoutId } = validChallenge
+    expect(ChallengeSchema.safeParse(withoutId).success).toBe(false)
+  })
+
+  it("rejects codePaths missing one of the four languages", () => {
+    const { c: _c, ...codePathsWithoutC } = validChallenge.codePaths
+    const result = ChallengeSchema.safeParse({
+      ...validChallenge,
+      codePaths: codePathsWithoutC,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects an unrecognized difficulty", () => {
+    const result = ChallengeSchema.safeParse({
+      ...validChallenge,
+      difficulty: "impossible",
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("LeetypeChallengesFileSchema", () => {
+  it("accepts a non-empty array of valid challenges", () => {
+    const result = LeetypeChallengesFileSchema.safeParse([validChallenge])
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects an empty array - an empty corpus has nothing to type", () => {
+    expect(LeetypeChallengesFileSchema.safeParse([]).success).toBe(false)
+  })
+})

--- a/apps/www/src/lib/leetype-challenges/schema.ts
+++ b/apps/www/src/lib/leetype-challenges/schema.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+/**
+ * Mirrors `@some-ui/leetype`'s `Challenge`
+ * (packages/ui/leetype/src/types/leetype.ts) - this is the contract an
+ * LLM-generated/local challenge corpus must satisfy to be usable as
+ * `Leetype`'s `challenges` pool override. Kept as an independent schema
+ * (not imported from `@some-ui/leetype`, which has no zod dependency of its
+ * own for this type) so `apps/www` can validate the fetched JSON before it
+ * ever reaches the component; `z.infer` below stays structurally assignable
+ * to `Challenge` because the field types match exactly.
+ *
+ * `codePaths` are resolved the same way the bundled demo's are - relative to
+ * whatever's mounted/symlinked at `public/leetype` (see
+ * infra/compose/www.yml and scripts/link-content-assets.js) - so a local
+ * corpus's `challenges.json` should point at files it also places under
+ * that same directory (e.g. `/leetype/samples/ds-stack.ts`), not at
+ * `/code-samples/*` (the small, committed demo set that ships on GitHub
+ * Pages).
+ */
+export const ChallengeSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  difficulty: z.enum(["easy", "medium", "hard"]),
+  mode: z.enum(["data-structure", "algorithm"]),
+  tags: z.array(z.string().min(1)),
+  codePaths: z.object({
+    typescript: z.string().min(1),
+    rust: z.string().min(1),
+    cpp: z.string().min(1),
+    c: z.string().min(1),
+  }),
+  levelRequired: z.number(),
+})
+
+export const LeetypeChallengesFileSchema = z.array(ChallengeSchema).min(1)
+
+export type LeetypeChallengesFile = z.infer<typeof LeetypeChallengesFileSchema>

--- a/crates/hangul-game-core/src/internal/engine.rs
+++ b/crates/hangul-game-core/src/internal/engine.rs
@@ -329,7 +329,11 @@ impl<D: ContentDomain> GameEngine<D> {
             0
         };
 
-        let is_timed_out = if self.game_duration_ms > 0 { elapsed_ms >= self.game_duration_ms } else { false };
+        let is_timed_out = if self.game_duration_ms > 0 && self.game_mode.has_time_limit() {
+            elapsed_ms >= self.game_duration_ms
+        } else {
+            false
+        };
 
         let time_remaining_ms = if self.game_duration_ms > 0 {
             self.game_duration_ms.saturating_sub(elapsed_ms)
@@ -894,6 +898,64 @@ mod tests {
             }
             other => panic!("expected CharacterSpawned from the new word pool, got {other:?}"),
         }
+    }
+
+    // game_timer_start_ms == 0 is this engine's "timer never started" sentinel
+    // (get_status's `if self.game_timer_start_ms > 0` gate, and the default/
+    // clear_session_state value) - these tests start the timer at a nonzero
+    // timestamp so elapsed time is actually computed, matching how a real
+    // caller always passes a genuine (always > 0) Date.now()-derived value.
+    const TIMER_START_MS: u64 = 1_000;
+
+    #[test]
+    fn completion_mode_times_out_once_game_duration_elapses() {
+        let mut engine = engine_with("completion");
+        engine.start_timer(TIMER_START_MS);
+
+        let status = engine.get_status(TIMER_START_MS + GameConfig::default().game_duration_ms);
+
+        assert!(status.is_timed_out);
+    }
+
+    #[test]
+    fn endless_mode_never_times_out_no_matter_how_long_the_timer_has_run() {
+        let mut engine = engine_with("endless");
+        engine.start_timer(TIMER_START_MS);
+
+        // Many multiples of the configured game_duration_ms - "endless" must mean endless, not
+        // "times out like every other mode, just not displayed."
+        let status = engine.get_status(TIMER_START_MS + GameConfig::default().game_duration_ms * 100);
+
+        assert!(!status.is_timed_out);
+    }
+
+    #[test]
+    fn vocabulary_endless_variant_never_times_out_but_the_non_endless_variant_does() {
+        let mut timed = engine_with("vocabulary");
+        timed.start_timer(TIMER_START_MS);
+        assert!(timed.get_status(TIMER_START_MS + GameConfig::default().game_duration_ms).is_timed_out);
+
+        let mut untimed = engine_with("vocabulary-endless");
+        untimed.start_timer(TIMER_START_MS);
+        assert!(!untimed.get_status(TIMER_START_MS + GameConfig::default().game_duration_ms * 100).is_timed_out);
+    }
+
+    #[test]
+    fn switching_from_a_timed_mode_to_endless_stops_it_from_timing_out() {
+        // set_mode replaces game_mode wholesale (canon Axiom 12.1) - has_time_limit must be
+        // re-read from whatever mode is current, not cached from construction time. set_mode
+        // also resets game_timer_start_ms to 0 (clear_session_state), so restart the timer
+        // explicitly to actually exercise the timed-out branch under the new mode instead of
+        // trivially passing because the timer never restarted.
+        let mut engine = engine_with("completion");
+        engine.start_timer(TIMER_START_MS);
+        let far_future = TIMER_START_MS + GameConfig::default().game_duration_ms * 100;
+        assert!(engine.get_status(far_future).is_timed_out);
+
+        engine.set_mode("endless".to_string(), vec![]);
+        engine.start_timer(TIMER_START_MS);
+
+        assert!(!engine.get_status(far_future).is_timed_out);
     }
 
     #[test]

--- a/crates/hangul-game-core/src/internal/game_modes.rs
+++ b/crates/hangul-game-core/src/internal/game_modes.rs
@@ -34,6 +34,15 @@ pub trait GameMode {
     /// Check if game is complete
     fn is_complete(&self) -> bool;
 
+    /// Whether this mode is bound by `GameConfig::game_duration_ms` at all - `GameEngine::get_status`
+    /// only ever reports `is_timed_out` when this is true. Defaults to `true` (today's universal
+    /// behavior for every mode that doesn't override it); `EndlessMode` and the endless variant of
+    /// `VocabularyMode` are the only ones that are not time-boxed by definition, so they're the only
+    /// overrides.
+    fn has_time_limit(&self) -> bool {
+        true
+    }
+
     /// Get progress information
     fn get_progress(&self) -> GameProgress;
 

--- a/crates/hangul-game-core/src/internal/game_modes/endless.rs
+++ b/crates/hangul-game-core/src/internal/game_modes/endless.rs
@@ -40,6 +40,10 @@ impl GameMode for EndlessMode {
         false // Never completes
     }
 
+    fn has_time_limit(&self) -> bool {
+        false // Endless means endless - no wall-clock cutoff either
+    }
+
     fn get_progress(&self) -> GameProgress {
         GameProgress {
             total_keys: 0,

--- a/crates/hangul-game-core/src/internal/game_modes/vocabulary.rs
+++ b/crates/hangul-game-core/src/internal/game_modes/vocabulary.rs
@@ -69,6 +69,12 @@ impl GameMode for VocabularyMode {
         !self.endless && !self.all.is_empty() && self.completed.len() == self.all.len()
     }
 
+    fn has_time_limit(&self) -> bool {
+        // Same "endless means endless" carve-out as EndlessMode - the non-endless variant keeps
+        // today's universal time-boxed behavior.
+        !self.endless
+    }
+
     fn get_progress(&self) -> GameProgress {
         let total = self.all.len();
         let completed = self.completed.len();

--- a/infra/compose/www.yml
+++ b/infra/compose/www.yml
@@ -21,15 +21,17 @@
 # `docker compose up www` working out of the box against this repo's own
 # (mostly empty/gitignored) copies.
 #
-# packages/some-content/public/hangul is the same story with one difference:
-# it's optional, not load-bearing. HangulHexGrid's own bundled demo seed
-# (@some-ui/honeycomb) always works with nothing mounted here at all - this
-# volume only matters if you've asked an LLM to generate a
-# hangul/words/vocab.json (see apps/www/src/lib/hangul-vocab) and want this
-# container to serve it instead of the demo words. Unlike sfx/code-samples,
-# the GitHub Pages build never bakes this in either way: there's no
-# companion data there, by design (apps/www resolves to "static" mode and
-# never fetches it).
+# packages/some-content/public/hangul and .../leetype are the same story with
+# one difference: they're optional, not load-bearing. HangulHexGrid's and
+# Leetype's own bundled demo pools (@some-ui/honeycomb's HANGUL_WORDS,
+# @some-ui/content's CHALLENGES) always work with nothing mounted here at
+# all - these volumes only matter if you've asked an LLM to generate a
+# hangul/words/vocab.json (see apps/www/src/lib/hangul-vocab) or a
+# leetype/challenges.json (see apps/www/src/lib/leetype-challenges) and want
+# this container to serve one instead of its demo pool. Unlike
+# sfx/code-samples, the GitHub Pages build never bakes either of these in
+# either way: there's no companion data there, by design (apps/www resolves
+# to "static" mode and never fetches them).
 #
 # REPO_ROOT must actually be exported (e.g. `export REPO_ROOT=$(pwd)` from
 # repo root) before running docker compose. The root docker-compose.yml
@@ -53,6 +55,7 @@ services:
       - ${WWW_SFX_ASSETS_PATH:-${REPO_ROOT:-.}/packages/some-content/public/sfx}:/usr/share/nginx/html/sfx:ro
       - ${WWW_CODE_SAMPLES_PATH:-${REPO_ROOT:-.}/packages/some-content/public/code-samples}:/usr/share/nginx/html/code-samples:ro
       - ${WWW_HANGUL_ASSETS_PATH:-${REPO_ROOT:-.}/packages/some-content/public/hangul}:/usr/share/nginx/html/hangul:ro
+      - ${WWW_LEETYPE_ASSETS_PATH:-${REPO_ROOT:-.}/packages/some-content/public/leetype}:/usr/share/nginx/html/leetype:ro
     networks:
       - some-ui-network
     # Dockerfile bakes in the same wget-spider HEALTHCHECK as a baseline for

--- a/packages/some-content/prompts/leetype-challenge-generator/index.md
+++ b/packages/some-content/prompts/leetype-challenge-generator/index.md
@@ -1,0 +1,138 @@
+# LeetType Challenge Generator
+
+Prompt template for generating a `Leetype` challenge-pool override: a corpus
+of data-structure/algorithm challenges, each with real, idiomatic code
+samples in all four supported languages, used in place of the bundled demo
+pool (`@some-ui/content`'s `CHALLENGES`, currently just "Two Sum") when
+running `apps/www` against `localhost` or Docker (see
+`apps/www/src/lib/leetype-challenges`). Not used by the GitHub Pages build,
+which always plays the bundled demo pool instead.
+
+---
+
+## Usage Example Header
+
+```
+Topics: [e.g. "stack, queue, binary search tree"]
+Difficulty spread: [e.g. "2 easy, 2 medium, 1 hard"]
+T: [Apply LeetType Challenge Generator v1.0]
+```
+
+The generator produces:
+
+1. One JSON array (`challenges.json`) following the schema below.
+2. One source file per `codePaths` entry per challenge (4 languages × N
+   challenges) - a complete, compilable/runnable, idiomatic reference
+   solution, not a stub. This is the text the player types verbatim, so it
+   must be real code a fluent developer in that language would write.
+
+---
+
+## Output Destination
+
+Write the manifest to:
+
+```
+packages/some-content/public/leetype/challenges.json
+```
+
+Write each challenge's code samples under the same root, e.g.:
+
+```
+packages/some-content/public/leetype/samples/<challenge-id>.ts
+packages/some-content/public/leetype/samples/<challenge-id>.rs
+packages/some-content/public/leetype/samples/<challenge-id>.cpp
+packages/some-content/public/leetype/samples/<challenge-id>.c
+```
+
+`codePaths` in the manifest must point at these with a leading slash, e.g.
+`"/leetype/samples/ds-stack.ts"` - **not** `/code-samples/...` (that's the
+small, committed demo set that ships on GitHub Pages; this corpus is a
+separate, wholly local override).
+
+This whole `packages/some-content/public/leetype/` tree is gitignored
+(`packages/**/public` in the repo root's `.gitignore`) - it is expected to
+be regenerated locally, never committed. Overwrite the manifest and any
+regenerated sample files each time; there is currently one active corpus,
+not one per topic set.
+
+---
+
+## Schema
+
+`challenges.json` is a JSON array of these, with **at least one entry**:
+
+```ts
+{
+  id: string                    // stable slug, kebab-case ASCII, unique within the file
+  title: string                 // display name, e.g. "Binary Search Tree"
+  description: string           // one or two sentences: what to implement, constraints
+  difficulty: "easy" | "medium" | "hard"
+  mode: "data-structure" | "algorithm"
+  tags: string[]                // free-form, e.g. ["bst", "trees", "recursion"]
+  codePaths: {                  // all four required, no partial sets
+    typescript: string
+    rust: string
+    cpp: string
+    c: string
+  }
+  levelRequired: number          // player level gate (see @some-ui/leetype's PlayerProgress) - 1 unless the caller specifies otherwise
+}
+```
+
+---
+
+## Code Sample Constraints
+
+- Each language's file for a given challenge must implement the **same**
+  data structure or algorithm - a player switching languages mid-selection
+  should see equivalent logic, not a different problem.
+- Prefer a self-contained file (no external crates/headers beyond the
+  language's standard library) so it compiles/runs on its own if extracted.
+- No TODOs, `unimplemented!()`, or stub bodies - the typing game replays
+  this text character-for-character, so an incomplete solution reads as
+  intentional (and untypeable) filler to the player.
+- Keep formatting consistent with idiomatic style for the language (rustfmt-
+  style for Rust, Prettier-style for TypeScript/C++, standard K&R for C) -
+  `Leetype` re-runs Prettier over TypeScript/C++ at load time
+  (`PRETTIER_PARSER_MAP` in `packages/ui/leetype/src/components/typing-game/
+leetype/index.tsx`), but Rust and C are displayed as authored.
+
+---
+
+## Worked Example
+
+```json
+{
+  "id": "ds-stack",
+  "title": "Stack",
+  "description": "Implement a stack (LIFO) using an array backing store with push and pop.",
+  "difficulty": "easy",
+  "mode": "data-structure",
+  "tags": ["stack", "lifo", "array"],
+  "codePaths": {
+    "typescript": "/leetype/samples/ds-stack.ts",
+    "rust": "/leetype/samples/ds-stack.rs",
+    "cpp": "/leetype/samples/ds-stack.cpp",
+    "c": "/leetype/samples/ds-stack.c"
+  },
+  "levelRequired": 1
+}
+```
+
+paired with four files at `packages/some-content/public/leetype/samples/`:
+`ds-stack.ts`, `ds-stack.rs`, `ds-stack.cpp`, `ds-stack.c`, each a complete
+stack implementation in that language.
+
+---
+
+## Self-Check Before Returning
+
+- [ ] Every `id` is unique within the array.
+- [ ] Every `codePaths` entry has all four languages, each a non-empty
+      `/leetype/samples/...` path (not `/code-samples/...`).
+- [ ] Every referenced sample file is actually being written out, and its
+      content is a complete, idiomatic solution - not a stub.
+- [ ] `difficulty` is one of `easy`/`medium`/`hard` and `mode` is one of
+      `data-structure`/`algorithm` - no other values.
+- [ ] The array has at least one entry.

--- a/packages/ui/honeycomb/src/components/hangul-hex-grid/overlay/index.tsx
+++ b/packages/ui/honeycomb/src/components/hangul-hex-grid/overlay/index.tsx
@@ -194,7 +194,11 @@ export const HangulHexGrid = ({
   useGameLoop({
     gameBridge,
     isInitialized,
-    isPaused: isPaused || isGridFatal || suspended,
+    // isGameOver mirrors useKeyboardInput's own gate below - without it, the
+    // spawn/update interval only stops once the onComplete/onTimeout
+    // callback's setIsPaused(true) round-trips through a render, one or more
+    // ticks after the engine-derived status already says the game is over.
+    isPaused: isPaused || isGameOver || isGridFatal || suspended,
     setActiveCharacters,
     setStats,
     setTimingParams,

--- a/packages/ui/leetype/src/components/typing-game/leetype/index.tsx
+++ b/packages/ui/leetype/src/components/typing-game/leetype/index.tsx
@@ -12,11 +12,14 @@ import type {
   Challenge,
   ChunkCompletionStats,
   CompletedSessionStats,
+  Difficulty,
   DisplayMode,
   GameState,
   Language,
   NContext,
 } from "@leetype/types/leetype"
+import { resolveChallenge } from "@leetype/utils/leetype"
+import { CHALLENGES } from "@some-ui/content"
 import { Badge } from "some-ui-shared"
 
 type LeetypeProps = {
@@ -24,6 +27,23 @@ type LeetypeProps = {
   codePaths?: Record<Language, string>
   /** Challenge metadata — enables adaptive mode and difficulty enforcement */
   challenge?: Challenge
+  /**
+   * Friendly difficulty label used to resolve a `challenge` out of
+   * `challenges` when the caller only has a config-time difficulty pick, not
+   * a fully hydrated challenge (the config-driven "LeetType" activity's
+   * path - see apps/www's activity-catalog). Ignored when `challenge` is
+   * passed directly.
+   */
+  difficulty?: Difficulty
+  /**
+   * The pool `difficulty` resolves against - defaults to the bundled demo
+   * set (`@some-ui/content`'s `CHALLENGES`), same as before this prop
+   * existed. This is the seam a host app uses to swap in its own challenge
+   * corpus (e.g. an LLM-generated, environment-specific set fetched at
+   * runtime) without this component knowing or caring where the challenges
+   * came from.
+   */
+  challenges?: Array<Challenge>
   /** Pre-selected language (challenge mode) */
   initialLanguage?: Language
   /** Pre-selected duration in seconds (challenge mode) */
@@ -55,12 +75,16 @@ type CumulativeStats = {
 export const Leetype: FC<LeetypeProps> = ({
   codePaths,
   challenge,
+  difficulty,
+  challenges = CHALLENGES,
   initialLanguage,
   initialDuration,
   nContext,
   onSessionComplete,
 }) => {
-  const isLegacyMode = !challenge
+  const resolvedChallenge =
+    challenge ?? resolveChallenge(challenges, difficulty)
+  const isLegacyMode = !resolvedChallenge
 
   const [gameState, setGameState] = useState<GameState>("idle")
   const [displayMode, setDisplayMode] = useState<DisplayMode>("shown")
@@ -101,7 +125,7 @@ export const Leetype: FC<LeetypeProps> = ({
   }, [onSessionComplete])
 
   const effectiveCodePaths: Partial<Record<Language, string>> =
-    challenge?.codePaths ?? codePaths ?? {}
+    resolvedChallenge?.codePaths ?? codePaths ?? {}
 
   const codeState = useChunkedCode(effectiveCodePaths[language] ?? "", {
     prettierParser: PRETTIER_PARSER_MAP[language],
@@ -170,7 +194,7 @@ export const Leetype: FC<LeetypeProps> = ({
     setAdaptiveHidden(true)
   }
 
-  const isHardDifficulty = challenge?.difficulty === "hard"
+  const isHardDifficulty = resolvedChallenge?.difficulty === "hard"
   const effectiveDisplayMode: DisplayMode =
     isHardDifficulty || adaptiveHidden ? "hidden" : displayMode
 
@@ -247,9 +271,11 @@ export const Leetype: FC<LeetypeProps> = ({
   }`
 
   const info: GameInfoContent = {
-    title: challenge ? challenge.title : "Problem Description",
-    description: challenge ? challenge.description : DEFAULT_PROMPT_DESCRIPTION,
-    tags: challenge ? challenge.tags : [],
+    title: resolvedChallenge ? resolvedChallenge.title : "Problem Description",
+    description: resolvedChallenge
+      ? resolvedChallenge.description
+      : DEFAULT_PROMPT_DESCRIPTION,
+    tags: resolvedChallenge ? resolvedChallenge.tags : [],
   }
 
   return (
@@ -260,22 +286,22 @@ export const Leetype: FC<LeetypeProps> = ({
       {/* Challenge identity strip — kept slim so the viewport still belongs
           to the code/input card below; everything actionable lives in the
           bottom nav's menus instead of inline controls. */}
-      {challenge && (
+      {resolvedChallenge && (
         <div className="mb-3 flex shrink-0 items-center gap-3">
           <span className="text-base font-semibold text-card-foreground">
-            {challenge.title}
+            {resolvedChallenge.title}
           </span>
           <Badge
             variant={
-              challenge.difficulty === "easy"
+              resolvedChallenge.difficulty === "easy"
                 ? "default"
-                : challenge.difficulty === "medium"
+                : resolvedChallenge.difficulty === "medium"
                   ? "secondary"
                   : "destructive"
             }
             className="capitalize"
           >
-            {challenge.difficulty}
+            {resolvedChallenge.difficulty}
           </Badge>
           {nContext && (
             <Badge variant="outline" className="font-mono text-xs capitalize">

--- a/packages/ui/leetype/src/utils/leetype/index.test.ts
+++ b/packages/ui/leetype/src/utils/leetype/index.test.ts
@@ -1,11 +1,12 @@
 import { buildDisplayMap } from "@leetype/lib/leetype/leetype-wasm-loader"
-import type { GameStats } from "@leetype/types/leetype"
+import type { Challenge, GameStats } from "@leetype/types/leetype"
 import { describe, expect, it, vi } from "vitest"
 
 import {
   codeToUnits,
   deriveCursorIndex,
   deriveDisplayMap,
+  resolveChallenge,
   sliceUserUnits,
 } from "."
 
@@ -88,5 +89,35 @@ describe("deriveDisplayMap", () => {
     vi.mocked(buildDisplayMap).mockReturnValue(new Uint32Array([2, 1, 0]))
     expect(deriveDisplayMap("abc")).toEqual([2, 1, 0])
     expect(buildDisplayMap).toHaveBeenCalledWith("abc")
+  })
+})
+
+describe("resolveChallenge", () => {
+  const makeChallenge = (overrides: Partial<Challenge> = {}): Challenge => ({
+    id: "id",
+    title: "title",
+    description: "description",
+    difficulty: "easy",
+    mode: "algorithm",
+    tags: [],
+    codePaths: { typescript: "", rust: "", cpp: "", c: "" },
+    levelRequired: 1,
+    ...overrides,
+  })
+
+  const easy = makeChallenge({ id: "easy-1", difficulty: "easy" })
+  const medium = makeChallenge({ id: "medium-1", difficulty: "medium" })
+  const pool = [easy, medium]
+
+  it("returns undefined when no difficulty is given", () => {
+    expect(resolveChallenge(pool, undefined)).toBeUndefined()
+  })
+
+  it("returns the first challenge matching the requested difficulty", () => {
+    expect(resolveChallenge(pool, "medium")).toBe(medium)
+  })
+
+  it("falls back to the pool's first entry when nothing matches", () => {
+    expect(resolveChallenge(pool, "hard")).toBe(easy)
   })
 })

--- a/packages/ui/leetype/src/utils/leetype/index.ts
+++ b/packages/ui/leetype/src/utils/leetype/index.ts
@@ -1,5 +1,10 @@
 import { buildDisplayMap } from "@leetype/lib/leetype/leetype-wasm-loader"
-import type { CanonicalUnit, GameStats } from "@leetype/types/leetype"
+import type {
+  CanonicalUnit,
+  Challenge,
+  Difficulty,
+  GameStats,
+} from "@leetype/types/leetype"
 
 export function codeToUnits(code: string): Array<CanonicalUnit> {
   return Array.from(code).map((char) => ({
@@ -29,4 +34,22 @@ export function deriveCursorIndex(stats: GameStats): number {
 export function deriveDisplayMap(input: string): Array<number> {
   if (!input) return []
   return Array.from(buildDisplayMap(input))
+}
+
+/**
+ * Resolves a friendly `difficulty` identifier into one challenge from
+ * `challenges` - deterministic (first match, not random), so replaying a
+ * session shows the same challenge it did the first time. Falls back to the
+ * pool's first entry when nothing matches, mirroring the pool always having
+ * *something* playable rather than leaving the caller with `undefined` for
+ * an off-pool difficulty label. Returns `undefined` only when `difficulty`
+ * itself is absent, so a caller that already has a fully hydrated
+ * `challenge` never needs to call this at all.
+ */
+export function resolveChallenge(
+  challenges: ReadonlyArray<Challenge>,
+  difficulty: Difficulty | undefined
+): Challenge | undefined {
+  if (!difficulty) return undefined
+  return challenges.find((c) => c.difficulty === difficulty) ?? challenges[0]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@some-ui/interview':
         specifier: workspace:*
         version: link:../../packages/ui/interview
+      '@some-ui/leetype':
+        specifier: workspace:*
+        version: link:../../packages/ui/leetype
       '@some-ui/slideshow':
         specifier: workspace:*
         version: link:../../packages/ui/slideshow


### PR DESCRIPTION
## Description

This PR adds support for overriding Leetype's bundled demo challenge pool with a custom corpus (e.g., LLM-generated challenges) in local/Docker development environments, while maintaining the demo pool on GitHub Pages.

### Key Changes

**Challenge Corpus Infrastructure**
- Added `packages/some-content/prompts/leetype-challenge-generator/index.md`: Comprehensive prompt template and schema documentation for generating custom challenge corpora
- Created `apps/www/src/lib/leetype-challenges/`: New module for fetching and validating challenge overrides
  - `index.ts`: `useLeetypeChallenges()` hook that fetches `/leetype/challenges.json` in server mode (localhost/Docker), returns `undefined` on GitHub Pages
  - `schema.ts`: Zod schemas validating challenge structure and ensuring all four languages are present
  - `schema.test.ts`: Tests for schema validation

**Component Updates**
- Modified `Leetype` component to accept:
  - `challenges`: Pool of challenges (defaults to bundled `CHALLENGES`)
  - `difficulty`: Friendly difficulty label resolved at render time against the pool
  - Replaced direct `challenge` prop resolution with `resolveChallenge()` utility
- Added `resolveChallenge()` utility in `packages/ui/leetype/src/utils/leetype/index.ts`: Deterministic difficulty-to-challenge resolution with fallback to first entry
- Updated `apps/www/src/components/player/session-viewport.tsx` to pass fetched challenges to Leetype

**Activity Catalog Refactor**
- Removed `pickLeetypeChallenge()` from `apps/www/src/lib/activity-catalog/catalog.ts`
- Changed `toSceneProps` to pass `difficulty` label instead of resolved challenge, deferring resolution to component render time (mirrors HangulHexGrid's word pool pattern)

**Game Engine Fixes**
- Added `has_time_limit()` trait method to `GameMode` (defaults to `true`)
- Implemented `has_time_limit()` in `EndlessMode` and `VocabularyMode` to return `false` for endless variants
- Fixed timeout logic in `GameEngine::get_status()` to respect mode's time limit setting (endless modes never timeout)
- Added comprehensive tests for timeout behavior across modes

**Infrastructure & Documentation**
- Updated `infra/compose/www.yml` to mount `packages/some-content/public/leetype` volume
- Updated `apps/www/scripts/link-content-assets.js` to symlink leetype assets for local dev
- Added `@some-ui/leetype` to `apps/www/package.json` dependencies
- Updated `.gitignore` comments to reflect leetype corpus handling

### Behavior

- **GitHub Pages**: No change—uses bundled `CHALLENGES` only
- **Local/Docker dev**: Fetches `/leetype/challenges.json` if present (gitignored, developer-populated); falls back silently to bundled pool if missing or on 404; logs warnings for other errors
- **Endless modes**: Now correctly never timeout, regardless of `game_duration_ms`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (timeout behavior for endless modes)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Added unit tests for schema validation, challenge resolution, and timeout behavior
- [x] Existing tests pass with changes
- [x] No new warnings generated
- [x] Documentation added (prompt template with schema and usage examples)

## Test Plan

- Schema validation tests in `schema.test.ts` verify challenge structure and language completeness
- `resolveChallenge()` tests verify difficulty resolution and fallback behavior
- Game engine timeout tests verify endless modes never timeout and timed modes respect the time limit
- Manual verification: Run `pnpm run content:link` to symlink assets, then generate a `challenges.json` in `packages/some-content/public/leetype/` to test corpus loading in local dev

https://claude.ai/code/session_01FsuvsQrjhkvDXkvbMXEEDV