### PR TITLE
Implement release PR workflow for Pages deployments

### DIFF
--- a/.github/actions/pages-detect/action.yml
+++ b/.github/actions/pages-detect/action.yml
@@ -1,0 +1,32 @@
+name: "Pages Detect"
+description: "Decide pages.yml's release_mode: publish, release-pr, or skip."
+inputs:
+  event-name:
+    description: "github.event_name"
+    required: true
+  publish-only:
+    description: "workflow_dispatch inputs.publish_only (empty when not dispatched)"
+    required: false
+    default: ""
+  commit-message:
+    description: "github.event.head_commit.message (empty outside push events)"
+    required: false
+    default: ""
+  release-commit-message:
+    description: "The commit message pages.yml's own release PR is opened/merged with"
+    required: true
+outputs:
+  release_mode:
+    description: "One of: publish, release-pr, skip"
+    value: ${{ steps.run.outputs.release_mode }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        EVENT_NAME: ${{ inputs.event-name }}
+        PUBLISH_ONLY: ${{ inputs.publish-only }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        RELEASE_COMMIT_MESSAGE: ${{ inputs.release-commit-message }}
+      run: bash "${{ github.action_path }}/detect.sh"

--- a/.github/actions/pages-detect/detect.sh
+++ b/.github/actions/pages-detect/detect.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Is this push *the* release commit (the release-pr job's PR just got
+# merged), rather than an ordinary source change? That commit only touches
+# .github/pages-release-marker.txt, which doesn't match pages.yml's own
+# trigger paths - but workflow_dispatch publish_only covers the equivalent
+# manual case, and a maintainer could still push it directly, so this stays
+# symmetric with wasm-release.yml / www-docker-release.yml's own guard.
+is_release_commit=false
+if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$PUBLISH_ONLY" = "true" ]; then
+	is_release_commit=true
+elif [ "$EVENT_NAME" = "push" ] && [[ "$COMMIT_MESSAGE" == "$RELEASE_COMMIT_MESSAGE"* ]]; then
+	is_release_commit=true
+fi
+
+if [ "$is_release_commit" = "true" ]; then
+	release_mode=publish
+elif [ "$EVENT_NAME" = "push" ]; then
+	# pages.yml's own `on.push.paths` filter already restricted this push to
+	# one touching apps/www, packages/**, .storybook/**, pnpm-lock.yaml, or
+	# this workflow's/action's own files - no need to re-diff here.
+	release_mode=release-pr
+elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+	release_mode=release-pr
+else
+	# pull_request - preview builds only, no release PR / deploy.
+	release_mode=skip
+fi
+
+echo "release_mode=${release_mode}" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,17 @@ name: Pages
 # directory tree, and only that merged tree is ever uploaded as the Pages
 # artifact / deployed. Splitting this into per-app workflows would silently
 # make each deploy wipe out the other app's last-deployed content.
+#
+# A plain `push: branches: [main]` trigger would also mean every merge to
+# main rebuilds and redeploys the whole site, even though several PRs often
+# land within minutes of each other - each one paying for a full www +
+# Storybook build that the next merge immediately supersedes. So, patterned
+# after wasm-release.yml / www-docker-release.yml: a push to main that
+# touches release-worthy paths doesn't deploy directly. It opens/updates a
+# standing release PR (branch `release/pages`) instead, and only merging
+# that PR - the human "yes, ship what's on main now" judgment call - builds
+# and deploys. Multiple merges before someone gets to it collapse into one
+# deploy instead of one per PR.
 on:
   push:
     branches: [main]
@@ -20,6 +31,10 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/pages.yml"
       - ".github/actions/**"
+      # The release PR's own commit only touches this file (see the
+      # release-pr job below) - without it here, merging that PR would
+      # never re-trigger the workflow, and the deploy would never fire.
+      - ".github/pages-release-marker.txt"
   pull_request:
     branches: [main]
     paths:
@@ -30,6 +45,14 @@ on:
       - ".github/workflows/pages.yml"
       - ".github/actions/**"
   workflow_dispatch:
+    inputs:
+      publish_only:
+        description: "Skip detection/PR and build+deploy the Pages site straight from the current main (use to force a redeploy, or retry a deploy that failed after the release PR merged)"
+        type: boolean
+        default: false
+env:
+  RELEASE_COMMIT_MESSAGE: "chore(release): deploy pages site"
+  RELEASE_BRANCH: "release/pages"
 permissions:
   contents: read
   pages: write
@@ -38,24 +61,25 @@ concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 jobs:
-  # ── Detect which of the two builds this change actually needs ───────────
-  # The paths above decide whether this workflow runs at all, but they're
-  # a union — a PR touching only apps/www/** still matches, and would build
-  # Storybook too without this. On pull_request, split www vs storybook so
-  # each build only runs when its own inputs changed.
+  # ── Detect which builds a PR needs, and what main's push should do ──────
+  # The paths above decide whether this workflow runs at all, but they're a
+  # union - a PR touching only apps/www/** still matches, and would build
+  # Storybook too without the per-path split below. On pull_request, split
+  # www vs storybook so each preview build only runs when its own inputs
+  # changed.
   #
-  # On push (and workflow_dispatch), always build both regardless: Pages
-  # serves one deployment per repo and assemble/deploy replace the *entire*
-  # artifact each run (see header) — skipping one build here would deploy a
-  # site missing whichever app wasn't rebuilt. Push already only reaches this
-  # workflow when the outer paths filter matched, so "build both" here is
-  # not the eager case this split is fixing.
+  # On push (and workflow_dispatch), the per-path split doesn't apply -
+  # pages-detect below decides instead whether this push opens/updates the
+  # release PR or is the release PR's own merge landing (in which case both
+  # builds always run regardless of what changed, since assemble/deploy
+  # replace the *entire* Pages artifact each run - see header).
   detect:
     name: Detect Pages Changes
     runs-on: ubuntu-latest
     outputs:
-      www: ${{ steps.gate.outputs.www }}
-      storybook: ${{ steps.gate.outputs.storybook }}
+      www: ${{ steps.filter.outputs.www }}
+      storybook: ${{ steps.filter.outputs.storybook }}
+      release_mode: ${{ steps.pages-detect.outputs.release_mode }}
     steps:
       - uses: actions/checkout@v7
       - name: Filter paths
@@ -75,22 +99,57 @@ jobs:
               - 'pnpm-lock.yaml'
               - '.github/workflows/pages.yml'
               - '.github/actions/**'
-      - name: Gate on event type
-        id: gate
+      - id: pages-detect
+        uses: ./.github/actions/pages-detect
+        with:
+          event-name: ${{ github.event_name }}
+          publish-only: ${{ inputs.publish_only }}
+          commit-message: ${{ github.event.head_commit.message }}
+          release-commit-message: ${{ env.RELEASE_COMMIT_MESSAGE }}
+
+  # ── Open/update the release PR ──────────────────────────────────────────
+  # Re-running this on a later push updates the same PR/branch, so several
+  # merges before a maintainer gets to it collapse into one review instead
+  # of one deploy each. No changeset/version bump here, unlike
+  # wasm-release.yml / www-docker-release.yml's release tracks - the Pages
+  # site isn't a versioned artifact, just a standing "deploy what's on main
+  # now" gate, so the PR's only content is a marker file to give it a diff.
+  release-pr:
+    name: Open/Update Pages Release PR
+    needs: detect
+    if: needs.detect.outputs.release_mode == 'release-pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Bump Pages release marker
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "www=${{ steps.filter.outputs.www }}" >> "$GITHUB_OUTPUT"
-            echo "storybook=${{ steps.filter.outputs.storybook }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "www=true" >> "$GITHUB_OUTPUT"
-            echo "storybook=true" >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo "Pending Pages deploy through commit ${{ github.sha }}"
+            echo "Updated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } > .github/pages-release-marker.txt
+      - name: Open release PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ${{ env.RELEASE_BRANCH }}
+          base: main
+          delete-branch: true
+          commit-message: ${{ env.RELEASE_COMMIT_MESSAGE }}
+          title: ${{ env.RELEASE_COMMIT_MESSAGE }}
+          body: >
+            Opened automatically because a change reachable from `apps/www`, `packages/**`, or `.storybook/**` landed on `main`. Several PRs landing close together would otherwise each trigger their own Pages build+deploy; this collects them into one. Review and merge via **squash** (the merge commit message drives the deploy step below) to build and deploy the Pages site (www + Storybook).
 
   # ── Build the tanstack app ───────────────────────────────────────────────
   build-www:
     name: Build www (TanStack app)
     needs: detect
-    if: needs.detect.outputs.www == 'true'
+    if: >
+      (github.event_name == 'pull_request' && needs.detect.outputs.www == 'true') ||
+      (github.event_name != 'pull_request' && needs.detect.outputs.release_mode == 'publish')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -153,7 +212,9 @@ jobs:
   build-storybook:
     name: Build Storybook
     needs: detect
-    if: needs.detect.outputs.storybook == 'true'
+    if: >
+      (github.event_name == 'pull_request' && needs.detect.outputs.storybook == 'true') ||
+      (github.event_name != 'pull_request' && needs.detect.outputs.release_mode == 'publish')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -225,8 +286,17 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: assemble
-    # Only deploy on pushes to main - not PRs, not workflow_dispatch previews.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Only deploy on the release commit landing on main (a merged release
+    # PR, or a forced workflow_dispatch publish_only) - never on ordinary
+    # PRs, preview builds, or a push that only opened/updated the release
+    # PR (assemble is skipped in that case). The explicit
+    # needs.assemble.result check matters here, not just event/ref: a
+    # skipped upstream job doesn't reliably skip a job with its own custom
+    # `if`, so this can't just rely on assemble having been skipped.
+    if: >
+      needs.assemble.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Description

This change implements a release PR workflow for the Pages deployment pipeline, similar to the existing patterns in `wasm-release.yml` and `www-docker-release.yml`. Instead of deploying on every push to main, the workflow now:

1. Opens/updates a standing release PR (`release/pages` branch) when changes land on main that affect the Pages site
2. Only builds and deploys when that release PR is merged (the human "yes, ship it" judgment call)
3. Collapses multiple rapid merges into a single deploy instead of one per PR

This reduces unnecessary builds and deployments when several PRs land within minutes of each other, each of which would previously trigger a full www + Storybook build that gets immediately superseded.

### Key Changes

- **New action**: `.github/actions/pages-detect/` - Determines whether to open a release PR, publish directly, or skip based on event type and commit message
- **Updated trigger logic**: Push events now open/update the release PR instead of deploying directly; only the release PR merge triggers deployment
- **New workflow input**: `workflow_dispatch` now accepts `publish_only` flag to force a direct deploy (for retries or manual redeploys)
- **Release marker file**: `.github/pages-release-marker.txt` provides a diff for the release PR and re-triggers the workflow when merged
- **Updated job conditions**: Build and deploy jobs now check `release_mode` output to determine whether to run

## Type of Change

- [x] New feature (implements release PR workflow for Pages)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are well-commented (extensive inline documentation in workflow)
- [x] No new warnings generated
- [x] Logic is symmetric with existing `wasm-release.yml` / `www-docker-release.yml` patterns

## Test Plan

The workflow logic can be validated by:
1. Pushing a change to main that touches `apps/www/**` or related paths → should open/update `release/pages` PR
2. Merging the release PR → should trigger build and deploy
3. Using `workflow_dispatch` with `publish_only: true` → should deploy directly without opening a PR
4. Creating a PR against main → should only run preview builds, not open a release PR

https://claude.ai/code/session_01KnVKEeXsoE7B1gS38FzBMG