### PR TITLE
chore(deps): ungroup majors in the typescript-tooling and eslint groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,23 @@ updates:
       wasm-crates:
         patterns:
           - "@some-ui/*"
+      # update-types keeps majors out of the group so they arrive as their
+      # own PRs. Without it a single breaking bump makes the whole group
+      # unmergeable and the routine patches riding with it stall too — see
+      # #515, where typescript 5.9.3 -> 7.0.2 held up five @typescript-eslint
+      # updates, and #775, where eslint-plugin-unicorn 69 -> 72 held up four.
+      # Majors are not dropped, only ungrouped.
       typescript-tooling:
         patterns:
           - "typescript*"
           - "@typescript-eslint/*"
           - "tsc-*"
+        update-types: ["minor", "patch"]
       eslint:
         patterns:
           - "eslint*"
           - "@eslint/*"
+        update-types: ["minor", "patch"]
       storybook:
         patterns:
           - "@storybook/*"


### PR DESCRIPTION
## Description

One-line-per-group change to `.github/dependabot.yml` that stops a single breaking bump from stranding the routine patches grouped with it.

Both `typescript-tooling` and `eslint` currently bundle every update type, so any major makes the whole group unmergeable. That is exactly what stalled two PRs for weeks:

| PR | Blocked by | Stranded alongside it |
| --- | --- | --- |
| #515 | `typescript` 5.9.3 → **7.0.2** | 4× `@typescript-eslint/*`, `tsc-alias` |
| #775 | `eslint-plugin-unicorn` 69 → **72**, `eslint-plugin-json` 4 → **5** | `eslint` 10.8.0, `@eslint/eslintrc`, `eslint-plugin-storybook`, `eslint-plugin-tailwindcss` |

Both had to be split by hand to land the safe two-thirds (done in #800).

```yaml
typescript-tooling:
  patterns:
    - "typescript*"
    - "@typescript-eslint/*"
    - "tsc-*"
  update-types: ["minor", "patch"]
eslint:
  patterns:
    - "eslint*"
    - "@eslint/*"
  update-types: ["minor", "patch"]
```

**Majors are not dropped.** They simply no longer match the group, so Dependabot raises them as individual PRs — which is what a major deserves: its own migration and its own review. The routine minor/patch updates keep flowing as a single grouped PR.

This is already live-testable: Dependabot reopened both groups as #803 and #805 immediately after #800 merged, carrying the same majors. Once this lands, the next run splits them.

## Left as-is

`wasm-crates` (internal workspace packages — majors there are ours to coordinate), `storybook`, `vite`, and the two `github-actions` groups. They share the same shape and could take the same treatment, but none has actually bitten yet, and widening the change would be a dependency-policy decision rather than the mechanical fix asked for.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

Verified: YAML parses, all five npm groups and both actions groups still resolve as expected, and prettier reports the file already correctly formatted. No source, build or runtime surface is touched — this only changes which PRs Dependabot opens on its next run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq7mp7ogjJ9Yi4MyJFoKLd)_