### PR TITLE
Add mission page and rewrite résumé in STAR format

### DIFF
--- a/.changeset/mission-page-and-resume-star-rewrite.md
+++ b/.changeset/mission-page-and-resume-star-rewrite.md
@@ -1,0 +1,50 @@
+---
+"@some-ui/resume": minor
+"www": minor
+---
+
+Rewrite the résumé to communicate what the work actually is, and give
+`apps/www` a mission page motivating the repo's high-level goals.
+
+**`@some-ui/resume` — STAR grammar, project-first.**
+
+The previous revision stated deliverables only, on the theory that a résumé
+is a pure evidence index. Read against the user stories behind these
+projects, that turned out to be an over-correction: stripped to deliverables,
+the work read like ordinary feature output, and nothing distinguished it from
+a ticket someone was handed. These projects are positions — a browser is an
+operating system and tabs are its processes; exposure should be opt-in;
+visual comfort is measurable; a curriculum should adapt to the learner — and
+omitting the position deletes the reason the artifact exists.
+
+`resume.typ` now leads each project with the premise it answers and then
+cashes that premise out in the mechanism implementing it, under an explicit
+rule: **a premise earns its place only if the next line names the mechanism.**
+"Suspension is virtualization, not cleanup" is followed by the native-discard
+behaviour and the absent `tabs.remove()`; "nothing earns attention by default"
+is followed by the `masked → meta → title → revealed` machine and the
+overloads that make an illegal transition a compile error.
+
+Also:
+
+- **Dropped the "Technical Skills" enumeration.** A comma-separated tool list
+  communicates nothing verifiable. Every tool in it still appears in the
+  résumé, attached to the thing it was used to build.
+- **Dropped the "Set in Typst from `packages/ui/resume/resume.typ`…"**
+  colophon — a note about the document's own build pipeline on a page whose
+  job is to be about the candidate. The pipeline stays documented in
+  `README.md`.
+- **Corrected the workspace counts** (61 → 58 packages, "15+" → 12
+  extensions); both are now derived rather than remembered, with the
+  derivation recorded in `resume.meta.typ`.
+- `resume.meta.typ` gains a per-project provenance map (claim → the crate,
+  package, or workflow backing it) and records the format reversal.
+
+**`www` — a `/mission` route.**
+
+`/` answers _what_ is deployed here and sends you to it; nothing answered why
+any of it exists. `/mission` is a visual statement page — not a journal or a
+blog, no dates and no posts — presenting each project as one refusal, one
+claim, and one mechanism, followed by the principles they share and the scale
+they ship at. Linked from `/` as a secondary text link so it doesn't compete
+with the three destination cards.

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as MissionRouteImport } from './routes/mission'
 import { Route as DashboardRouteImport } from './routes/_dashboard'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DashboardSettingsRouteImport } from './routes/_dashboard/settings'
@@ -19,6 +20,11 @@ import { Route as DashboardSessionsIndexRouteImport } from './routes/_dashboard/
 import { Route as DashboardSessionsNewRouteImport } from './routes/_dashboard/sessions/new'
 import { Route as DashboardSessionsSessionIdRouteImport } from './routes/_dashboard/sessions/$sessionId'
 
+const MissionRoute = MissionRouteImport.update({
+  id: '/mission',
+  path: '/mission',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
   id: '/_dashboard',
   getParentRoute: () => rootRouteImport,
@@ -67,6 +73,7 @@ const DashboardSessionsSessionIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/mission': typeof MissionRoute
   '/app': typeof DashboardAppRoute
   '/profile': typeof DashboardProfileRoute
   '/resume': typeof DashboardResumeRoute
@@ -77,6 +84,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/mission': typeof MissionRoute
   '/app': typeof DashboardAppRoute
   '/profile': typeof DashboardProfileRoute
   '/resume': typeof DashboardResumeRoute
@@ -89,6 +97,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_dashboard': typeof DashboardRouteWithChildren
+  '/mission': typeof MissionRoute
   '/_dashboard/app': typeof DashboardAppRoute
   '/_dashboard/profile': typeof DashboardProfileRoute
   '/_dashboard/resume': typeof DashboardResumeRoute
@@ -101,6 +110,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/mission'
     | '/app'
     | '/profile'
     | '/resume'
@@ -111,6 +121,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/mission'
     | '/app'
     | '/profile'
     | '/resume'
@@ -122,6 +133,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_dashboard'
+    | '/mission'
     | '/_dashboard/app'
     | '/_dashboard/profile'
     | '/_dashboard/resume'
@@ -134,10 +146,18 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DashboardRoute: typeof DashboardRouteWithChildren
+  MissionRoute: typeof MissionRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/mission': {
+      id: '/mission'
+      path: '/mission'
+      fullPath: '/mission'
+      preLoaderRoute: typeof MissionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_dashboard': {
       id: '/_dashboard'
       path: ''
@@ -231,6 +251,7 @@ const DashboardRouteWithChildren = DashboardRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DashboardRoute: DashboardRouteWithChildren,
+  MissionRoute: MissionRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -122,6 +122,16 @@ const Landing = (): JSX.Element => (
           résumé - built and deployed from a single monorepo. Pick a destination
           below.
         </p>
+        {/* The three cards answer "what is deployed here". /mission answers
+            why any of it exists - kept as a text link so it doesn't compete
+            with the destinations for the same glance. */}
+        <Link
+          to="/mission"
+          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm underline-offset-4 transition-colors hover:underline"
+        >
+          Why this exists
+          <ArrowRight className="size-3.5" aria-hidden />
+        </Link>
       </div>
       <div className="grid gap-4 sm:grid-cols-3">
         {DESTINATIONS.map((destination) => (

--- a/apps/www/src/routes/mission.tsx
+++ b/apps/www/src/routes/mission.tsx
@@ -1,0 +1,331 @@
+import type { JSX } from "react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import {
+  ArrowLeft,
+  Ban,
+  Brain,
+  Contrast,
+  EyeOff,
+  Fingerprint,
+  HardDrive,
+  KeyRound,
+  Ruler,
+  ScrollText,
+  WifiOff,
+} from "lucide-react"
+
+import { ThemeSwitcher } from "@/components/theme-switcher"
+
+/**
+ * The "why" behind this workspace, as a page rather than a document.
+ *
+ * "/" answers *what* is deployed here (an app, a Storybook, a résumé) and
+ * sends you to it. Nothing answered why any of it exists — and the projects
+ * in this repo are not features, they are positions: a browser is an
+ * operating system, exposure should be opt-in, visual comfort is measurable,
+ * a curriculum should adapt to the learner. Those positions are the actual
+ * through-line, and they were previously only legible to someone willing to
+ * read four separate READMEs and three canons.
+ *
+ * Deliberately not a journal or a blog: no dates, no narrative, no posts.
+ * Each position is one refusal, one claim, and one mechanism, stated at a
+ * size you can read across a room. The rule the copy is held to is the same
+ * one `packages/ui/resume/resume.typ` follows — a premise earns its place
+ * only if it is immediately cashed out in the mechanism implementing it.
+ */
+
+type Position = {
+  /** Display ordinal. Not derived from the array index — it's typeset. */
+  ordinal: string
+  /** The thing this project is constantly mistaken for. */
+  foil: string
+  /** What it actually is. */
+  claim: string
+  /** How the claim is made true in code — the part that keeps this honest. */
+  mechanism: string
+  /** Where it lives in this workspace. */
+  artifact: string
+  icon: typeof HardDrive
+}
+
+const POSITIONS: ReadonlyArray<Position> = [
+  {
+    ordinal: "01",
+    foil: "Not another tab suspender.",
+    claim: "A virtual-memory subsystem for the browser.",
+    mechanism:
+      "A browser used as an operating system holds hundreds of tabs that are long-lived workspaces, not pages. So suspension is virtualization, not cleanup: memory is reclaimed while the tab keeps its strip position, its history entry, and its identity. There is no code path that closes a tab — reversibility is structural, not intended.",
+    artifact: "suspender-ledger",
+    icon: HardDrive,
+  },
+  {
+    ordinal: "02",
+    foil: "Not an ad blocker.",
+    claim: "An attention firewall.",
+    mechanism:
+      "Recommendation surfaces are engineered to maximize exposure. Inverting that means nothing earns attention by default — every recommendation begins hidden and surrenders exactly one layer at a time, through a state machine whose illegal transitions are compile errors. Searching for something should never require being exposed to everything around it.",
+    artifact: "some-censor",
+    icon: EyeOff,
+  },
+  {
+    ordinal: "03",
+    foil: "Not a dark mode.",
+    claim: "A rendering layer for the readable web.",
+    mechanism:
+      "Every site ships its own contrast and palette, forcing the eye to re-adapt on each navigation. Visual comfort is treated as a measurable property of what a page actually renders, scored against a corpus of human-labeled fixtures — so a visual regression is something you can fail a build on, not something you argue about.",
+    artifact: "some-filter",
+    icon: Contrast,
+  },
+  {
+    ordinal: "04",
+    foil: "Not educational games.",
+    claim: "An engine that estimates what a learner knows.",
+    mechanism:
+      "Fixed curricula make the learner adapt to the software. Inverting that makes the software responsible for inferring a hidden knowledge state from every interaction and choosing the next experience that teaches the most — adapting the modality, not just the difficulty. The games are not the product; they are the measurement instruments.",
+    artifact: "hangul-game-core · honeycomb",
+    icon: Brain,
+  },
+]
+
+type Principle = {
+  term: string
+  gloss: string
+  icon: typeof HardDrive
+}
+
+const PRINCIPLES: ReadonlyArray<Principle> = [
+  {
+    term: "Own the critical path",
+    gloss:
+      "Anything load-bearing enough to lose your state is too important to rent from a closed-source vendor.",
+    icon: KeyRound,
+  },
+  {
+    term: "Default deny",
+    gloss:
+      "Nothing earns attention, memory, or visibility automatically. Access is granted by intent.",
+    icon: Ban,
+  },
+  {
+    term: "Preserve identity",
+    gloss:
+      "Reclaiming a resource must never destroy the thing holding it. Eviction is not deletion.",
+    icon: Fingerprint,
+  },
+  {
+    term: "Local-first",
+    gloss:
+      "The work happens on the client, under the user's control, with no service to depend on or outlive.",
+    icon: WifiOff,
+  },
+  {
+    term: "Measure, don't assert",
+    gloss:
+      "Comfort, learning, and reliability get metrics and labeled corpora — not opinions in a review thread.",
+    icon: Ruler,
+  },
+  {
+    term: "Derive before you code",
+    gloss:
+      "Hard subsystems are proved in a canon of definitions and theorems first; modules cite it or the diff is incomplete.",
+    icon: ScrollText,
+  },
+]
+
+type Figure = { value: string; label: string }
+
+const FIGURES: ReadonlyArray<Figure> = [
+  { value: "58", label: "workspace packages" },
+  { value: "12", label: "browser extensions" },
+  { value: "3", label: "formal canons" },
+  { value: "1", label: "engineer" },
+]
+
+const PositionRow = ({
+  ordinal,
+  foil,
+  claim,
+  mechanism,
+  artifact,
+  icon: Icon,
+}: Position): JSX.Element => (
+  <article className="border-border/60 grid gap-x-8 gap-y-5 border-t py-12 md:grid-cols-[7rem_1fr] md:py-16">
+    <div className="flex items-start gap-4 md:flex-col md:gap-5">
+      <span className="text-muted-foreground/35 font-mono text-5xl leading-none font-bold tabular-nums md:text-6xl">
+        {ordinal}
+      </span>
+      <span className="border-border/70 bg-surface/60 flex size-11 shrink-0 items-center justify-center rounded-full border">
+        <Icon className="text-muted-foreground size-5" aria-hidden />
+      </span>
+    </div>
+
+    <div className="space-y-5">
+      <p className="text-muted-foreground/70 text-base font-medium line-through decoration-1 md:text-lg">
+        {foil}
+      </p>
+      <h3 className="text-gradient-heading max-w-3xl text-3xl leading-[1.1] font-bold tracking-tight text-balance md:text-5xl">
+        {claim}
+      </h3>
+      <p className="text-muted-foreground max-w-2xl leading-relaxed">
+        {mechanism}
+      </p>
+      <p className="text-muted-foreground/80 pt-1 font-mono text-xs tracking-wide">
+        {artifact}
+      </p>
+    </div>
+  </article>
+)
+
+const Mission = (): JSX.Element => (
+  <main className="bg-background text-foreground min-h-svh">
+    {/* Fixed chrome: the page is a long read, so the way back and the theme
+        control stay reachable without scrolling to a header. */}
+    <div className="fixed inset-x-0 top-0 z-10 flex items-center justify-between px-5 py-4 md:px-8">
+      <Link
+        to="/"
+        className="text-muted-foreground hover:text-foreground bg-background/70 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-sm backdrop-blur transition-colors"
+      >
+        <ArrowLeft className="size-4" aria-hidden />
+        Back
+      </Link>
+      <ThemeSwitcher />
+    </div>
+
+    <div className="mx-auto max-w-5xl px-5 md:px-8">
+      {/* ── Thesis ─────────────────────────────────────────────────────── */}
+      <header className="flex min-h-svh flex-col justify-center py-24">
+        <p className="text-muted-foreground text-xs font-medium tracking-[0.2em] uppercase">
+          Some UI — Mission
+        </p>
+        <h1 className="text-gradient-heading mt-6 text-5xl leading-[1.05] font-bold tracking-tight text-balance sm:text-6xl md:text-7xl">
+          Own the software you depend on.
+        </h1>
+        <p className="text-muted-foreground mt-8 max-w-2xl text-lg leading-relaxed text-pretty md:text-xl">
+          The tools that mediate a working day — the browser holding your state,
+          the feed spending your attention, the surface straining your eyes, the
+          software claiming to teach you — arrive with defaults chosen by
+          someone else. Every one of those defaults is reversible.
+        </p>
+        <p className="text-muted-foreground/80 mt-5 max-w-2xl leading-relaxed text-pretty">
+          This workspace is four such reversals, built and operated as
+          production software rather than as arguments.
+        </p>
+      </header>
+
+      {/* ── The four positions ─────────────────────────────────────────── */}
+      <section aria-labelledby="positions-heading" className="pb-8">
+        <h2
+          id="positions-heading"
+          className="text-muted-foreground pb-2 text-xs font-medium tracking-[0.2em] uppercase"
+        >
+          Positions
+        </h2>
+        {POSITIONS.map((position) => (
+          <PositionRow key={position.ordinal} {...position} />
+        ))}
+      </section>
+
+      {/* ── The through-line ───────────────────────────────────────────── */}
+      <section className="border-border/60 border-t py-20 md:py-28">
+        <div className="border-primary/40 border-l-2 pl-6 md:pl-10">
+          <p className="max-w-3xl text-2xl leading-snug font-semibold tracking-tight text-balance md:text-3xl">
+            Each of these begins by refusing a default, and none of them stops
+            there.
+          </p>
+          <p className="text-muted-foreground mt-6 max-w-2xl leading-relaxed text-pretty">
+            A position that cannot be cashed out in a mechanism is just taste.
+            So every claim above is load-bearing somewhere in the tree: an
+            invariant that makes the bad state unconstructible, a type that
+            turns a mistake into a compile error, a corpus that turns a
+            preference into a test.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Principles ─────────────────────────────────────────────────── */}
+      <section
+        aria-labelledby="principles-heading"
+        className="border-border/60 border-t py-16 md:py-20"
+      >
+        <h2
+          id="principles-heading"
+          className="text-muted-foreground text-xs font-medium tracking-[0.2em] uppercase"
+        >
+          Principles
+        </h2>
+        <dl className="mt-10 grid gap-x-10 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
+          {PRINCIPLES.map(({ term, gloss, icon: Icon }) => (
+            <div key={term} className="space-y-3">
+              <Icon className="text-primary/70 size-5" aria-hidden />
+              <dt className="font-semibold tracking-tight">{term}</dt>
+              <dd className="text-muted-foreground text-sm leading-relaxed">
+                {gloss}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      {/* ── Scale ──────────────────────────────────────────────────────── */}
+      <section
+        aria-labelledby="scale-heading"
+        className="border-border/60 border-t py-16 md:py-20"
+      >
+        <h2
+          id="scale-heading"
+          className="text-muted-foreground text-xs font-medium tracking-[0.2em] uppercase"
+        >
+          One workspace
+        </h2>
+        <dl className="mt-10 grid grid-cols-2 gap-8 lg:grid-cols-4">
+          {FIGURES.map(({ value, label }) => (
+            <div key={label}>
+              <dt className="sr-only">{label}</dt>
+              <dd>
+                <span className="text-gradient-accent block text-4xl font-bold tabular-nums md:text-5xl">
+                  {value}
+                </span>
+                <span className="text-muted-foreground mt-2 block text-sm">
+                  {label}
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+        <p className="text-muted-foreground mt-10 max-w-2xl text-sm leading-relaxed text-pretty">
+          TypeScript and Rust in a single monorepo, behind one merge gate that
+          scopes its work to what actually changed — and one release path that
+          versions, builds, and signs everything above.
+        </p>
+      </section>
+
+      {/* ── Onward ─────────────────────────────────────────────────────── */}
+      <section className="border-border/60 flex flex-wrap gap-x-8 gap-y-3 border-t py-14 text-sm">
+        <Link
+          to="/app"
+          className="text-primary font-medium underline-offset-4 hover:underline"
+        >
+          Open the app
+        </Link>
+        <Link
+          to="/resume"
+          className="text-primary font-medium underline-offset-4 hover:underline"
+        >
+          Résumé
+        </Link>
+        <a
+          href="https://github.com/paulgsc/some-ui"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary font-medium underline-offset-4 hover:underline"
+        >
+          Source on GitHub
+        </a>
+      </section>
+    </div>
+  </main>
+)
+
+export const Route = createFileRoute("/mission")({
+  component: Mission,
+})

--- a/packages/ui/resume/README.md
+++ b/packages/ui/resume/README.md
@@ -2,14 +2,33 @@
 
 `resume.typ` is the source of truth for Paul Gathondu's résumé — a
 [Typst](https://typst.app) document, distilled from this repository itself.
-It's written in conventional résumé grammar (deliverables and technologies,
-one page, no posting-specific content) so it's a reusable drop-in for any
-application flow.
 
-The engineering rationale behind each line, and any posting-specific
-requirements analysis, live separately in `resume.meta.typ` — read as
-source, the same way `docs/canon/*.typ` is not something you build so much
-as something you cite. See its header comment for why the split exists.
+It's written in STAR grammar, told project-first. Each entry opens with the
+premise the project exists to answer — a browser is an operating system and
+tabs are its processes; exposure should be opt-in; visual comfort is
+measurable; a curriculum should adapt to the learner — and then cashes that
+premise out in the mechanism implementing it: the state machine, the
+invariant, the build constraint, the test corpus. The rule the document is
+held to is that **a premise earns its place only if the next line cashes it
+out in a mechanism**; motivation without mechanism doesn't belong on the
+page.
+
+There is deliberately no "Technical Skills" list. Enumerating languages and
+tools communicates nothing a reader can verify; the same tools appear in the
+bullets, attached to the thing they were used to build.
+
+Nothing posting-specific lives here, so the document stays a reusable
+drop-in for any application flow. The provenance map (résumé claim → the
+crate, package, or workflow file backing it), the format's revision history,
+and any posting-specific requirements analysis live separately in
+`resume.meta.typ` — read as source, the same way `docs/canon/*.typ` is not
+something you build so much as something you cite. See its header comment
+for why the split exists.
+
+> Claims in `resume.typ` are load-bearing: if something here stops being
+> true, cut the line rather than re-justifying it, and update the matching
+> entry in `resume.meta.typ` §2. The workspace counts in particular are
+> derived, not remembered — see that section's _Counts_ note.
 
 ## Pipeline (MVP)
 

--- a/packages/ui/resume/resume.meta.typ
+++ b/packages/ui/resume/resume.meta.typ
@@ -8,14 +8,19 @@
 //  Why this file exists: an earlier draft of resume.typ carried this
 //  material inline — the motivation behind each engineering decision, and
 //  a table scoring the repo against a specific job posting's requirements.
-//  External review (kept below, §3) argued a résumé's job is to be an
-//  evidence index, not an engineering design review or a self-assessment,
-//  and that argument holds. So: resume.typ now states deliverables only,
-//  in conventional grammar, reusable as a drop-in for any application. The
-//  "why" and the posting-specific analysis moved here instead of being
-//  deleted, on the same principle docs/canon/README.md states for source
-//  vs. rationale: the code is disposable and re-derivable, the reasoning is
-//  the durable object worth keeping.
+//  A résumé should not do its reader's evaluative work for them, so the
+//  posting-specific scoring moved here (§4) instead of being deleted, on
+//  the same principle docs/canon/README.md states for source vs. rationale:
+//  the code is disposable and re-derivable, the reasoning is the durable
+//  object worth keeping.
+//
+//  Note that the *motivation* did not stay here. v3 stripped it out on the
+//  theory that a résumé is a pure evidence index; v4 put it back, because
+//  a deliverables-only index turned out to describe artifacts nobody could
+//  tell apart from ordinary feature work. See §5 for that reversal and the
+//  reasoning behind it — the distinction v4 rests on is that a premise is
+//  résumé content when it is immediately cashed out in a mechanism, and
+//  self-indulgence when it is not.
 // ═══════════════════════════════════════════════════════════════════════════
 
 #set document(title: "some-ui — Résumé Meta", author: "Paul Gathondu")
@@ -26,53 +31,124 @@
 
 = What this is
 
-`resume.typ` is the résumé — conventional grammar, deliverables and
-technologies only, no self-scoring, no engineering philosophy. This file is
-everything that got cut to get there: the provenance for each résumé line
-(§2), the production method (§3), and a requirements-map analysis against a
-specific posting (§4) — the kind of scoring a résumé shouldn't do to its
-reader but that's genuinely useful for deciding *whether and how to apply*.
-§5 is a short revision log.
+`resume.typ` is the résumé: four projects in STAR grammar, each opening with
+the premise it answers and then cashing that premise out in the mechanism
+that implements it. This file is the apparatus around it — the provenance
+for each claim (§2), the production method (§3), a requirements-map analysis
+against a specific posting (§4) — the kind of scoring a résumé shouldn't do
+to its reader but that's genuinely useful for deciding *whether and how to
+apply* — and a revision log (§5) that is mostly a record of getting the
+format wrong twice.
 
-= Provenance --- résumé line to repo evidence
+= Provenance --- résumé claim to repo evidence
 
-Every bullet in `resume.typ`'s Highlights traces to something that actually
-ships. None of this is aspirational; if a line here stops being true, the
-résumé bullet it backs should be cut, not kept and re-justified.
+Every claim in `resume.typ` traces to something that actually ships. None of
+it is aspirational; if a line here stops being true, the résumé claim it
+backs should be cut, not kept and re-justified.
 
-- *Rust/WebAssembly engine + hex-grid UI* --- `crates/hangul-game-core`
-  (Rust, compiled to WASM) and `packages/ui/honeycomb` (React). Both ship
-  in the production app.
-- *TOPIK prep + typing drill* --- `packages/ui/topik` and the typing-drill
-  engine (`leetype` family: `crates/leetype_wasm`, `packages/ui/leetype`).
-- *ADRs ahead of curriculum changes* --- the single-glyph → multi-token
-  generalization is documented and derived, not just coded, in
+== Suspender Ledger
+
+- *The extension* --- `extensions/suspender-ledger`, a Firefox MV3 tab
+  suspender. A TypeScript port of `auto-tab-discard` v3 rebuilt for the MV3
+  background-script model; the résumé says "built", and the port lineage is
+  stated plainly in that package's README rather than hidden.
+- *Suspension is virtualization* --- the extension drives the browser's
+  native discard, so the tab keeps its strip position and history entry and
+  transparently reloads on activation. Stated as a README invariant and
+  enforced by there being no `tabs.remove()` in the source at all.
+- *Typed boundaries, resilient storage* --- `src/types/messages.ts` (the
+  validated popup ↔ worker ↔ content protocol, original work rather than
+  ported) and `src/worker/core/prefs`, which falls back to defaults on a
+  missing or corrupt read.
+- *Flat worker bundle* --- `vite.config.ts` sets `manualChunks: () => {}`
+  because Firefox MV3 background scripts cannot be code-split;
+  `src/lib/platform/firefox.ts` is the platform shim.
+- *Signed release gate* --- `sign:firefox` (`web-ext`, AMO unlisted
+  channel), behind `typecheck`, `test` (Vitest), `lint:js`, `lint:ext`, and
+  `check:headers` (MPL headers on ported files).
+
+== some-censor
+
+- *The FSM and its invariants* --- `src/lib/content/fsm.ts` states F1–F4
+  directly: every state carries a `SessionId`, transition functions are
+  overloaded so illegal transitions are compile errors, `project()` is an
+  exhaustive switch, and `applyReset()` is the only function that can mint
+  a new session. The résumé's "compile error rather than a silent no-op"
+  is quoting F2 nearly verbatim.
+- *Progressive disclosure states* --- `src/types/states.ts`: `ViewState =
+  Masked | MetaState | TitleState | Revealed | Whitelisted`.
+- *Click gate* --- `src/lib/content/click-gate.ts`, `DBLCLICK_WINDOW_MS =
+  300`, documented as "onCommit fires exactly once per logical interaction".
+- *Resolver lifecycle* --- `src/types/states.ts`: `NodeState = Unresolved |
+  Resolved | Failed`, with `failed` carrying a reason
+  (`missing-video-id` / `missing-channel-id`); `src/lib/content/observer.ts`
+  is the MutationObserver driving it.
+
+== some-filter
+
+- *Structural isolation* --- `extensions/some-filter` README, Layer Model
+  and Invariants table: `__sw_overlay_root` is never a descendant of
+  `__sw_page_layer`, and theme CSS is scoped to `#__sw_page_layer`.
+  Governed by `docs/canon/dom-state-estimation-canon.typ`.
+- *Comfort metric* --- `adapter/swatches.ts` (`comfortReport` /
+  `satisfiesComfort` / `sampleBodyComfort`), generalized from a registry
+  `Swatch`'s static hex tokens to any observed `(bg, text)` pair so it can
+  run against live `getComputedStyle`. Kept separate from `theme-detector.ts`
+  (`classifyPage` / `detect`, luminance-only) — the two verdicts disagreeing
+  is the point of issue #722.
+- *Test corpus* --- `extensions/filter-classifier`: a standalone Playwright
+  workspace whose harness (`tests/e2e/harness/entry.ts`) imports the real
+  shipped modules from `@some-extension/filter` and bundles them with
+  esbuild. No extension build, no `--load-extension`, no reimplementation.
+
+== Adaptive learning platform
+
+- *Engine + UI* --- `crates/hangul-game-core` (pure Rust, compiled to WASM)
+  and `packages/ui/honeycomb` (React hex grid). Both ship in the production
+  app; `packages/ui/topik` and the `leetype` family (`crates/leetype_wasm`,
+  `packages/ui/leetype`) are the exam-prep and typing-drill modules.
+- *Single-glyph → multi-token generalization* --- derived in
   `docs/canon/hangul-progression-canon.typ` ("The Single-Glyph Ceiling")
   before the corresponding source change landed. The `Stimulus`/`Answer`
-  content-schema split is a real type boundary in the curriculum model,
-  not resume framing.
-- *Turborepo/pnpm CI/CD, scoped to changed packages* --- root
-  `turbo.json` + `.github/workflows`; the required `ci-gate` check scopes
-  lint/typecheck/test to changed packages and transitive dependents, backed
-  by a separate full-repo trunk sweep and a standalone Rust CI job running
-  clippy and cargo-deny.
-- *Release pipeline* --- Changesets config + `.changeset/` drive versioned
-  publishing and changelogs across all 61 workspace packages; GitHub
-  Actions handle Storybook/design-system deploys, Docker/GHCR builds for
-  `apps/www`, and signed extension releases.
-- *`some-filter` DOM-isolation architecture* --- `extensions/some-filter`,
-  governed by `docs/canon/dom-state-estimation-canon.typ` ("The Unsettled
-  Surface"). The invariant is that extension UI can never nest inside the
-  patched page's DOM layer; 14 other extensions ship alongside it on shared
-  `extensions/common` / `extensions/transport` packages.
-- *Design system + classifier corpus* --- `packages/some-styles` (Tailwind
-  CSS v4, documented in Storybook) and `extensions/filter-classifier` (a
-  Playwright corpus of human-labeled fixtures used to calibrate and verify
-  `some-filter`'s DOM comfort/theme classifier).
-- *61 packages, 15+ extensions* --- counted directly from the pnpm
-  workspace at the time of writing (2026-07-26); re-count via
-  `pnpm -r list --depth -1 | wc -l` and `ls extensions | wc -l` before
-  reusing these numbers in the résumé if meaningful time has passed.
+  split is a real type boundary in the curriculum model, not résumé framing.
+- *The canon and its negative result* --- `docs/canon/adaptive-learning-canon.typ`
+  ("The Unobservable Learner"), ~2,100 lines, sections for the domain, the
+  latent learner, the observation channel, the exercise, the estimator, the
+  policy, the persistence budget, the semantic boundary, and falsifiers.
+  The impossibility result the résumé cites is Prop. 2.2 / Thm. 6.1: a
+  `HashSet` of completed identities plus one shared difficulty scalar cannot
+  become adaptive. That it is a proof about *the code that currently ships*
+  is the part worth keeping in the bullet.
+
+== Platform, release, and reuse
+
+- *Scoped CI gate* --- root `turbo.json` plus `.github/workflows`; the
+  required gate (`pr.yml`, `_detect-changes.yml`) scopes lint/typecheck/test
+  to changed packages and transitive dependents, backed by `trunk.yml`
+  (full-repo sweep) and `_rust-ci.yml` (clippy, cargo-deny).
+- *Release path* --- Changesets and `.changeset/` drive versioning and
+  changelogs across the workspace; `release.yml`, `www-docker-release.yml`
+  (Docker/GHCR), `pages.yml` (GitHub Pages + Storybook), `wasm-release.yml`,
+  and `extension-sign*.yml` / `_extension-verify.yml` cover the rest.
+- *Hoisted contract, not a shared runtime* --- `extensions/common`
+  (`GOOD_CITIZEN.md` and the "two mandates": disjointness vs. no
+  reinvention) with idioms enforced by `packages/eslint`
+  (`@some-ui/eslint-kit`).
+- *`transport` kernel independence* --- `extensions/transport`: an
+  observe/estimate/plan/act kernel whose unit and Playwright conformance
+  suites pass against `adapter/null-adapter.ts` alone (Theorem D.2), with no
+  domain logic anywhere in the tree.
+
+== Counts
+
+*58 workspace packages, 12 browser extensions* --- counted 2026-07-26.
+`pnpm -r list --depth -1` reports 59 workspace projects including the repo
+root, hence 58. The extension count is directories under `extensions/` that
+declare a `manifest_version`, which deliberately excludes the shared
+packages (`common`, `transport`, `docs`, `scripts`) and the
+`filter-classifier` test corpus. Re-derive both before reusing them if
+meaningful time has passed --- an earlier revision of this résumé claimed
+"61 packages" and "15+ extensions", and neither survived a recount.
 
 = Method
 
@@ -165,11 +241,51 @@ not claim AWS or model-training experience that isn't backed by the repo.
 - *v2* --- added an inline "Requirements Map" section scoring the résumé
   against this posting, on the theory that legible divergence was more
   honest than tailored-sounding copy.
-- *v3 (current)* --- external review argued a résumé is an evidence index,
-  not a design review: motivation, proof-of-correctness language, and
-  self-scoring all cost reader attention without helping a hiring decision,
-  and the requirements map in particular does the reader's evaluative work
-  for them. Agreed for `resume.typ` itself. Pivoted `resume.typ` to
-  conventional grammar (deliverables, technologies, one page, reusable
-  across applications) and moved the "why" and the posting-specific
-  analysis here, rather than deleting them.
+- *v3* --- external review argued a résumé is an evidence index, not a
+  design review: motivation, proof-of-correctness language, and self-scoring
+  all cost reader attention without helping a hiring decision, and the
+  requirements map in particular does the reader's evaluative work for them.
+  Pivoted `resume.typ` to conventional grammar (deliverables, technologies,
+  one page, reusable across applications) and moved the "why" and the
+  posting-specific analysis here rather than deleting them.
+
+- *v4 (current)* --- v3 was over-corrected, and reading it against the
+  actual user stories behind the projects made the failure obvious. Stripped
+  to deliverables, the work read like ordinary feature output: "developed a
+  browser-extension architecture that isolates extension UI from host-page
+  DOM mutations" describes what was built and none of what makes it
+  interesting, and a reader has no way to distinguish it from a ticket
+  someone was handed. The projects in this repo are *positions* --- a
+  browser is an operating system and tabs are processes; attention is a
+  finite resource and exposure should be opt-in; visual comfort is
+  measurable rather than aesthetic; a curriculum should adapt to the learner
+  rather than the reverse --- and a résumé that omits the position has
+  deleted the reason the artifact exists.
+
+  So v4 restores motivation, but under a constraint that answers v3's
+  objection rather than ignoring it: *a premise earns its place only if the
+  next line cashes it out in a mechanism.* "Suspension is virtualization,
+  not cleanup" is followed immediately by the native-discard behaviour and
+  the absent `tabs.remove()`. "Nothing earns attention by default" is
+  followed by the `masked → meta → title → revealed` state machine and the
+  overloads that make an illegal transition a compile error. Motivation
+  without mechanism is the self-indulgence v3 correctly cut; motivation
+  *with* mechanism is the difference between a feature list and an
+  engineering position, and it is what this résumé is for.
+
+  Two further changes, both housekeeping:
+
+  - *Dropped the "Technical Skills" enumeration.* A comma-separated list of
+    languages and tools communicates nothing verifiable --- it is closer to
+    listing the applications one has opened than to evidencing expertise.
+    Every tool that was in that list still appears in the résumé, attached
+    to the thing it was used to build, where it carries information a reader
+    can check. Expertise is communicated through artifacts, not inventory.
+  - *Dropped the "Set in Typst from `packages/ui/resume/resume.typ`..."*
+    colophon. It was a note about this document's own build pipeline, on a
+    page whose entire job is to be about the candidate; the pipeline is
+    genuinely interesting and it is documented in `README.md`, which is
+    where someone who cares can find it.
+
+  Also corrected the workspace counts (61 → 58 packages, "15+" → 12
+  extensions); see §2's *Counts* note for how both are derived.

--- a/packages/ui/resume/resume.typ
+++ b/packages/ui/resume/resume.typ
@@ -1,100 +1,240 @@
 // ═══════════════════════════════════════════════════════════════════════════
-//  resume.typ — Paul Gathondu's résumé. Conventional grammar, on purpose:
-//  deliverables and technologies, not motivation or methodology. This file
-//  is meant to be a generic drop-in for any application flow (upload, ATS
-//  parse, print) — nothing posting-specific lives here.
+//  resume.typ — Paul Gathondu's résumé.
 //
-//  Every line still traces to something that actually ships from `some-ui`
-//  (a package, a workflow file, a shipped extension) — see
-//  packages/ui/resume/resume.meta.typ (same directory) for the full
-//  provenance map, the "why" behind each decision, and any posting-specific
-//  requirements analysis. That file is commentary; this one is the résumé.
+//  Grammar: STAR, told project-first. Each entry opens with the premise the
+//  project exists to answer (situation + task, one italic line), then bullets
+//  carrying the engineering action and the result it produced. The premise is
+//  the point — these projects are not features, they are positions about how
+//  software should behave — but this is a *technical* résumé, so every
+//  premise is immediately cashed out in the mechanism that implements it:
+//  the state machine, the invariant, the build constraint, the test corpus.
+//
+//  There is deliberately no "Technical Skills" list. Enumerating languages
+//  and tools communicates nothing a reader can verify; the same tools appear
+//  in the bullets, attached to the thing they were used to build, where they
+//  actually carry information.
+//
+//  Every line traces to something that ships from `some-ui` — a crate, a
+//  package, a workflow file, a signed extension. See resume.meta.typ (same
+//  directory) for the provenance map and the rationale behind the format.
 // ═══════════════════════════════════════════════════════════════════════════
 
 #set document(title: "Paul Gathondu — Résumé", author: "Paul Gathondu")
-#set page(paper: "us-letter", margin: (x: 1.9cm, y: 1.6cm))
-#set text(font: "Libertinus Serif", size: 10pt, lang: "en")
-#set par(justify: true, leading: 0.62em)
+#set page(paper: "us-letter", margin: (x: 1.7cm, y: 1.5cm))
+#set text(font: "Libertinus Serif", size: 9.9pt, lang: "en")
+#set par(justify: true, leading: 0.64em)
 #show heading: set text(font: "New Computer Modern")
 
-#let tagline(body) = text(size: 9.6pt, fill: rgb("#4a4a4a"))[#body]
+#set list(indent: 0.2em, spacing: 0.62em, marker: [•])
+
+#let tagline(body) = text(size: 9.5pt, fill: rgb("#4a4a4a"))[#body]
+
+// `sticky` keeps a section rule glued to the content beneath it, so a heading
+// can never be stranded alone at the foot of a page.
 #let sectionhead(title) = [
-  #v(0.5em)
-  #block(below: 0.35em)[
-    #text(size: 11.5pt, weight: "bold", tracking: 0.4pt)[#upper(title)]
+  #v(0.6em)
+  #block(below: 0.45em, sticky: true)[
+    #text(size: 11pt, weight: "bold", tracking: 0.4pt)[#upper(title)]
     #line(length: 100%, stroke: 0.5pt + rgb("#bbbbbb"))
+  ]
+]
+
+// A project entry: name + what it is, then the premise it answers. The
+// premise line is the "situation/task" half of STAR; the bullets that follow
+// are "action/result". The whole header is one unbreakable, sticky block —
+// a project's name and its premise travel together, and travel with the
+// first bullet of the evidence that backs them.
+#let project(name, kind, premise) = block(
+  breakable: false,
+  sticky: true,
+  above: 1.15em,
+  below: 0.42em,
+)[
+  #block(below: 0.34em)[
+    #text(size: 10.4pt, weight: "bold")[#name]
+    #h(0.45em)
+    #text(size: 9pt, fill: rgb("#5a5a5a"))[#kind]
+  ]
+  #block(
+    inset: (left: 0.55em),
+    stroke: (left: 1.2pt + rgb("#c8c8c8")),
+  )[
+    #pad(left: 0.5em)[
+      #text(size: 9.4pt, style: "italic", fill: rgb("#3c3c3c"))[#premise]
+    ]
   ]
 ]
 
 // ── Header ───────────────────────────────────────────────────────────────
 
 #align(center)[
-  #text(size: 20pt, weight: "bold")[Paul Gathondu]
-  #v(0.15em)
-  #tagline[Software Engineer — Rust/WebAssembly, TypeScript/React, CI/CD]
-  #v(0.25em)
-  #text(size: 9pt)[
+  #text(size: 19pt, weight: "bold")[Paul Gathondu]
+  #v(0.12em)
+  #tagline[
+    Software Engineer --- browser and systems infrastructure in Rust,
+    WebAssembly, and TypeScript
+  ]
+  #v(0.22em)
+  #text(size: 8.8pt)[
     paulgathondudev\@gmail.com
-    #h(0.6em) · #h(0.6em)
+    #h(0.55em) · #h(0.55em)
     github.com/paulgsc
-    #h(0.6em) · #h(0.6em)
+    #h(0.55em) · #h(0.55em)
     paulgsc.github.io/some-ui
-    #h(0.6em) · #h(0.6em)
+    #h(0.55em) · #h(0.55em)
     github.com/paulgsc/some-ui
   ]
 ]
 
 #sectionhead[Summary]
 
-Software engineer who designs, builds, and operates production systems end
-to end — a Rust/WebAssembly engine, a React/TypeScript application, and the
-CI/CD and release infrastructure behind them. Sole maintainer of `some-ui`,
-a 61-package monorepo shipping an adaptive language-learning platform and
-15+ browser extensions.
+Software engineer who builds the infrastructure he depends on instead of
+renting it: a virtual-memory layer for a browser used as an operating system,
+an attention firewall that makes exposure opt-in rather than default, a
+rendering layer that treats visual comfort as a measurable property, and an
+instruction engine that estimates what a learner knows instead of marching
+them through a fixed curriculum. All four ship from `some-ui` --- a
+58-package TypeScript and Rust monorepo --- alongside the CI/CD, release, and
+signing pipelines behind them. Sole engineer, from architecture to production.
 
-#sectionhead[Sole Engineer --- some-ui (2024 --- Present)]
+#sectionhead[Selected Work --- some-ui, sole engineer (2024 --- Present)]
 
-Design, build, and maintain a production-scale monorepo (61 TypeScript and
-Rust packages) powering an adaptive language-learning platform and a suite
-of browser extensions, alone, from architecture through release.
-
-*Highlights*
-
-- Developed a Rust/WebAssembly game engine (`hangul-game-core`) and a React
-  hex-grid study interface (`honeycomb`) for an adaptive Hangul-learning
-  platform.
-- Built a TOPIK exam-prep module and a typing-drill engine on the same
-  curriculum platform.
-- Authored architecture decision records ahead of curriculum-model changes,
-  including generalizing the engine from single-character to multi-word
-  exercises, backed by a typed `Stimulus`/`Answer` content schema.
-- Built a Turborepo + pnpm CI/CD pipeline on GitHub Actions that scopes
-  lint, type-check, and test runs to changed packages and their
-  dependents behind a required merge check, plus a full-repo sweep and a
-  standalone Rust CI job (clippy, cargo-deny).
-- Built a release pipeline with Changesets (versioned publishing,
-  changelogs), GitHub Actions (Storybook and design-system deploys,
-  Docker/GHCR builds), and signed browser-extension releases.
-- Developed a browser-extension architecture (`some-filter`) that isolates
-  extension UI from host-page DOM mutations, preventing style leakage on
-  arbitrary third-party sites; shipped alongside 14 other extensions on
-  shared internal packages.
-- Built a Tailwind CSS design system (`some-styles`) documented in
-  Storybook, and a labeled test corpus (`filter-classifier`) for a DOM
-  theme/comfort classifier.
-
-#sectionhead[Technical Skills]
-
-#text(size: 9.3pt)[
-  TypeScript · React · Rust · WebAssembly · Tailwind CSS · Storybook ·
-  Turborepo · pnpm · Vite · Docker · GitHub Actions · Git · Zod ·
-  Changesets · Typst
+#project(
+  "Suspender Ledger",
+  [Firefox MV3 extension · TypeScript, Vite, Vitest],
+)[
+  A browser used as an operating system holds hundreds of tabs that are
+  long-lived workspaces, not pages --- so suspension is virtualization, not
+  cleanup. Reclaiming memory must never cost a tab its identity, and that
+  guarantee was being rented from a closed-source vendor extension.
 ]
 
-#v(0.6em)
-#align(center)[
-  #text(size: 7.7pt, fill: rgb("#8a8a8a"), style: "italic")[
-    Set in Typst from `packages/ui/resume/resume.typ` in this repository —
-    compiled to PDF as part of its own build pipeline.
-  ]
+- Built a tab suspender around the browser's native discard mechanism so a
+  suspended tab keeps its strip position and history entry and reloads
+  transparently on activation --- the logical tab survives even though its
+  memory does not.
+- Made irreversibility structurally impossible rather than merely unintended:
+  no `tabs.remove()` exists anywhere in the source, every popup ↔ worker ↔
+  content message is typed and validated at the boundary, and a corrupt or
+  missing preferences read falls back to defaults instead of throwing --- the
+  non-happy path cannot strand a tab.
+- Solved Firefox MV3's prohibition on code-split background scripts by
+  emitting the service worker as a single flat bundle (Vite `manualChunks`),
+  with browser-API differences quarantined behind a platform shim rather than
+  branching at call sites.
+- Ships as a signed, unlisted `.xpi` through AMO, gated by a pipeline that
+  must pass `tsc`, Vitest, ESLint, `web-ext lint`, and an MPL-header check
+  before a build is eligible to sign.
+
+#project(
+  "some-censor",
+  [Browser extension · TypeScript, MutationObserver, typed FSM],
+)[
+  Recommendation surfaces are engineered to maximize exposure. Inverting that
+  means nothing earns attention by default: content stays hidden until it is
+  deliberately revealed, so searching for something never requires being
+  exposed to everything around it.
 ]
+
+- Implemented progressive disclosure as an explicit finite state machine ---
+  `masked → meta → title → revealed`, plus a `whitelisted` escape --- over a
+  discriminated-union `ViewState`, so a recommendation surrenders exactly one
+  layer of information per deliberate interaction.
+- Encoded the machine's invariants in the type system instead of in review
+  comments: transition functions are overloaded so an illegal transition is a
+  compile error rather than a silent no-op, an exhaustive `project()` switch
+  makes adding a state variant fail the build until every branch is handled,
+  and every state carries a `SessionId` that only a reset can mint --- so a
+  single-page navigation cannot leak reveal state between pages.
+- Wrote an async click gate that disambiguates click from double-click within
+  a 300 ms window, guaranteeing one commit per logical interaction so a reveal
+  step can never be skipped by event ordering.
+- Reconciles a virtualized, continuously re-rendered feed to stable video and
+  channel identity through a MutationObserver-driven resolver whose output is
+  itself a typed lifecycle (`unresolved | resolved | failed`), so extraction
+  failures are represented rather than swallowed.
+
+#project(
+  "some-filter",
+  [Browser extension + Playwright corpus · TypeScript, esbuild],
+)[
+  Every site ships its own contrast, luminance, and palette, forcing the eye
+  to re-adapt on each navigation. Visual comfort is an engineering problem
+  with measurable properties, not a theming preference --- which means visual
+  regressions should be testable, not arguable.
+]
+
+- Designed a structural isolation layer that relocates vendor DOM into a
+  dedicated page layer and mounts extension UI as its sibling, holding the
+  invariant that the overlay root is never a descendant of the page layer ---
+  so theme CSS scoped to that layer is provably incapable of leaking into
+  extension UI on an arbitrary third-party site.
+- Built a comfort metric over observed background/text pairs sampled from live
+  `getComputedStyle`, generalized from static palette tokens so it evaluates
+  what a page actually renders, and kept it deliberately separate from the
+  page-level light/dark classifier so the two verdicts can disagree ---
+  the disagreement is the diagnostic signal.
+- Stood up `filter-classifier`, a standalone Playwright corpus of
+  human-labeled fixtures that bundles the extension's real shipped modules via
+  esbuild rather than reimplementing them, so a fix in the extension is
+  exercised by the corpus on the next run with no duplicated logic and no
+  extension build step.
+
+#project(
+  "Adaptive learning platform",
+  [Rust → WebAssembly engine + React application],
+)[
+  Conventional courseware fixes the curriculum and expects every learner to
+  adapt to it. Inverting that makes the software responsible for inferring
+  what the learner knows, choosing the smallest next concept that produces
+  progress, and adapting the modality --- not just the difficulty --- to
+  teach it.
+]
+
+- Built the game engine as a pure-Rust crate compiled to WebAssembly
+  (`hangul-game-core`), consumed by a React hex-grid study interface
+  (`honeycomb`), with a TOPIK exam-prep module and a typing-drill engine
+  sharing the same curriculum platform.
+- Generalized the content model from single-glyph to multi-token exercises
+  behind a typed `Stimulus`/`Answer` schema --- a real type boundary in the
+  curriculum model --- after deriving the ceiling the previous model had hit,
+  rather than discovering it in production.
+- Authored *The Unobservable Learner*, a 2,000-line formal treatment of
+  adaptive instruction as state estimation over latent learner knowledge:
+  observation channel, estimator, policy, and persistence budget, each stated
+  as numbered definitions and theorems with stable citation anchors.
+- Used it to prove a negative result about the shipping engine --- that a set
+  of completed identities plus one shared difficulty scalar is insufficient to
+  ever become adaptive --- establishing what the replacement must carry before
+  any of it was written.
+
+#sectionhead[Platform, Release, and Reuse]
+
+- Operate a 58-package pnpm and Turborepo monorepo spanning TypeScript and
+  Rust. A required merge gate scopes lint, type-check, and test runs to
+  changed packages and their transitive dependents, backed by a full-repo
+  trunk sweep and a standalone Rust job running `clippy` and `cargo-deny`.
+- Own the release path end to end: Changesets-driven versioning and
+  changelogs across every workspace package, plus GitHub Actions pipelines for
+  Docker/GHCR image builds, GitHub Pages and Storybook deploys, WASM releases,
+  and signed browser-extension releases.
+- Solved cross-extension coupling by hoisting the *contract* --- shared types,
+  typestate, and boundary guards --- into a commons package while enforcing
+  the idioms through a custom ESLint plugin rather than a shared runtime, so a
+  change in one extension cannot produce a defect in another.
+- Extracted `transport`, a property-agnostic observe/estimate/plan/act kernel
+  for reasoning about partially-observable DOM, and held it to an independence
+  bar: its full unit and Playwright conformance suites pass against a null
+  adapter alone, with no domain logic anywhere in the tree.
+
+#sectionhead[Engineering Practice]
+
+Architecture decisions are derived before they are coded. Non-trivial
+subsystems in this repository are governed by a *canon* --- a formal document
+stating the definitions, axioms, and impossibility results the implementation
+must satisfy, carrying stable citation anchors and an explicit amendment
+protocol. Modules are reviewed against a theorem number rather than a feature
+spec: a diff that changes governed behaviour and cites nothing is treated as
+incomplete. The discipline exists to make the reasoning the durable artifact
+and the code the disposable one --- which is also why the negative results
+above were provable rather than merely suspected.


### PR DESCRIPTION
## Description

This PR adds a `/mission` route to `apps/www` that articulates the high-level positions behind the projects in this workspace, and rewrites the résumé to lead each project with the premise it answers before cashing that out in the mechanism implementing it.

**Problem:** The previous résumé stated deliverables only, treating it as a pure evidence index. This made the work read like ordinary feature output — nothing distinguished these projects from tickets someone was handed. The workspace's actual through-line — that a browser is an operating system, exposure should be opt-in, visual comfort is measurable, a curriculum should adapt to the learner — was only legible to someone willing to read four separate READMEs and three formal canons.

**Solution:** 

- **`/mission` page** — A visual statement (not a blog or journal) presenting four projects as one refusal, one claim, and one mechanism each, followed by the principles they share. Kept as a text link on the landing page so it doesn't compete with the destination cards for attention.

- **Résumé rewrite** — Each project now opens with the premise it answers, then immediately cashes that out in the mechanism implementing it. The rule is explicit: **a premise earns its place only if the next line names the mechanism.** "Suspension is virtualization, not cleanup" is followed by the native-discard behaviour and the absent `tabs.remove()`; "nothing earns attention by default" is followed by the `masked → meta → title → revealed` state machine and the overloads that make an illegal transition a compile error.

- **Dropped "Technical Skills" enumeration** — A comma-separated tool list communicates nothing verifiable. Every tool still appears in the résumé, attached to the thing it was used to build.

- **Corrected workspace counts** — 61 → 58 packages, "15+" → 12 extensions. Both are now derived rather than remembered, with the derivation recorded in `resume.meta.typ`.

- **Per-project provenance map** — `resume.meta.typ` now maps each résumé claim to the crate, package, or workflow file backing it, and records the format reversal.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Notes

- The mission page uses the same design system and theme infrastructure as the rest of the site (`some-styles`, `ThemeSwitcher`).
- The résumé's STAR format is enforced by the rule stated in the document itself and in `resume.meta.typ` — no mechanism, no premise.
- Both the mission page and résumé are generated from source (Typst for the résumé, React for the mission page) and are part of the same build and release pipeline.

https://claude.ai/code/session_01NPSivw23yBYocDYFD63fyK