### PR TITLE
chore(deps): bump once_cell to 1.21.4 and serde_json to 1.0.151

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",


### PR DESCRIPTION
## Description

Lockfile-only patch bumps, batched because both touch `Cargo.lock` and would otherwise have formed a rebase chain.

| Dependency | Version | PR |
| --- | --- | --- |
| `once_cell` | 1.21.3 → 1.21.4 | #809 |
| `serde_json` | 1.0.150 → 1.0.151 | #811 |

### Verification

Compared against a **deterministic** clippy diff — the full set of `(file, line, lint)` error diagnostics from `cargo clippy --workspace --all-targets --keep-going --message-format=json`, before and after:

```
baseline (main):  492 diagnostics
with bumps:       492 diagnostics
new:              none
```

The `--keep-going` matters. Without it cargo stops scheduling after the first failing crate, so *which* crates emit diagnostics varies between runs — a plain count comparison is meaningless. My first attempt without it showed a spurious 64 → 65 and a large phantom diff of `some-bricks` / `hangul-game-core` entries that were pure scheduling noise.

Also verified: workspace builds, all 25 test suites pass, and all four cargo-deny checks pass (advisories, licenses, bans, sources).

## Not included

**serde 1.0.229 (#810)** — held back. `serde_derive@1.0.229` moves to `syn 3.0.3` while the rest of the dependency graph is still on `syn 2.0.108`. The workspace denies `clippy::cargo`, so this adds a second `clippy::multiple_crate_versions` error:

```
baseline           error: multiple versions for dependency `windows-sys`: 0.60.2, 0.61.2
with serde 1.0.229 error: multiple versions for dependency `windows-sys`: 0.60.2, 0.61.2
                   error: multiple versions for dependency `syn`: 2.0.108, 3.0.3   ← new
```

Reproduced in both directions. It's a genuinely new denied lint, so it waits until the rest of the graph reaches syn 3.

**rand 0.8.7 → 0.9.5 (#808)** — closed separately; rationale on that PR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq7mp7ogjJ9Yi4MyJFoKLd)_