### PR TITLE
fix(leetype): required challenge picker, cursor tracking, prettier formatting

### DIFF
--- a/apps/www/src/lib/activity-catalog/catalog.ts
+++ b/apps/www/src/lib/activity-catalog/catalog.ts
@@ -188,17 +188,6 @@ const leetype: ActivityDefinition = {
       defaultValue: "typescript",
     },
     {
-      kind: "select",
-      key: "difficulty",
-      label: "Difficulty",
-      options: [
-        { value: "easy", label: "Easy" },
-        { value: "medium", label: "Medium" },
-        { value: "hard", label: "Hard" },
-      ],
-      defaultValue: "easy",
-    },
-    {
       kind: "duration",
       key: "durationMinutes",
       label: "Session length",
@@ -210,18 +199,16 @@ const leetype: ActivityDefinition = {
   ],
   defaultConfig: {
     language: "typescript",
-    difficulty: "easy",
     durationMinutes: 10,
   },
-  // `difficulty` is passed through as the friendly label the player picked
-  // ("easy"/"medium"/"hard"), not resolved into a full Challenge here -
-  // Leetype (@some-ui/leetype) resolves it at render time against its own
+  // No `difficulty`/challenge picked here - that's a required step of the
+  // session itself now, not a composer-time setting (issue #829). Leetype
+  // (@some-ui/leetype) prompts for it at render time against its own
   // `challenges` pool (bundled CHALLENGES by default, optionally overridden
   // with a local/Docker-fetched corpus - see
   // apps/www/src/lib/leetype-challenges), the same way session-viewport
   // already lets HangulHexGrid resolve its own word pool.
   toSceneProps: (config) => ({
-    difficulty: config.difficulty,
     initialLanguage: config.language,
   }),
 }

--- a/apps/www/src/lib/activity-catalog/to-scene-config.test.ts
+++ b/apps/www/src/lib/activity-catalog/to-scene-config.test.ts
@@ -32,7 +32,7 @@ describe("toSceneConfig", () => {
   it("converts durationMinutes into milliseconds", () => {
     const scene = toSceneConfig(
       "leetype",
-      { language: "rust", difficulty: "medium", durationMinutes: 5 },
+      { language: "rust", durationMinutes: 5 },
       { startTime: 0 }
     )
     expect(scene.duration).toBe(5 * 60_000)

--- a/packages/ui/leetype/src/components/typing-game/code-display/index.stories.tsx
+++ b/packages/ui/leetype/src/components/typing-game/code-display/index.stories.tsx
@@ -32,11 +32,13 @@ const StoryFromFile = ({
 }) => {
   // Determine the Prettier parser
   const prettierParser =
-    language === "typescript" || language === "c"
+    language === "typescript"
       ? "typescript"
       : language === "rust"
         ? "rust"
-        : "babel"
+        : language === "cpp"
+          ? "cpp"
+          : "c"
 
   // Consume the full FSM state
   const state = useFormattedCode(path, {
@@ -111,7 +113,7 @@ const StoryFromFile = ({
           language={language}
           targetUnits={targetUnits}
           userUnits={userUnits}
-          cursorUnitIndex={typedChars}
+          cursorDisplayIndex={typedChars}
         />
       )
     }

--- a/packages/ui/leetype/src/components/typing-game/code-display/index.tsx
+++ b/packages/ui/leetype/src/components/typing-game/code-display/index.tsx
@@ -9,6 +9,7 @@ import type {
   DisplayMode,
   TextGradient,
 } from "@leetype/types/leetype"
+import { ChevronDown } from "lucide-react"
 import Prism from "prismjs"
 import { cn } from "some-ui-utils"
 
@@ -55,7 +56,16 @@ type CodeDisplayProps = {
   language: string
   targetUnits: Array<CanonicalUnit>
   userUnits: Array<CanonicalUnit>
-  cursorUnitIndex: number
+  /**
+   * Index, into `displayCode`'s characters (not canonical units), of the
+   * character the player is currently on. Deliberately display-character
+   * granularity rather than unit granularity: a canonical unit can span
+   * several rendered characters (e.g. a run of indentation whitespace
+   * collapses to one separator unit), and matching on unit index made the
+   * cursor highlight that whole run at once instead of tracking each
+   * keystroke - the off-by-one/visual-confusion bug from issue #829.
+   */
+  cursorDisplayIndex: number
   displayMode?: DisplayMode
   adaptiveMessage?: string
   className?: string
@@ -74,7 +84,7 @@ export const CodeDisplay: FC<CodeDisplayProps> = ({
   language,
   targetUnits,
   userUnits,
-  cursorUnitIndex,
+  cursorDisplayIndex,
   displayMode = "shown",
   adaptiveMessage,
   className,
@@ -137,7 +147,7 @@ export const CodeDisplay: FC<CodeDisplayProps> = ({
         caret.scrollIntoView({ behavior: "smooth", block: "center" })
       }
     }
-  }, [cursorUnitIndex])
+  }, [cursorDisplayIndex])
 
   const renderHighlightedCode = (): ReactNode => {
     if (!displayBuffer) return displayCode
@@ -161,13 +171,18 @@ export const CodeDisplay: FC<CodeDisplayProps> = ({
       const { char, unitIndex, displayIndex } = displayChar
       const isWhitespace = char.trim() === ""
 
-      if (unitIndex === cursorUnitIndex) {
+      if (displayIndex === cursorDisplayIndex) {
         return (
           <span
             key={displayIndex}
             ref={caretRef}
-            className="bg-blue-500/30 animate-pulse"
+            title="You are here"
+            className="relative rounded-[2px] bg-blue-500/30 ring-2 ring-blue-400 ring-offset-1 ring-offset-background animate-pulse"
           >
+            <ChevronDown
+              aria-hidden="true"
+              className="pointer-events-none absolute -top-3.5 left-1/2 h-3 w-3 -translate-x-1/2 text-blue-400"
+            />
             {isHidden && !isWhitespace ? MASK_CHAR : char}
           </span>
         )

--- a/packages/ui/leetype/src/components/typing-game/code-input-card/index.stories.tsx
+++ b/packages/ui/leetype/src/components/typing-game/code-input-card/index.stories.tsx
@@ -62,11 +62,13 @@ const StoryFromFile = ({
   const wasmReady = useWasmReady()
 
   const prettierParser =
-    language === "typescript" || language === "c"
+    language === "typescript"
       ? "typescript"
       : language === "rust"
         ? "rust"
-        : "babel"
+        : language === "cpp"
+          ? "cpp"
+          : "c"
 
   const state = useFormattedCode(path, { prettierParser })
 
@@ -85,7 +87,7 @@ const StoryFromFile = ({
             language={language}
             targetUnits={[]}
             userUnits={[]}
-            cursorUnitIndex={0}
+            cursorDisplayIndex={0}
             displayMode={displayMode}
             gameState="idle"
             userInput=""
@@ -111,7 +113,7 @@ const StoryFromFile = ({
             language={language}
             targetUnits={[]}
             userUnits={[]}
-            cursorUnitIndex={0}
+            cursorDisplayIndex={0}
             displayMode={displayMode}
             gameState="idle"
             userInput=""
@@ -140,7 +142,7 @@ const StoryFromFile = ({
             language={language}
             targetUnits={targetUnits}
             userUnits={userUnits}
-            cursorUnitIndex={typedChars}
+            cursorDisplayIndex={typedChars}
             displayMode={displayMode}
             gameState={gameState}
             userInput={userInput}

--- a/packages/ui/leetype/src/components/typing-game/code-input-card/index.tsx
+++ b/packages/ui/leetype/src/components/typing-game/code-input-card/index.tsx
@@ -21,7 +21,7 @@ type CodeInputCardProps = {
   language: string
   targetUnits: Array<CanonicalUnit>
   userUnits: Array<CanonicalUnit>
-  cursorUnitIndex: number
+  cursorDisplayIndex: number
   displayMode: DisplayMode
   adaptiveMessage?: string
   textGradient?: TextGradient
@@ -56,7 +56,7 @@ export const CodeInputCard: FC<CodeInputCardProps> = ({
   language,
   targetUnits,
   userUnits,
-  cursorUnitIndex,
+  cursorDisplayIndex,
   displayMode,
   adaptiveMessage,
   textGradient,
@@ -113,7 +113,7 @@ export const CodeInputCard: FC<CodeInputCardProps> = ({
             displayCode={displayCode}
             language={language}
             targetUnits={targetUnits}
-            cursorUnitIndex={cursorUnitIndex}
+            cursorDisplayIndex={cursorDisplayIndex}
             userUnits={userUnits}
             displayMode={displayMode}
             adaptiveMessage={adaptiveMessage}

--- a/packages/ui/leetype/src/components/typing-game/leetype/index.tsx
+++ b/packages/ui/leetype/src/components/typing-game/leetype/index.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
 import { useEffect, useRef, useState } from "react"
+import { ChallengeSelector } from "@leetype/components/typing-game/challenge-selector"
 import { CodeInputCard } from "@leetype/components/typing-game/code-input-card"
 import type { GameInfoContent } from "@leetype/components/typing-game/game-bottom-nav"
 import { GameBottomNav } from "@leetype/components/typing-game/game-bottom-nav"
@@ -7,42 +8,46 @@ import { TypingErrorAlert } from "@leetype/components/typing-game/typing-error-a
 import { useGameTimer } from "@leetype/hooks"
 import { useTypingGame } from "@leetype/hooks/leetype"
 import { useChunkedCode } from "@leetype/hooks/leetype/use-chunked-code"
+import { usePlayerProgress } from "@leetype/hooks/leetype/use-player-progress"
+import type { PrettierParser } from "@leetype/lib/leetype/format-code"
 import { ADAPTIVE_WPM_THRESHOLD } from "@leetype/lib/leetype/player-store"
 import type {
   Challenge,
   ChunkCompletionStats,
   CompletedSessionStats,
-  Difficulty,
   DisplayMode,
   GameState,
   Language,
   NContext,
   TextGradient,
 } from "@leetype/types/leetype"
-import { resolveChallenge } from "@leetype/utils/leetype"
 import { CHALLENGES } from "@some-ui/content"
-import { Badge } from "some-ui-shared"
+import {
+  Badge,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "some-ui-shared"
 
 type LeetypeProps = {
-  /** Direct code paths (legacy / story mode) */
+  /** Direct code paths (legacy / story mode) — skips the challenge picker. */
   codePaths?: Record<Language, string>
-  /** Challenge metadata — enables adaptive mode and difficulty enforcement */
+  /**
+   * A pre-hydrated challenge, e.g. from a host flow (like `LeetypeApp`) that
+   * already ran its own selection step before mounting this component.
+   * Skips the challenge picker below.
+   */
   challenge?: Challenge
   /**
-   * Friendly difficulty label used to resolve a `challenge` out of
-   * `challenges` when the caller only has a config-time difficulty pick, not
-   * a fully hydrated challenge (the config-driven "LeetType" activity's
-   * path - see apps/www's activity-catalog). Ignored when `challenge` is
-   * passed directly.
-   */
-  difficulty?: Difficulty
-  /**
-   * The pool `difficulty` resolves against - defaults to the bundled demo
-   * set (`@some-ui/content`'s `CHALLENGES`), same as before this prop
-   * existed. This is the seam a host app uses to swap in its own challenge
-   * corpus (e.g. an LLM-generated, environment-specific set fetched at
-   * runtime) without this component knowing or caring where the challenges
-   * came from.
+   * The pool the required challenge picker selects from when neither
+   * `challenge` nor `codePaths` is given (the config-driven "LeetType"
+   * activity's path - see apps/www's activity-catalog). Defaults to the
+   * bundled demo set (`@some-ui/content`'s `CHALLENGES`). This is the seam a
+   * host app uses to swap in its own challenge corpus (e.g. an
+   * LLM-generated, environment-specific set fetched at runtime) without this
+   * component knowing or caring where the challenges came from.
    */
   challenges?: Array<Challenge>
   /** Pre-selected language (challenge mode) */
@@ -55,13 +60,11 @@ type LeetypeProps = {
   onSessionComplete?: (stats: CompletedSessionStats) => void
 }
 
-type PrettierParser = "typescript" | "babel" | "rust" | "cpp"
-
 const PRETTIER_PARSER_MAP: Record<Language, PrettierParser> = {
   typescript: "typescript",
   rust: "rust",
-  cpp: "babel",
-  c: "typescript",
+  cpp: "cpp",
+  c: "c",
 }
 
 const DEFAULT_PROMPT_DESCRIPTION =
@@ -76,16 +79,24 @@ type CumulativeStats = {
 export const Leetype: FC<LeetypeProps> = ({
   codePaths,
   challenge,
-  difficulty,
   challenges = CHALLENGES,
   initialLanguage,
   initialDuration,
   nContext,
   onSessionComplete,
 }) => {
-  const resolvedChallenge =
-    challenge ?? resolveChallenge(challenges, difficulty)
-  const isLegacyMode = !resolvedChallenge
+  // Neither a fully-hydrated challenge nor direct code paths were given, so
+  // this mount is the config-driven "LeetType" activity's path: the picker
+  // below is a required, blocking step of the session itself (not a
+  // composer-time setting) — see issue #829.
+  const needsChallengeSelection = !challenge && codePaths === undefined
+  const [pickedChallenge, setPickedChallenge] = useState<Challenge | null>(null)
+  const { progress: playerProgress } = usePlayerProgress()
+
+  const resolvedChallenge = challenge ?? pickedChallenge ?? undefined
+  const isLegacyMode = !needsChallengeSelection && !resolvedChallenge
+  const awaitingChallengeSelection =
+    needsChallengeSelection && !resolvedChallenge
 
   const [gameState, setGameState] = useState<GameState>("idle")
   const [displayMode, setDisplayMode] = useState<DisplayMode>("shown")
@@ -161,7 +172,7 @@ export const Leetype: FC<LeetypeProps> = ({
     consecutiveErrors,
     userInput,
     elapsedTime,
-    cursorUnitIndex,
+    cursorDisplayIndex,
     userUnits,
     displayCode,
     targetUnits,
@@ -285,100 +296,138 @@ export const Leetype: FC<LeetypeProps> = ({
       ref={setThemedContainer}
       className="dark code absolute inset-0 flex flex-col overflow-hidden"
     >
-      {/* Challenge identity strip — kept slim so the viewport still belongs
-          to the code/input card below; everything actionable lives in the
-          bottom nav's menus instead of inline controls. */}
-      {resolvedChallenge && (
-        <div className="mb-3 flex shrink-0 items-center gap-3">
-          <span className="text-base font-semibold text-card-foreground">
-            {resolvedChallenge.title}
-          </span>
-          <Badge
-            variant={
-              resolvedChallenge.difficulty === "easy"
-                ? "default"
-                : resolvedChallenge.difficulty === "medium"
-                  ? "secondary"
-                  : "destructive"
-            }
-            className="capitalize"
+      {awaitingChallengeSelection ? (
+        // Required, blocking step of the session itself — no close button,
+        // and outside interactions are suppressed so a session can't start
+        // without a challenge picked (see issue #829: this used to be a
+        // silent composer-time "difficulty" setting instead).
+        <Dialog open>
+          <DialogContent
+            container={themedContainer}
+            showOverlay
+            showCloseButton={false}
+            className="max-h-[85vh] max-w-3xl overflow-y-auto"
+            onEscapeKeyDown={(e) => e.preventDefault()}
+            onPointerDownOutside={(e) => e.preventDefault()}
+            onInteractOutside={(e) => e.preventDefault()}
           >
-            {resolvedChallenge.difficulty}
-          </Badge>
-          {nContext && (
-            <Badge variant="outline" className="font-mono text-xs capitalize">
-              N={nContext}
-            </Badge>
-          )}
-          {effectiveDisplayMode === "hidden" && (
-            <Badge variant="outline" className="text-xs text-muted-foreground">
-              {adaptiveHidden ? "Adaptive: hidden" : "Hidden mode"}
-            </Badge>
-          )}
-        </div>
-      )}
-
-      <div className="relative min-h-0 flex-1">
-        <CodeInputCard
-          status={codeState.status}
-          loadError={codeState.error}
-          path={effectiveCodePaths[language] ?? ""}
-          onRetryLoad={() => handleLanguageChange(language)}
-          displayCode={displayCode}
-          language={language}
-          targetUnits={targetUnits}
-          userUnits={userUnits}
-          cursorUnitIndex={cursorUnitIndex}
-          displayMode={effectiveDisplayMode}
-          adaptiveMessage={
-            adaptiveHidden
-              ? `Adaptive mode engaged at ${ADAPTIVE_WPM_THRESHOLD} WPM`
-              : undefined
-          }
-          textGradient={textGradient}
-          gameState={gameState}
-          userInput={userInput}
-          onInputChange={handleInputChange}
-          inputRef={inputRef}
-          elapsedTime={elapsedTime}
-          accuracy={accuracy}
-          progress={progress}
-        />
-
-        <div className="pointer-events-none absolute inset-x-4 top-4 z-10">
-          <div className="pointer-events-auto">
-            <TypingErrorAlert
-              consecutiveErrors={consecutiveErrors}
-              onDismiss={onDismiss}
-              showErrorAlert={showErrorAlert}
+            <DialogHeader className="sr-only">
+              <DialogTitle>Choose a Challenge</DialogTitle>
+              <DialogDescription>
+                Pick what you want to type before the session begins.
+              </DialogDescription>
+            </DialogHeader>
+            <ChallengeSelector
+              challenges={challenges}
+              progress={playerProgress}
+              onSelect={setPickedChallenge}
             />
-          </div>
-        </div>
-      </div>
+          </DialogContent>
+        </Dialog>
+      ) : (
+        <>
+          {/* Challenge identity strip — kept slim so the viewport still
+              belongs to the code/input card below; everything actionable
+              lives in the bottom nav's menus instead of inline controls. */}
+          {resolvedChallenge && (
+            <div className="mb-3 flex shrink-0 items-center gap-3">
+              <span className="text-base font-semibold text-card-foreground">
+                {resolvedChallenge.title}
+              </span>
+              <Badge
+                variant={
+                  resolvedChallenge.difficulty === "easy"
+                    ? "default"
+                    : resolvedChallenge.difficulty === "medium"
+                      ? "secondary"
+                      : "destructive"
+                }
+                className="capitalize"
+              >
+                {resolvedChallenge.difficulty}
+              </Badge>
+              {nContext && (
+                <Badge
+                  variant="outline"
+                  className="font-mono text-xs capitalize"
+                >
+                  N={nContext}
+                </Badge>
+              )}
+              {effectiveDisplayMode === "hidden" && (
+                <Badge
+                  variant="outline"
+                  className="text-xs text-muted-foreground"
+                >
+                  {adaptiveHidden ? "Adaptive: hidden" : "Hidden mode"}
+                </Badge>
+              )}
+            </div>
+          )}
 
-      <GameBottomNav
-        gameState={gameState}
-        onStart={handleStart}
-        onReset={handleReset}
-        timeLeft={timer.timeLeft}
-        duration={duration}
-        wpm={wpm}
-        accuracy={accuracy}
-        progress={overallProgress}
-        errors={totalErrors}
-        chunkLabel={chunkLabel}
-        language={language}
-        displayMode={displayMode}
-        displayModeLocked={isHardDifficulty || adaptiveHidden}
-        settingsEnabled={isLegacyMode && gameState === "idle"}
-        textGradient={textGradient}
-        onLanguageChange={handleLanguageChange}
-        onDisplayModeChange={setDisplayMode}
-        onDurationChange={setDuration}
-        onTextGradientChange={setTextGradient}
-        info={info}
-        portalContainer={themedContainer}
-      />
+          <div className="relative min-h-0 flex-1">
+            <CodeInputCard
+              status={codeState.status}
+              loadError={codeState.error}
+              path={effectiveCodePaths[language] ?? ""}
+              onRetryLoad={() => handleLanguageChange(language)}
+              displayCode={displayCode}
+              language={language}
+              targetUnits={targetUnits}
+              userUnits={userUnits}
+              cursorDisplayIndex={cursorDisplayIndex}
+              displayMode={effectiveDisplayMode}
+              adaptiveMessage={
+                adaptiveHidden
+                  ? `Adaptive mode engaged at ${ADAPTIVE_WPM_THRESHOLD} WPM`
+                  : undefined
+              }
+              textGradient={textGradient}
+              gameState={gameState}
+              userInput={userInput}
+              onInputChange={handleInputChange}
+              inputRef={inputRef}
+              elapsedTime={elapsedTime}
+              accuracy={accuracy}
+              progress={progress}
+            />
+
+            <div className="pointer-events-none absolute inset-x-4 top-4 z-10">
+              <div className="pointer-events-auto">
+                <TypingErrorAlert
+                  consecutiveErrors={consecutiveErrors}
+                  onDismiss={onDismiss}
+                  showErrorAlert={showErrorAlert}
+                />
+              </div>
+            </div>
+          </div>
+
+          <GameBottomNav
+            gameState={gameState}
+            onStart={handleStart}
+            onReset={handleReset}
+            timeLeft={timer.timeLeft}
+            duration={duration}
+            wpm={wpm}
+            accuracy={accuracy}
+            progress={overallProgress}
+            errors={totalErrors}
+            chunkLabel={chunkLabel}
+            language={language}
+            displayMode={displayMode}
+            displayModeLocked={isHardDifficulty || adaptiveHidden}
+            settingsEnabled={isLegacyMode && gameState === "idle"}
+            textGradient={textGradient}
+            onLanguageChange={handleLanguageChange}
+            onDisplayModeChange={setDisplayMode}
+            onDurationChange={setDuration}
+            onTextGradientChange={setTextGradient}
+            info={info}
+            portalContainer={themedContainer}
+          />
+        </>
+      )}
     </div>
   )
 }

--- a/packages/ui/leetype/src/hooks/leetype/use-chunked-code/index.ts
+++ b/packages/ui/leetype/src/hooks/leetype/use-chunked-code/index.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import type { PrettierParser } from "@leetype/lib/leetype/format-code"
 import type { CodeChunk, TextModel } from "@leetype/lib/leetype/load-code-file"
 import { loadTextModel } from "@leetype/lib/leetype/load-code-file"
 import { withTimeout } from "@leetype/utils"
 
 type Options = {
-  prettierParser: "typescript" | "babel" | "rust" | "cpp"
+  prettierParser: PrettierParser
   linesPerChunk?: number
 }
 
@@ -28,9 +29,10 @@ type FirstChunkResult = {
 
 async function loadFirstChunk(
   path: string,
-  linesPerChunk: number
+  linesPerChunk: number,
+  prettierParser: Options["prettierParser"]
 ): Promise<FirstChunkResult> {
-  const model = await loadTextModel(path, linesPerChunk)
+  const model = await loadTextModel(path, linesPerChunk, prettierParser)
 
   return {
     model,
@@ -46,7 +48,7 @@ async function loadFirstChunk(
 
 export function useChunkedCode(
   path: string,
-  { linesPerChunk = 100 }: Options
+  { prettierParser, linesPerChunk = 100 }: Options
 ): ChunkedCodeState {
   const [status, setStatus] = useState<ChunkedCodeState["status"]>("IDLE")
   const [currentChunk, setCurrentChunk] = useState<CodeChunk>()
@@ -101,7 +103,7 @@ export function useChunkedCode(
 
       try {
         const result = await withTimeout(
-          loadFirstChunk(path, linesPerChunk),
+          loadFirstChunk(path, linesPerChunk, prettierParser),
           TIMEOUT_MS,
           controller.signal
         )
@@ -134,7 +136,7 @@ export function useChunkedCode(
     void run()
 
     return (): void => controller.abort()
-  }, [path, linesPerChunk])
+  }, [path, linesPerChunk, prettierParser])
 
   return {
     status,

--- a/packages/ui/leetype/src/hooks/leetype/use-formatted-code/index.ts
+++ b/packages/ui/leetype/src/hooks/leetype/use-formatted-code/index.ts
@@ -1,83 +1,17 @@
 import { useEffect, useState } from "react"
+import { formatCode, preloadPrettier } from "@leetype/lib/leetype/format-code"
+import type { PrettierParser } from "@leetype/lib/leetype/format-code"
 import { loadTextModel } from "@leetype/lib/leetype/load-code-file"
 import type { FormattedCodeState } from "@leetype/types/load-code-file"
-import { assertNever, withTimeout } from "@leetype/utils"
+import { withTimeout } from "@leetype/utils"
 
-export type PrettierParser = "typescript" | "babel"
+export type { PrettierParser }
 
 type Options = {
-  prettierParser: PrettierParser | "rust" | "cpp"
+  prettierParser: PrettierParser
 }
 
 const TIMEOUT_MS = 5000
-
-// ============================================================================
-// PRETTIER CACHE
-// ============================================================================
-
-type PrettierModule = {
-  format: (
-    content: string,
-    options?: Record<string, unknown>
-  ) => Promise<string>
-  plugins: Array<unknown>
-}
-
-let prettierCache: Promise<PrettierModule> | undefined
-
-function getPrettier(parser: PrettierParser): Promise<PrettierModule> {
-  if (prettierCache) {
-    return prettierCache
-  }
-
-  const promise: Promise<PrettierModule> = (async () => {
-    const [standaloneMod, estreeMod, parserMod] = await Promise.all([
-      import("prettier/standalone"),
-      import("prettier/plugins/estree"),
-      parser === "typescript"
-        ? import("prettier/plugins/typescript")
-        : import("prettier/plugins/babel"),
-    ])
-
-    const standalone =
-      "default" in standaloneMod ? standaloneMod.default : standaloneMod
-
-    const estree = "default" in estreeMod ? estreeMod.default : estreeMod
-
-    const parserPlugin = "default" in parserMod ? parserMod.default : parserMod
-
-    return {
-      format: standalone.format,
-      plugins: [parserPlugin, estree],
-    }
-  })()
-
-  prettierCache = promise
-  return promise
-}
-
-async function formatCode(
-  raw: string,
-  parser: Options["prettierParser"]
-): Promise<string> {
-  switch (parser) {
-    case "typescript":
-    case "babel": {
-      const { format, plugins } = await getPrettier(parser)
-      return format(raw, { parser, plugins })
-    }
-
-    case "rust":
-    case "cpp": {
-      return raw
-    }
-
-    default: {
-      parser satisfies never
-      assertNever(parser)
-    }
-  }
-}
 
 async function loadFormattedCode(
   path: string,
@@ -170,8 +104,4 @@ export function useFormattedCode(
   return state
 }
 
-export async function preloadPrettier(
-  parser: PrettierParser = "typescript"
-): Promise<void> {
-  await getPrettier(parser)
-}
+export { preloadPrettier }

--- a/packages/ui/leetype/src/hooks/leetype/use-typing-game-wasm/index.ts
+++ b/packages/ui/leetype/src/hooks/leetype/use-typing-game-wasm/index.ts
@@ -13,7 +13,10 @@ import type {
   InputResult,
   TypedTypingGame as TypedTypingGameType,
 } from "@leetype/types/leetype"
-import { deriveCursorIndex, deriveDisplayMap } from "@leetype/utils/leetype"
+import {
+  deriveCursorDisplayIndex,
+  deriveDisplayMap,
+} from "@leetype/utils/leetype"
 
 type UseTypingGameProps = {
   targetCode: string
@@ -29,7 +32,7 @@ type UseTypingGameReturn = {
   displayCode: string
   targetUnits: Array<CanonicalUnit>
   userUnits: Array<CanonicalUnit>
-  cursorUnitIndex: number
+  cursorDisplayIndex: number
   displayMap: Array<number>
   errors: number
   consecutiveErrors: number
@@ -133,7 +136,12 @@ export function useTypingGame({
     return deriveDisplayMap(rawUserInput)
   }, [rawUserInput])
 
-  const cursorUnitIndex = stats ? deriveCursorIndex(stats) : 0
+  // Display-character granularity, not canonical-unit granularity: derived
+  // from the raw accepted keystrokes so it advances one rendered character
+  // per keystroke, including through multi-char whitespace runs (see
+  // CodeDisplay's `cursorDisplayIndex` doc comment for why unit granularity
+  // was wrong here).
+  const cursorDisplayIndex = deriveCursorDisplayIndex(rawUserInput)
 
   const handleInputChange = useCallback(
     (input: string): void => {
@@ -209,7 +217,7 @@ export function useTypingGame({
       displayCode: targetCode,
       targetUnits,
       userUnits: [],
-      cursorUnitIndex: 0,
+      cursorDisplayIndex,
       displayMap: [],
       errors: 0,
       consecutiveErrors: 0,
@@ -233,7 +241,7 @@ export function useTypingGame({
     displayCode: targetCode,
     targetUnits,
     userUnits,
-    cursorUnitIndex,
+    cursorDisplayIndex,
     displayMap,
     errors: stats.total_errors,
     consecutiveErrors: stats.consecutive_errors,

--- a/packages/ui/leetype/src/lib/leetype/format-code.ts
+++ b/packages/ui/leetype/src/lib/leetype/format-code.ts
@@ -1,0 +1,82 @@
+import { assertNever } from "@leetype/utils"
+
+/**
+ * Matches `Language` 1:1 - every supported language routes through here,
+ * even the ones prettier can't format on its own (see `formatCode` below).
+ */
+export type PrettierParser = "typescript" | "rust" | "cpp" | "c"
+
+type PrettierModule = {
+  format: (
+    content: string,
+    options?: Record<string, unknown>
+  ) => Promise<string>
+  plugins: Array<unknown>
+}
+
+// Module-level cache (not per-hook-instance) so every caller - the real
+// chunked-code loader and the storybook-only formatted-code preview alike -
+// shares one lazily-loaded prettier bundle instead of each paying its own
+// dynamic-import cost.
+let prettierCache: Promise<PrettierModule> | undefined
+
+function getPrettier(): Promise<PrettierModule> {
+  if (prettierCache) {
+    return prettierCache
+  }
+
+  const promise: Promise<PrettierModule> = (async () => {
+    const [standaloneMod, estreeMod, typescriptMod] = await Promise.all([
+      import("prettier/standalone"),
+      import("prettier/plugins/estree"),
+      import("prettier/plugins/typescript"),
+    ])
+
+    const standalone =
+      "default" in standaloneMod ? standaloneMod.default : standaloneMod
+    const estree = "default" in estreeMod ? estreeMod.default : estreeMod
+    const typescript =
+      "default" in typescriptMod ? typescriptMod.default : typescriptMod
+
+    return {
+      format: standalone.format,
+      plugins: [typescript, estree],
+    }
+  })()
+
+  prettierCache = promise
+  return promise
+}
+
+/**
+ * Formats `raw` for display. Only `typescript` has a bundled prettier
+ * plugin here - rust/cpp/c pass through unchanged rather than being run
+ * through a parser that can't understand their syntax (prettier has no
+ * built-in support for them, and no community plugin is bundled).
+ */
+export async function formatCode(
+  raw: string,
+  parser: PrettierParser
+): Promise<string> {
+  switch (parser) {
+    case "typescript": {
+      const { format, plugins } = await getPrettier()
+      return format(raw, { parser: "typescript", plugins })
+    }
+
+    case "rust":
+    case "cpp":
+    case "c": {
+      return raw
+    }
+
+    default: {
+      parser satisfies never
+      return assertNever(parser)
+    }
+  }
+}
+
+export async function preloadPrettier(): Promise<void> {
+  await getPrettier()
+}

--- a/packages/ui/leetype/src/lib/leetype/load-code-file.ts
+++ b/packages/ui/leetype/src/lib/leetype/load-code-file.ts
@@ -1,3 +1,6 @@
+import type { PrettierParser } from "./format-code"
+import { formatCode } from "./format-code"
+
 const modelCache = new Map<string, Promise<TextModel>>()
 
 export type CodeChunk = {
@@ -53,15 +56,23 @@ export class TextModel {
 }
 
 /**
- * Loads a text model and caches it by path.
+ * Loads a text model and caches it by path (+ formatting intent, so a path
+ * requested both raw and through prettier never share a cache slot).
  * Editor semantics: one resident model per open file.
+ *
+ * When `prettierParser` is given, the fetched text is formatted once here,
+ * before the model ever slices it into chunks - so every chunk (including
+ * ones loaded later via `getChunk`) is already-formatted text, not just the
+ * first one. Omitting it preserves the previous raw-text behavior exactly.
  */
 export async function loadTextModel(
   path: string,
-  linesPerChunk = 100
+  linesPerChunk = 100,
+  prettierParser?: PrettierParser
 ): Promise<TextModel> {
-  if (modelCache.has(path)) {
-    return modelCache.get(path)!
+  const cacheKey = `${path}::${prettierParser ?? "raw"}`
+  if (modelCache.has(cacheKey)) {
+    return modelCache.get(cacheKey)!
   }
 
   const promise = (async () => {
@@ -70,11 +81,12 @@ export async function loadTextModel(
       throw new Error(`Failed to load code file: ${path}, status ${res.status}`)
     }
 
-    const text = await res.text()
+    const raw = await res.text()
+    const text = prettierParser ? await formatCode(raw, prettierParser) : raw
     return new TextModel(text, linesPerChunk)
   })()
 
-  modelCache.set(path, promise)
+  modelCache.set(cacheKey, promise)
   return promise
 }
 

--- a/packages/ui/leetype/src/utils/leetype/index.test.ts
+++ b/packages/ui/leetype/src/utils/leetype/index.test.ts
@@ -1,33 +1,16 @@
 import { buildDisplayMap } from "@leetype/lib/leetype/leetype-wasm-loader"
-import type { Challenge, GameStats } from "@leetype/types/leetype"
 import { describe, expect, it, vi } from "vitest"
 
 import {
   codeToUnits,
-  deriveCursorIndex,
+  deriveCursorDisplayIndex,
   deriveDisplayMap,
-  resolveChallenge,
   sliceUserUnits,
 } from "."
 
 vi.mock("@leetype/lib/leetype/leetype-wasm-loader", () => ({
   buildDisplayMap: vi.fn(),
 }))
-
-function makeStats(overrides: Partial<GameStats> = {}): GameStats {
-  return {
-    progress: 0,
-    accuracy: 0,
-    wpm: 0,
-    elapsed_time: 0,
-    total_errors: 0,
-    consecutive_errors: 0,
-    show_error_alert: false,
-    cursor: 0,
-    is_complete: false,
-    ...overrides,
-  }
-}
 
 describe("codeToUnits", () => {
   it("maps every character to a char-kind canonical unit", () => {
@@ -73,9 +56,17 @@ describe("sliceUserUnits", () => {
   })
 })
 
-describe("deriveCursorIndex", () => {
-  it("returns the stats' cursor field", () => {
-    expect(deriveCursorIndex(makeStats({ cursor: 7 }))).toBe(7)
+describe("deriveCursorDisplayIndex", () => {
+  it("returns the raw input's character count", () => {
+    expect(deriveCursorDisplayIndex("func")).toBe(4)
+  })
+
+  it("returns 0 for empty input", () => {
+    expect(deriveCursorDisplayIndex("")).toBe(0)
+  })
+
+  it("counts by code point, not UTF-16 code unit, for astral characters", () => {
+    expect(deriveCursorDisplayIndex("a🙂b")).toBe(3)
   })
 })
 
@@ -89,35 +80,5 @@ describe("deriveDisplayMap", () => {
     vi.mocked(buildDisplayMap).mockReturnValue(new Uint32Array([2, 1, 0]))
     expect(deriveDisplayMap("abc")).toEqual([2, 1, 0])
     expect(buildDisplayMap).toHaveBeenCalledWith("abc")
-  })
-})
-
-describe("resolveChallenge", () => {
-  const makeChallenge = (overrides: Partial<Challenge> = {}): Challenge => ({
-    id: "id",
-    title: "title",
-    description: "description",
-    difficulty: "easy",
-    mode: "algorithm",
-    tags: [],
-    codePaths: { typescript: "", rust: "", cpp: "", c: "" },
-    levelRequired: 1,
-    ...overrides,
-  })
-
-  const easy = makeChallenge({ id: "easy-1", difficulty: "easy" })
-  const medium = makeChallenge({ id: "medium-1", difficulty: "medium" })
-  const pool = [easy, medium]
-
-  it("returns undefined when no difficulty is given", () => {
-    expect(resolveChallenge(pool, undefined)).toBeUndefined()
-  })
-
-  it("returns the first challenge matching the requested difficulty", () => {
-    expect(resolveChallenge(pool, "medium")).toBe(medium)
-  })
-
-  it("falls back to the pool's first entry when nothing matches", () => {
-    expect(resolveChallenge(pool, "hard")).toBe(easy)
   })
 })

--- a/packages/ui/leetype/src/utils/leetype/index.ts
+++ b/packages/ui/leetype/src/utils/leetype/index.ts
@@ -1,10 +1,5 @@
 import { buildDisplayMap } from "@leetype/lib/leetype/leetype-wasm-loader"
-import type {
-  CanonicalUnit,
-  Challenge,
-  Difficulty,
-  GameStats,
-} from "@leetype/types/leetype"
+import type { CanonicalUnit } from "@leetype/types/leetype"
 
 export function codeToUnits(code: string): Array<CanonicalUnit> {
   return Array.from(code).map((char) => ({
@@ -21,10 +16,14 @@ export function sliceUserUnits(
 }
 
 /**
- * Derive cursor index from game stats
+ * Derive the cursor's position in `displayCode`'s characters (not canonical
+ * units) from the raw, already-accepted keystrokes typed so far - advances
+ * exactly one display character per accepted keystroke, including through
+ * multi-char whitespace runs where a canonical unit spans several rendered
+ * characters.
  */
-export function deriveCursorIndex(stats: GameStats): number {
-  return stats.cursor
+export function deriveCursorDisplayIndex(rawUserInput: string): number {
+  return Array.from(rawUserInput).length
 }
 
 /**
@@ -34,22 +33,4 @@ export function deriveCursorIndex(stats: GameStats): number {
 export function deriveDisplayMap(input: string): Array<number> {
   if (!input) return []
   return Array.from(buildDisplayMap(input))
-}
-
-/**
- * Resolves a friendly `difficulty` identifier into one challenge from
- * `challenges` - deterministic (first match, not random), so replaying a
- * session shows the same challenge it did the first time. Falls back to the
- * pool's first entry when nothing matches, mirroring the pool always having
- * *something* playable rather than leaving the caller with `undefined` for
- * an off-pool difficulty label. Returns `undefined` only when `difficulty`
- * itself is absent, so a caller that already has a fully hydrated
- * `challenge` never needs to call this at all.
- */
-export function resolveChallenge(
-  challenges: ReadonlyArray<Challenge>,
-  difficulty: Difficulty | undefined
-): Challenge | undefined {
-  if (!difficulty) return undefined
-  return challenges.find((c) => c.difficulty === difficulty) ?? challenges[0]
 }


### PR DESCRIPTION
## Description

Closes #829

Three separate bugs in the LeetType activity:

1. **Challenge picker was a silent composer setting, not a session step.** The session composer asked for a `difficulty` dropdown and quietly auto-resolved it to the *first* challenge in the pool matching that difficulty — never actually letting the player pick a specific challenge. The picker is now a required, blocking modal shown when the LeetType session begins (via the existing `ChallengeSelector`), and the composer config for LeetType no longer asks for `difficulty` at all (just language + duration).
2. **Cursor placement was off.** The typing cursor was highlighted by matching the WASM engine's *canonical-unit* index against the display buffer's unit index. A canonical unit can span several rendered characters (e.g. a run of indentation whitespace collapses into a single "separator" unit), so the cursor would highlight an entire whitespace run at once instead of tracking one character at a time, and visibly skip a step when that run flushed into a unit. The cursor now tracks the exact next *display character* (derived from the raw accepted keystrokes) instead, and is also more visually prominent — a ring, a small marker icon, and a "You are here" tooltip.
3. **Prettier formatting never actually ran.** `useChunkedCode` accepted a `prettierParser` option but never passed it anywhere — the chunked code loader always displayed raw, unformatted source regardless of language. It's now wired into the loader so the fetched source is formatted once before being chunked. Also fixed the language→parser mapping, which routed C++ through Prettier's Babel (JS) parser and C through the TypeScript parser — both would have thrown on non-JS syntax the moment formatting was actually invoked.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (115 leetype package tests, 64 www tests)

## Test plan

- `pnpm --filter @some-ui/leetype lint / typecheck / test / build` — all pass
- `pnpm --filter www lint / typecheck / test` — all pass
- Manual read-through of the modal flow (`Leetype` → required `ChallengeSelector` dialog → game), the cursor's `displayIndex`-based derivation, and the prettier wiring end-to-end (`load-code-file.ts` → `useChunkedCode` → `Leetype`'s `PRETTIER_PARSER_MAP`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpvH7e1VzEWLMqgfXKmSBN)_