### PR TITLE
Fix #831: prevent self-feedback loops in theme application

### DIFF
--- a/extensions/some-filter/src/adapter/__tests__/actuator.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/actuator.test.ts
@@ -130,6 +130,68 @@ describe("realize — idempotence (Theorem 7.2)", () => {
 
     cleanUp()
   })
+
+  it("re-running the same actions twice emits no mutation records at all (#831)", async () => {
+    // Equal *outcome* is not enough: the Sensor reacts to mutation records,
+    // not to net state. `style.textContent =` replaces the sheet's child
+    // text node and `setAttribute` re-queues a record even for an identical
+    // value, so a byte-identical re-realize used to look — to the observer
+    // watching childList over the whole documentElement subtree — exactly
+    // like the vendor changing the page, which scheduled the next round,
+    // which re-realized, forever.
+    const div = document.createElement("div")
+    document.body.appendChild(div)
+    const key: SurfaceKey = "rgb(255, 255, 255)"
+    const elementsByKey = new Map([[key, [div]]])
+    const actions: ReadonlyArray<FilterAction> = [
+      { kind: "activate-theme", swatchId: "default" },
+      { kind: "tag-surface", key, role: "surface" },
+      { kind: "emit-surface-color", key, css: "rgb(10, 10, 20)" },
+    ]
+
+    realize(actions, elementsByKey)
+
+    const records: Array<MutationRecord> = []
+    const observer = new MutationObserver((batch) => records.push(...batch))
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    })
+
+    realize(actions, elementsByKey)
+    await Promise.resolve()
+
+    expect(records).toEqual([])
+    observer.disconnect()
+
+    cleanUp()
+  })
+
+  it("marks its dynamic stylesheet [data-my-ext] so the Sensor can recognise it", () => {
+    const div = document.createElement("div")
+    document.body.appendChild(div)
+    const key: SurfaceKey = "rgb(255, 255, 255)"
+
+    realize(
+      [
+        { kind: "activate-theme", swatchId: "default" },
+        { kind: "tag-surface", key, role: "surface" },
+        { kind: "emit-surface-color", key, css: "rgb(10, 10, 20)" },
+      ],
+      new Map([[key, [div]]])
+    )
+
+    expect(
+      document.getElementById(DYNAMIC_STYLE_ID)?.hasAttribute("data-my-ext")
+    ).toBe(true)
+    expect(document.getElementById(STYLE_ID)?.hasAttribute("data-my-ext")).toBe(
+      true
+    )
+
+    cleanUp()
+  })
 })
 
 describe("realize — restore-native", () => {

--- a/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
+++ b/extensions/some-filter/src/adapter/__tests__/pipeline.test.ts
@@ -2,7 +2,12 @@ import { DARK_THEME_ATTR } from "@filter/lib/content/theme-apply"
 import { createSessionLifecycle } from "@some-extension/transport/session/lifecycle"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { createContentSession, scan } from "../pipeline"
+import {
+  createContentSession,
+  isSelfAuthored,
+  scan,
+  withVendorColorsVisible,
+} from "../pipeline"
 import { SWATCHES } from "../swatches"
 
 const STYLE_ID = "__sw_dark_theme"
@@ -273,5 +278,338 @@ describe("createContentSession — observer survives body replacement", () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe("createContentSession — Axiom 3.5: actuation is not evidence (#831)", () => {
+  it("quiesces after a settled round instead of re-triggering itself forever", async () => {
+    // The reported symptom: a steadily incrementing log line on a page that
+    // is not changing. Realizing a verdict writes to the DOM (the theme
+    // stylesheet into <head>, the dynamic sheet's text, the veil's ownership
+    // class), the observer sees those writes, schedules another round, and
+    // that round realizes the same verdict again — a closed loop with no
+    // vendor mutation anywhere in it. Once settled, an untouched page must
+    // cost exactly zero further cycles.
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML =
+        '<div id="a" style="background-color: rgb(255, 255, 255)"></div>' +
+        '<div id="b" style="background-color: rgb(240, 240, 240)"></div>'
+      const session = createSessionLifecycle()
+      let fireCount = 0
+      const contentSession = createContentSession(
+        SWATCHES.default,
+        session,
+        () => {
+          fireCount += 1
+        }
+      )
+
+      contentSession.observe()
+      contentSession.rescan()
+
+      expect(fireCount).toBe(1)
+
+      // Let the observer deliver whatever the round's own writes produced,
+      // then run the clock well past several debounce windows. Nothing in
+      // the page changed, so nothing more may fire.
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve()
+        await Promise.resolve()
+        vi.advanceTimersByTime(200)
+      }
+
+      expect(fireCount).toBe(1)
+
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("ignores mutations authored by the extension itself", async () => {
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML = '<div id="a"></div>'
+      const session = createSessionLifecycle()
+      let fireCount = 0
+      const contentSession = createContentSession(
+        SWATCHES.default,
+        session,
+        () => {
+          fireCount += 1
+        }
+      )
+
+      contentSession.observe()
+
+      // An extension-owned stylesheet landing in <head> is a childList
+      // mutation under documentElement — the attributeFilter never covered
+      // it, which is how injecting the theme re-triggered the scan that
+      // injected it.
+      const own = document.createElement("style")
+      own.setAttribute("data-my-ext", "")
+      own.textContent = "body{}"
+      document.head.appendChild(own)
+
+      // The veil's ownership signal is the one extension write that lands on
+      // a vendor node, so it can only be recognised by what changed.
+      document.documentElement.classList.add("sw-dirty")
+      document.documentElement.classList.remove("sw-dirty")
+
+      await Promise.resolve()
+      await Promise.resolve()
+      vi.advanceTimersByTime(200)
+
+      expect(fireCount).toBe(0)
+
+      own.remove()
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("still reacts to a vendor class change on <html>", async () => {
+    // The `sw-dirty` filter must be keyed on the veil's own token, not on
+    // "class changes on <html> are boring" — vendors drive real theming off
+    // exactly that attribute.
+    vi.useFakeTimers()
+    try {
+      document.body.innerHTML = '<div id="a"></div>'
+      const session = createSessionLifecycle()
+      let fireCount = 0
+      const contentSession = createContentSession(
+        SWATCHES.default,
+        session,
+        () => {
+          fireCount += 1
+        }
+      )
+
+      contentSession.observe()
+
+      document.documentElement.classList.add("vendor-dark")
+
+      await Promise.resolve()
+      await Promise.resolve()
+      vi.advanceTimersByTime(200)
+
+      expect(fireCount).toBe(1)
+
+      document.documentElement.classList.remove("vendor-dark")
+      contentSession.teardown()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("senses once per coalesced round, not once per raw mutation batch", async () => {
+    // The compute half of the report: sensing used to run on the raw
+    // mutation callback while only decide/realize was debounced, so the
+    // Sensor's cost (a full tree walk plus a getComputedStyle per node)
+    // scaled with the vendor's churn rate and all but the last result was
+    // thrown away. Definition 7.2 says a burst costs one round.
+    vi.useFakeTimers()
+    const walkSpy = vi.spyOn(document, "createTreeWalker")
+    try {
+      document.body.innerHTML = '<div id="a"></div>'
+      const session = createSessionLifecycle()
+      const contentSession = createContentSession(SWATCHES.default, session)
+
+      const target = document.getElementById("a")
+      expect(target).not.toBeNull()
+      if (target === null) return
+
+      contentSession.observe()
+      walkSpy.mockClear()
+
+      for (let i = 0; i < 10; i++) {
+        target.style.backgroundColor = `rgb(${i}, ${i}, ${i})`
+      }
+      await Promise.resolve()
+      await Promise.resolve()
+      vi.advanceTimersByTime(200)
+
+      expect(walkSpy).toHaveBeenCalledTimes(1)
+
+      contentSession.teardown()
+    } finally {
+      walkSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe("isSelfAuthored", () => {
+  function recordsFrom(
+    mutate: () => void,
+    init: MutationObserverInit
+  ): Promise<ReadonlyArray<MutationRecord>> {
+    return new Promise((resolve) => {
+      const observer = new MutationObserver((batch) => {
+        observer.disconnect()
+        resolve(batch)
+      })
+      observer.observe(document.documentElement, init)
+      mutate()
+    })
+  }
+
+  it("recognises a stylesheet this extension inserted into <head>", async () => {
+    const own = document.createElement("style")
+    own.setAttribute("data-my-ext", "")
+
+    const records = await recordsFrom(() => document.head.appendChild(own), {
+      childList: true,
+      subtree: true,
+    })
+
+    expect(records.length).toBeGreaterThan(0)
+    expect(records.every(isSelfAuthored)).toBe(true)
+    own.remove()
+  })
+
+  it("does not recognise a vendor node inserted into the page", async () => {
+    const vendor = document.createElement("div")
+
+    const records = await recordsFrom(() => document.body.appendChild(vendor), {
+      childList: true,
+      subtree: true,
+    })
+
+    expect(records.some((record) => !isSelfAuthored(record))).toBe(true)
+    vendor.remove()
+  })
+
+  it("does not recognise the removal of an extension-owned node (Remark 7.2)", async () => {
+    // "Our node is gone" is ambiguous between our own teardown and a hostile
+    // page stripping [data-my-ext] out from under us. Reading it as our own
+    // would mean never repairing the second case — the swatch-oracle's
+    // extensionDomRemoval primitive is exactly that scenario.
+    const own = document.createElement("style")
+    own.setAttribute("data-my-ext", "")
+    document.head.appendChild(own)
+
+    const records = await recordsFrom(() => own.remove(), {
+      childList: true,
+      subtree: true,
+    })
+
+    expect(records.some((record) => !isSelfAuthored(record))).toBe(true)
+  })
+
+  it("recognises the veil's sw-dirty toggle alongside unrelated vendor classes", async () => {
+    document.documentElement.className = "vendor-a vendor-b"
+
+    const records = await recordsFrom(
+      () => document.documentElement.classList.add("sw-dirty"),
+      { attributes: true, attributeFilter: ["class"], attributeOldValue: true }
+    )
+
+    expect(records.every(isSelfAuthored)).toBe(true)
+    document.documentElement.className = ""
+  })
+
+  it("does not recognise a vendor class change that happens to also carry sw-dirty", async () => {
+    document.documentElement.className = "sw-dirty"
+
+    const records = await recordsFrom(
+      () => document.documentElement.classList.add("vendor-dark"),
+      { attributes: true, attributeFilter: ["class"], attributeOldValue: true }
+    )
+
+    expect(records.some((record) => !isSelfAuthored(record))).toBe(true)
+    document.documentElement.className = ""
+  })
+})
+
+describe("withVendorColorsVisible — evidence is vendor truth, not our own output", () => {
+  function ownSheet(id: string): HTMLStyleElement {
+    const style = document.createElement("style")
+    style.id = id
+    style.setAttribute("data-my-ext", "")
+    style.textContent = "body{background-color:rgb(13,17,23)}"
+    document.head.appendChild(style)
+    return style
+  }
+
+  it("disables the extension's own color sheets for the duration of the scan", () => {
+    const stat = ownSheet(STYLE_ID)
+    const dynamic = ownSheet(DYNAMIC_STYLE_ID)
+
+    const seen = withVendorColorsVisible(() => [
+      stat.sheet?.disabled,
+      dynamic.sheet?.disabled,
+    ])
+
+    expect(seen).toEqual([true, true])
+    expect(stat.sheet?.disabled).toBe(false)
+    expect(dynamic.sheet?.disabled).toBe(false)
+
+    stat.remove()
+    dynamic.remove()
+  })
+
+  it("re-enables them even when the scan throws", () => {
+    const stat = ownSheet(STYLE_ID)
+
+    expect(() =>
+      withVendorColorsVisible(() => {
+        throw new Error("scan blew up")
+      })
+    ).toThrow("scan blew up")
+
+    expect(stat.sheet?.disabled).toBe(false)
+
+    stat.remove()
+  })
+
+  it("leaves a vendor stylesheet alone", () => {
+    const vendor = document.createElement("style")
+    vendor.id = "vendor-sheet"
+    vendor.textContent = "body{background-color:rgb(255,255,255)}"
+    document.head.appendChild(vendor)
+
+    // jsdom leaves `disabled` unset until something assigns it, so compare
+    // against the truthy state the suppression actually sets, not `false`.
+    const seen = withVendorColorsVisible(() => vendor.sheet?.disabled === true)
+
+    expect(seen).toBe(false)
+    vendor.remove()
+  })
+})
+
+describe("createContentSession — evidence is scoped to the content epoch", () => {
+  it("drops the previous route's evidence after a content reset (Theorem D.1(a))", () => {
+    // Ĥ never forgets a key, and epoch dominance only settles keys that
+    // *recur*. Without an explicit drop, colors from a route the user has
+    // already navigated away from keep voting in the page-level verdict —
+    // enough of them, and a light page inherits the previous page's "already
+    // dark" conclusion and never gets themed.
+    document.body.innerHTML =
+      '<div style="background-color: rgb(13, 17, 23)"></div>' +
+      '<div style="background-color: rgb(5, 5, 5)"></div>' +
+      '<div style="background-color: rgb(10, 10, 10)"></div>' +
+      '<div style="background-color: rgb(20, 20, 20)"></div>'
+
+    const session = createSessionLifecycle()
+    const contentSession = createContentSession(SWATCHES.default, session)
+
+    contentSession.rescan()
+    expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(false)
+
+    // Same-document navigation to a light route.
+    document.body.innerHTML =
+      '<div style="background-color: rgb(180, 180, 180)"></div>' +
+      '<div style="background-color: rgb(185, 185, 185)"></div>' +
+      '<div style="background-color: rgb(190, 190, 190)"></div>'
+    session.resetContent()
+
+    contentSession.rescan()
+
+    expect(document.documentElement.hasAttribute(DARK_THEME_ATTR)).toBe(true)
+
+    contentSession.teardown()
   })
 })

--- a/extensions/some-filter/src/adapter/actuator.ts
+++ b/extensions/some-filter/src/adapter/actuator.ts
@@ -123,11 +123,22 @@ export function realize(
   }
 
   const colorRules = actions
-    .filter((action) => action.kind === "emit-surface-color")
-    .map(
-      (action) =>
-        `[data-sw-patched="${action.key}"]${EXT_GUARD}{background-color:${action.css}!important}`
+    .filter(
+      (
+        action
+      ): action is Extract<FilterAction, { kind: "emit-surface-color" }> =>
+        action.kind === "emit-surface-color"
     )
+    .map((action) => {
+      const declarations = [`background-color:${action.css}!important`]
+      if (action.textCss !== undefined) {
+        declarations.push(`color:${action.textCss}!important`)
+      }
+      if (action.suppressImage === true) {
+        declarations.push("background-image:none!important")
+      }
+      return `[data-sw-patched="${action.key}"]${EXT_GUARD}{${declarations.join(";")}}`
+    })
 
   if (colorRules.length > 0) {
     const css = colorRules.join("\n")

--- a/extensions/some-filter/src/adapter/actuator.ts
+++ b/extensions/some-filter/src/adapter/actuator.ts
@@ -16,17 +16,27 @@
  * 7.3.1 requires is already discharged the way canon §9.2 already
  * describes for this extension — `[data-my-ext]` marks extension-owned
  * subtrees (checked by the Sensor before an element is ever read, in
- * `pipeline.ts`), and the Sensor's `MutationObserver` watches only
- * `attributeFilter: ["class", "style"]`, so writing `data-sw-patched`,
- * `data-sw-dark`, or the `<style>` elements' `textContent` can never
- * itself re-trigger ingestion. Adding transport's generic ownership
- * attributes on top would tag thousands of ordinary vendor elements with
- * extension bookkeeping for no additional loop-suppression benefit.
+ * `pipeline.ts`). Adding transport's generic ownership attributes on top
+ * would tag thousands of ordinary vendor elements with extension
+ * bookkeeping for no additional loop-suppression benefit.
+ *
+ * The `attributeFilter: ["class", "style"]` on the Sensor's observer is
+ * *not*, on its own, the reason our writes cannot re-trigger ingestion —
+ * this module's doc used to claim it was, and that claim cost #831. The
+ * filter constrains only the `attributes` records; the observer is also
+ * subscribed to `childList` over the whole `documentElement` subtree, and
+ * injecting a `<style>` into `<head>` (or reassigning its `textContent`,
+ * which replaces its child text node) is exactly such a mutation. Two
+ * things close that hole, both required: every stylesheet this extension
+ * inserts carries `[data-my-ext]` so the Sensor can *recognise* the record
+ * as its own (`pipeline.ts`'s `isSelfAuthored`), and every write below is
+ * guarded so an unchanged round emits no record to recognise.
  *
  * Idempotence (Theorem 7.2): every `realize` call rebuilds the dynamic
  * stylesheet's *entire* content from the current action list (not an
- * incremental append), so re-running the same actions twice is a no-op
- * `style.textContent` assignment. Per-surface tagging never explicitly
+ * incremental append), and assigns it only when the rebuilt text actually
+ * differs, so re-running the same actions twice is not merely a no-op in
+ * *effect* but a no-op in *DOM writes*. Per-surface tagging never explicitly
  * clears a stale attribute when an element's classification changes away
  * from "surface"/"preserve" — this matches the pre-S5 patcher's own
  * behavior exactly (`patchElement` never cleared either), not a new gap.
@@ -43,13 +53,16 @@ import {
 import type { FilterAction, SurfaceKey } from "./contracts"
 import { getSwatch } from "./swatches"
 
-const DYNAMIC_STYLE_ID = "__sw_dark_dynamic"
+export const DYNAMIC_STYLE_ID = "__sw_dark_dynamic"
 
 function dynamicStyleEl(): HTMLStyleElement {
   const existing = document.getElementById(DYNAMIC_STYLE_ID)
   if (existing instanceof HTMLStyleElement) return existing
   const style = document.createElement("style")
   style.id = DYNAMIC_STYLE_ID
+  // Marks this sheet extension-owned for both EXT_GUARD and the Sensor's
+  // self-authored-mutation filter — see theme-apply.ts's createExtensionStyle.
+  style.setAttribute("data-my-ext", "")
   document.head.appendChild(style)
   return style
 }
@@ -86,7 +99,13 @@ export function realize(
       action.kind === "activate-theme"
   )
   if (activate !== undefined) {
-    document.documentElement.setAttribute(DARK_THEME_ATTR, "")
+    // `setAttribute` re-queues a mutation record even when the value is
+    // unchanged (unlike `removeAttribute`, which no-ops on an absent
+    // attribute) — write only on a real transition, so a re-fire of an
+    // unchanged verdict touches nothing at all (#831).
+    if (!document.documentElement.hasAttribute(DARK_THEME_ATTR)) {
+      document.documentElement.setAttribute(DARK_THEME_ATTR, "")
+    }
     injectDarkTheme(getSwatch(activate.swatchId))
   } else {
     document.documentElement.removeAttribute(DARK_THEME_ATTR)
@@ -97,7 +116,7 @@ export function realize(
     if (action.kind !== "tag-surface") continue
     const value = action.role === "preserve" ? "preserve" : action.key
     for (const el of elementsByKey.get(action.key) ?? []) {
-      if (el instanceof HTMLElement) {
+      if (el instanceof HTMLElement && el.dataset.swPatched !== value) {
         el.dataset.swPatched = value
       }
     }
@@ -111,7 +130,16 @@ export function realize(
     )
 
   if (colorRules.length > 0) {
-    dynamicStyleEl().textContent = colorRules.join("\n")
+    const css = colorRules.join("\n")
+    const style = dynamicStyleEl()
+    // Same reason as the attribute guard above, one level up: `textContent =`
+    // replaces the element's child text node unconditionally, so re-emitting
+    // byte-identical CSS is still a childList mutation the Sensor sees. That
+    // is what turned "rebuild the whole sheet every round" (this module's
+    // idempotence strategy) into a self-sustaining rescan loop (#831).
+    if (style.textContent !== css) {
+      style.textContent = css
+    }
   } else {
     document.getElementById(DYNAMIC_STYLE_ID)?.remove()
   }

--- a/extensions/some-filter/src/adapter/contracts.ts
+++ b/extensions/some-filter/src/adapter/contracts.ts
@@ -66,6 +66,24 @@ export type SurfaceAttr = {
   readonly color: RGBA
   readonly luminance: number
   readonly opacity: number
+  /**
+   * The element's own, non-inherited text color — set only when it differs
+   * from its parent's computed `color` (an explicit vendor declaration, not
+   * ambient inheritance). `undefined`/`null` when there is nothing of the
+   * carrier's own to re-target. A `surface`-classified element's inline
+   * text was authored for its *original* (light) background and is
+   * otherwise left untouched when that background gets darkened — #741's
+   * "it darkens text so that it's not visible at all".
+   */
+  readonly text?: RGBA | null
+  /**
+   * True when this key's `color`/`luminance` are an *assumed* stand-in
+   * (not a real `background-color`) for a light `background-image`
+   * gradient the sampler found no other way to evidence — #741's "white
+   * gradients leak". The actuator suppresses the image itself for these
+   * keys, since there is no real color to recolor.
+   */
+  readonly imageOnly?: boolean
 }
 
 /**
@@ -94,6 +112,10 @@ export type EmitSurfaceColorAction = {
   readonly kind: "emit-surface-color"
   readonly key: SurfaceKey
   readonly css: string
+  /** Hue-preserving-lightened override for the carrier's own text color (`SurfaceAttr.text`), when it has one. */
+  readonly textCss?: string
+  /** Suppresses `background-image` on the carrier — set when this key's evidence came from `SurfaceAttr.imageOnly`, so there is no real background color underneath the emitted `css` to show through otherwise. */
+  readonly suppressImage?: boolean
 }
 
 /**

--- a/extensions/some-filter/src/adapter/pipeline.ts
+++ b/extensions/some-filter/src/adapter/pipeline.ts
@@ -10,7 +10,11 @@
  * element's computed background via `color.ts` — the one place in this
  * story that still calls `getComputedStyle` (Axiom D.1 scopes the DOM-free
  * requirement to `decide`, not to sensing). A `MutationObserver` with the
- * same `attributeFilter: ["class", "style"]` as before re-triggers it.
+ * same `attributeFilter: ["class", "style"]` as before re-triggers it,
+ * filtered by `isSelfAuthored` so the Actuator's own writes are never
+ * mistaken for vendor evidence (Axiom 3.5), and every scan runs under
+ * `withVendorColorsVisible` so what it reads is the vendor's page and not
+ * the theme this pipeline painted on it.
  *
  * Estimator: one `update()` per *distinct* observed key per scan (Ĥ is
  * keyed by color, not by element — S1) using transport's own
@@ -22,11 +26,13 @@
  * Scheduler: `RECONCILE_POLICY`/`BOUNDED_DELIVERY_MS` are Definition 7.2's
  * `R`, declared once here (§8.3's conformance requirement) — a burst of N
  * mutations inside the debounce window coalesces into exactly one
- * `decide`/`realize` cycle.
+ * sense/`decide`/`realize` cycle, sensing included.
  */
 
 import { parseColor, relativeLuminance } from "@filter/lib/content/color"
 import { rgbaToCss } from "@filter/lib/content/modify-colors"
+import { PREPAINT_DIRTY_CLASS } from "@filter/lib/content/prepaint"
+import { DARK_THEME_STYLE_ID } from "@filter/lib/content/theme-apply"
 import { invoke } from "@some-extension/transport/adapter/invoke"
 import { createHypothesis } from "@some-extension/transport/estimator/hypothesis"
 import {
@@ -41,7 +47,7 @@ import {
 } from "@some-extension/transport/scheduler/reconcile"
 import type { SessionLifecycle } from "@some-extension/transport/session/lifecycle"
 
-import { realize } from "./actuator"
+import { DYNAMIC_STYLE_ID, realize } from "./actuator"
 import type { FilterAction, SurfaceAttr, SurfaceKey } from "./contracts"
 import type { Swatch } from "./swatches"
 import { decide } from "./theme-adapter"
@@ -105,6 +111,118 @@ function readAttr(el: Element): SurfaceAttr | null {
   }
 }
 
+// ── Vendor truth (Axiom 3.5, read side) ──────────────────────────────────────
+
+/** The two sheets that carry *our* colors; everything else in the page is vendor. */
+const OWN_COLOR_SHEET_IDS: ReadonlyArray<string> = [
+  DARK_THEME_STYLE_ID,
+  DYNAMIC_STYLE_ID,
+]
+
+/**
+ * Runs `fn` with this extension's own color sheets disabled, so every
+ * `getComputedStyle` inside it reads the *vendor's* background rather than
+ * the theme we painted over it.
+ *
+ * `shouldSkip`'s `[data-sw-patched]` exclusion covers only the surfaces the
+ * Actuator tagged. The static layer (`buildDarkThemeCSS`) recolors far more
+ * than that — `html`/`body`, `th`, `pre`, `code`, `input`, `textarea`,
+ * `select`, `dialog` — with `!important` rules keyed on element type, and
+ * none of those carriers are tagged. Their post-activation computed
+ * background is our swatch, and the hypothesis is append-only, so every
+ * reactive rescan folded more of our own dark output back in as if it were
+ * fresh vendor evidence until `pageAlreadyDark()`'s mean crossed the
+ * threshold and `decide()` emitted `restore-native` — the theme undoing
+ * itself with no vendor change involved (#831, symptom 2).
+ *
+ * Disabling via `CSSStyleSheet.disabled` rather than detaching the elements
+ * is what makes this safe to do on the hot path: it mutates no DOM (so it
+ * queues no MutationRecord to react to) and, because the whole scan is one
+ * synchronous task, no frame is ever painted with the theme off.
+ */
+export function withVendorColorsVisible<T>(fn: () => T): T {
+  const suppressed: Array<CSSStyleSheet> = []
+
+  for (const id of OWN_COLOR_SHEET_IDS) {
+    const el = document.getElementById(id)
+    const sheet = el instanceof HTMLStyleElement ? el.sheet : null
+    if (sheet !== null && !sheet.disabled) {
+      sheet.disabled = true
+      suppressed.push(sheet)
+    }
+  }
+
+  try {
+    return fn()
+  } finally {
+    for (const sheet of suppressed) {
+      sheet.disabled = false
+    }
+  }
+}
+
+// ── Self-authored mutations (Axiom 3.5, write side) ──────────────────────────
+
+function isExtensionAuthored(node: Node): boolean {
+  const el = node instanceof Element ? node : node.parentElement
+  if (el === null) return false
+  return el.hasAttribute("data-my-ext") || el.closest("[data-my-ext]") !== null
+}
+
+/**
+ * The prepaint veil's ownership signal is the one extension write that
+ * lands on a *vendor* node (`sw-dirty` on `<html>`), so it cannot be
+ * recognised by target — only by what changed. Compares the record's
+ * `oldValue` against the live class list and reports whether the veil class
+ * is the *only* difference.
+ */
+function isDirtyClassToggle(record: MutationRecord): boolean {
+  if (record.attributeName !== "class") return false
+  if (record.target !== document.documentElement) return false
+
+  const before = new Set(
+    (record.oldValue ?? "").split(/\s+/).filter((token) => token.length > 0)
+  )
+  const after = new Set(document.documentElement.classList)
+
+  before.delete(PREPAINT_DIRTY_CLASS)
+  after.delete(PREPAINT_DIRTY_CLASS)
+
+  if (before.size !== after.size) return false
+  for (const token of before) {
+    if (!after.has(token)) return false
+  }
+  return true
+}
+
+/**
+ * Axiom 3.5 (Actuator re-entrance): true when this record is our own
+ * actuation echoing back, not vendor evidence. Defense in depth alongside
+ * the write guards in `actuator.ts`/`prepaint.ts` — those keep an unchanged
+ * round from emitting records at all; this keeps the records a *changed*
+ * round legitimately emits from being mistaken for a reason to run again.
+ */
+export function isSelfAuthored(record: MutationRecord): boolean {
+  if (isExtensionAuthored(record.target)) return true
+
+  if (record.type === "childList") {
+    // Removal of an extension-owned node is deliberately *not* treated as
+    // self-authored, even though this module is one of the things that
+    // removes them. Remark 7.2's whole point is that "our node is gone" is
+    // ambiguous between "we took it down" and "the vendor did" — and the
+    // second case is the one that must be repaired, so the ambiguity has to
+    // resolve toward reacting. Reacting to our own teardown costs exactly
+    // one extra round and cannot loop: the round that follows re-derives
+    // the same verdict and, finding nothing left to remove, writes nothing.
+    if (record.removedNodes.length > 0) return false
+
+    const added = [...record.addedNodes]
+    return added.length > 0 && added.every(isExtensionAuthored)
+  }
+
+  return isDirtyClassToggle(record)
+}
+
 export type ScanResult = {
   readonly elementsByKey: ReadonlyMap<SurfaceKey, ReadonlyArray<Element>>
   readonly attrsByKey: ReadonlyMap<SurfaceKey, SurfaceAttr>
@@ -158,10 +276,31 @@ export function createContentSession(
   const provenance: ProvenanceStore<SurfaceKey> = createProvenanceStore()
   let lastScan: ScanResult = { elementsByKey: new Map(), attrsByKey: new Map() }
   let observer: MutationObserver | null = null
+  let evidenceEpoch = session.epoch
+
+  /**
+   * Theorem D.1(a): a content reset means the page under us was replaced.
+   * `update()`'s epoch dominance already keeps stale evidence from *winning*
+   * a key that recurs, but Ĥ never forgets a key outright, so keys the new
+   * page does not carry at all would otherwise keep voting in
+   * `pageAlreadyDark()`'s mean forever — the previous route's colors
+   * deciding the current route's verdict.
+   */
+  function dropStaleEvidence(): void {
+    for (const key of [...hypothesis.keys()]) {
+      hypothesis.delete(key)
+    }
+    provenance.clear()
+  }
 
   function ingest(root: Element): void {
     try {
-      lastScan = scan(root)
+      if (session.epoch !== evidenceEpoch) {
+        evidenceEpoch = session.epoch
+        dropStaleEvidence()
+      }
+
+      lastScan = withVendorColorsVisible(() => scan(root))
       const timestamp = Date.now()
       for (const [key, attrs] of lastScan.attrsByKey) {
         update(hypothesis, provenance, {
@@ -203,7 +342,23 @@ export function createContentSession(
     onFire?.(actions)
   }
 
-  const coalescer: Coalescer = createCoalescer(RECONCILE_POLICY, fire)
+  /** One full round: sense, then decide/realize on what was sensed. */
+  function cycle(root: Element): void {
+    ingest(root)
+    fire()
+  }
+
+  // The coalesced round senses *inside* the debounce window, not before it.
+  // Scanning per raw mutation batch (as this used to) made the Sensor's cost
+  // scale with the vendor's churn rate rather than with the reconcile
+  // policy: a page mutating steadily paid a full O(nodes) tree walk plus a
+  // getComputedStyle per node for every batch, and threw away all but the
+  // last result when the single coalesced fire finally ran (#831, symptom
+  // 3). Definition 7.2's whole point is that a burst of N mutations costs
+  // one round — sensing included.
+  const coalescer: Coalescer = createCoalescer(RECONCILE_POLICY, () => {
+    cycle(document.body)
+  })
 
   return {
     rescan(root: Element = document.body): void {
@@ -216,8 +371,7 @@ export function createContentSession(
       // The coalescer is reserved for the one path Definition 7.2 actually
       // governs: the observer callback below, where a burst of N raw
       // mutations must still settle as exactly one decide/realize round.
-      ingest(root)
-      fire()
+      cycle(root)
     },
     observe(): void {
       if (observer !== null) return
@@ -235,11 +389,14 @@ export function createContentSession(
       // swap, `document.body` the getter already points at the new one.
       observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
-          if (mutation.type === "childList" || mutation.type === "attributes") {
-            ingest(document.body)
-            coalescer.trigger()
-            return
-          }
+          // Axiom 3.5: our own actuation is not evidence. Without this,
+          // realizing a verdict (injecting the theme sheet, lifting the
+          // veil) is itself a mutation that schedules the next round, which
+          // realizes the same verdict again — a closed loop that never
+          // quiesces and never involves the vendor at all (#831).
+          if (isSelfAuthored(mutation)) continue
+          coalescer.trigger()
+          return
         }
       })
       observer.observe(document.documentElement, {
@@ -247,6 +404,10 @@ export function createContentSession(
         subtree: true,
         attributes: true,
         attributeFilter: ["class", "style"],
+        // Required by isSelfAuthored's `sw-dirty` check — the veil's
+        // ownership signal is only distinguishable from a vendor class
+        // change by diffing against the previous value.
+        attributeOldValue: true,
       })
     },
     teardown(): void {

--- a/extensions/some-filter/src/adapter/pipeline.ts
+++ b/extensions/some-filter/src/adapter/pipeline.ts
@@ -29,7 +29,11 @@
  * sense/`decide`/`realize` cycle, sensing included.
  */
 
-import { parseColor, relativeLuminance } from "@filter/lib/content/color"
+import {
+  parseColor,
+  relativeLuminance,
+  type RGBA,
+} from "@filter/lib/content/color"
 import { rgbaToCss } from "@filter/lib/content/modify-colors"
 import { PREPAINT_DIRTY_CLASS } from "@filter/lib/content/prepaint"
 import { DARK_THEME_STYLE_ID } from "@filter/lib/content/theme-apply"
@@ -100,15 +104,58 @@ function shouldSkip(el: Element): boolean {
   return false
 }
 
+// Only recognized gradient functions — real `url(...)` photographic
+// background-images are out of scope (#741 is specifically about gradients;
+// there is no reliable way to assume a color for an arbitrary photo, and
+// forcibly stripping one would be a much bigger, untested visual change).
+const GRADIENT_RE = /(?:repeating-)?(?:linear|radial|conic)-gradient\(/i
+
+/** Luminance 1 (pure white) — the same "unknown == probably light" bias `theme-detector.ts` already documents, applied here to a surface whose real color a `background-image` gradient hides from every sampler in this file. */
+const ASSUMED_LIGHT_IMAGE: SurfaceAttr["color"] = [1, 1, 1, 1]
+
+/**
+ * The element's own, non-inherited text color, or null when it has none of
+ * its own (its computed `color` just matches its parent's — plain
+ * inheritance, nothing for a surface-role recolor to re-target). `color` is
+ * an inherited CSS property, so — unlike `background-color` — a matching
+ * value doesn't mean "unset here," it means "not overridden here."
+ */
+function ownTextColor(el: Element, style: CSSStyleDeclaration): RGBA | null {
+  const parent = el.parentElement
+  if (parent === null) return null
+  const inherited = getComputedStyle(parent).color
+  if (style.color === inherited) return null
+  return parseColor(style.color)
+}
+
 function readAttr(el: Element): SurfaceAttr | null {
-  const bg = getComputedStyle(el).backgroundColor
-  const c = parseColor(bg)
-  if (c === null) return null
-  return {
-    color: c,
-    luminance: relativeLuminance(c[0], c[1], c[2]),
-    opacity: c[3],
+  const style = getComputedStyle(el)
+  const c = parseColor(style.backgroundColor)
+
+  if (c !== null) {
+    return {
+      color: c,
+      luminance: relativeLuminance(c[0], c[1], c[2]),
+      opacity: c[3],
+      text: ownTextColor(el, style),
+    }
   }
+
+  // No explicit background-color, but a light gradient background-image is
+  // just as capable of leaking a bright surface onto an otherwise-dark page
+  // (#741) and is invisible to every other check here — treat it as
+  // assumed-light evidence so it gets themed like any other surface.
+  if (GRADIENT_RE.test(style.backgroundImage)) {
+    return {
+      color: ASSUMED_LIGHT_IMAGE,
+      luminance: 1,
+      opacity: 1,
+      text: ownTextColor(el, style),
+      imageOnly: true,
+    }
+  }
+
+  return null
 }
 
 // ── Vendor truth (Axiom 3.5, read side) ──────────────────────────────────────
@@ -228,6 +275,47 @@ export type ScanResult = {
   readonly attrsByKey: ReadonlyMap<SurfaceKey, SurfaceAttr>
 }
 
+/**
+ * The dedup key for a scanned element's evidence. Normally just its
+ * canonical background color (S1's original design — "one hypothesis per
+ * observed background"). Two refinements fold additional attributes into
+ * the key, both guarding the same failure mode: `elementsByKey`/`attrsByKey`
+ * only ever record the *first* element seen for a given key (`scan()`
+ * below) — every later element sharing that key is tagged identically but
+ * never gets to contribute its own evidence.
+ *
+ *   - Own text color: an element sharing a light ancestor's exact
+ *     background (`<main style="background-color: white">` wrapping
+ *     `<div id="card" style="background-color: white; color: #141414">` is
+ *     an ordinary vendor pattern, not a contrived one) collapses onto
+ *     whichever of the two `scan()`'s TreeWalker visits *first* — always
+ *     the ancestor, which has no `color` of its own — permanently
+ *     discarding the descendant's own text color from the hypothesis
+ *     (#741's "it darkens text so that it's not visible at all": the
+ *     per-surface foreground fix in `theme-adapter.ts`'s `decide()` never
+ *     even sees the evidence needed to apply it).
+ *   - `imageOnly`: an assumed-light gradient carrier can coincidentally
+ *     share its assumed color's canonical string with a real, same-colored
+ *     `background-color` elsewhere on the page (#741's "white gradients
+ *     leak" fixture is exactly this — a white `<main>` ancestor, and a
+ *     transparent-bg `<div>` whose only color evidence is a white
+ *     gradient) — without a distinct key, the real background-color
+ *     element's (correct, non-suppressing) attr wins and the gradient
+ *     carrier's own `background-image` is never actually suppressed.
+ *
+ * Both refinements give same-bg-but-differently-evidenced carriers distinct
+ * keys, each with its own tag and dynamic rule, instead of silently sharing
+ * whichever arrived first.
+ */
+function surfaceKeyFor(attr: SurfaceAttr): SurfaceKey {
+  const bgKey =
+    attr.imageOnly === true
+      ? `image:${rgbaToCss(attr.color)}`
+      : rgbaToCss(attr.color)
+  if (attr.text === undefined || attr.text === null) return bgKey
+  return `${bgKey}|text:${rgbaToCss(attr.text)}`
+}
+
 /** Walks `root`'s descendants (never `root` itself — matches `patchAll`'s old scope; `root`'s own canvas is the static layer's job). */
 export function scan(root: Element): ScanResult {
   const elementsByKey = new Map<SurfaceKey, Array<Element>>()
@@ -240,7 +328,7 @@ export function scan(root: Element): ScanResult {
     if (node instanceof HTMLElement && !shouldSkip(node)) {
       const attr = readAttr(node)
       if (attr !== null) {
-        const key = rgbaToCss(attr.color)
+        const key = surfaceKeyFor(attr)
         const list = elementsByKey.get(key)
         if (list !== undefined) {
           list.push(node)

--- a/extensions/some-filter/src/adapter/theme-adapter.ts
+++ b/extensions/some-filter/src/adapter/theme-adapter.ts
@@ -30,6 +30,7 @@
 
 import {
   modifyBackgroundColor,
+  modifyForegroundColor,
   rgbaToCss,
 } from "@filter/lib/content/modify-colors"
 import type { Hypothesis } from "@some-extension/transport/contracts/hypothesis"
@@ -123,6 +124,22 @@ export function decide(
         kind: "emit-surface-color",
         key,
         css: rgbaToCss(modifyBackgroundColor(attr.color)),
+        // The carrier's own inline text color (if it has one) was authored
+        // for its *original* light background and is otherwise left
+        // untouched by darkening that background out from under it — #741
+        // ("it darkens text so that it's not visible at all"). Lifted
+        // through the same hue-preserving band the swatch registry's own
+        // text tokens use, never a raw #fff (Φ_comfort's "text is never the
+        // brightest thing on screen" — the "bright white text" failure mode
+        // is exactly as unacceptable here as the unthemed-bright-bg one).
+        ...(attr.text !== undefined && attr.text !== null
+          ? { textCss: rgbaToCss(modifyForegroundColor(attr.text)) }
+          : {}),
+        // imageOnly evidence (a light background-image gradient, #741 "white
+        // gradients leak") has no real background-color underneath the
+        // emitted css above — the image itself must go, or it keeps
+        // rendering exactly as authored on top of it.
+        ...(attr.imageOnly === true ? { suppressImage: true } : {}),
       })
       continue
     }

--- a/extensions/some-filter/src/lib/content/__tests__/prepaint.test.ts
+++ b/extensions/some-filter/src/lib/content/__tests__/prepaint.test.ts
@@ -45,6 +45,26 @@ describe("enablePrepaint", () => {
     expect(document.documentElement.classList.contains("sw-dirty")).toBe(true)
   })
 
+  it("writes nothing at all when the veil is already up (#831)", async () => {
+    enablePrepaint()
+    document.documentElement.classList.add("vendor-a")
+    const records: Array<MutationRecord> = []
+    const observer = new MutationObserver((batch) => records.push(...batch))
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+      childList: true,
+      subtree: true,
+    })
+
+    enablePrepaint()
+    await Promise.resolve()
+
+    expect(records).toEqual([])
+    observer.disconnect()
+    document.documentElement.classList.remove("vendor-a")
+  })
+
   it("sw-dirty is added even when a veil element already exists", () => {
     document.documentElement.classList.remove("sw-dirty")
     enablePrepaint() // creates veil
@@ -84,6 +104,33 @@ describe("disablePrepaint", () => {
     disablePrepaint()
     expect(document.documentElement.classList.contains("sw-dirty")).toBe(false)
   })
+
+  it("writes nothing at all when the veil is already down (#831)", async () => {
+    // `classList.remove` of an *absent* token still re-serializes and re-sets
+    // the class attribute whenever the element has one — which every real
+    // page's <html> does — and a same-value setAttribute still queues a
+    // MutationRecord. The pipeline watches `class`, so an unguarded no-op
+    // here is a phantom "the page changed" signal; because content.ts calls
+    // commitVisualState() -> disablePrepaint() on every fire, that signal
+    // schedules the next fire, which sends it again. "No veil to remove"
+    // must therefore mean "no DOM writes", not just "no visible change".
+    document.documentElement.className = "vendor-a vendor-b"
+    const records: Array<MutationRecord> = []
+    const observer = new MutationObserver((batch) => records.push(...batch))
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+      childList: true,
+      subtree: true,
+    })
+
+    disablePrepaint()
+    await Promise.resolve()
+
+    expect(records).toEqual([])
+    observer.disconnect()
+    document.documentElement.className = ""
+  })
 })
 
 describe("commitVisualState", () => {
@@ -93,6 +140,22 @@ describe("commitVisualState", () => {
     // vitest.setup.ts stubs rAF to execute synchronously,
     // so both nested rAFs fire immediately.
     expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+  })
+
+  it("schedules nothing when the veil is already down (#831)", () => {
+    // Called on every pipeline fire, not just the first. Once there is no
+    // veil left to commit, the rAF pair and the fallback timer would only
+    // queue work whose sole effect is another disablePrepaint().
+    const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame")
+    try {
+      expect(document.getElementById(PREPAINT_VEIL_ID)).toBeNull()
+
+      commitVisualState()
+
+      expect(rafSpy).not.toHaveBeenCalled()
+    } finally {
+      rafSpy.mockRestore()
+    }
   })
 
   it("removes the veil via the timer fallback when rAF never fires", () => {

--- a/extensions/some-filter/src/lib/content/color.ts
+++ b/extensions/some-filter/src/lib/content/color.ts
@@ -117,15 +117,24 @@ export function relativeLuminance(r: number, g: number, b: number): number {
 
 /**
  * Walk up the DOM from el to find the first ancestor with a non-transparent
- * background-color. Returns luminance 0-1, or null if none found.
+ * background-color. Returns the parsed color, or null if none found.
  */
-export function effectiveBgLuminance(el: Element): number | null {
+export function effectiveBgColor(el: Element): RGBA | null {
   let cur: Element | null = el
   while (cur) {
     const bg = getComputedStyle(cur).backgroundColor
     const c = parseColor(bg)
-    if (c) return relativeLuminance(c[0], c[1], c[2])
+    if (c) return c
     cur = cur.parentElement
   }
   return null
+}
+
+/**
+ * Walk up the DOM from el to find the first ancestor with a non-transparent
+ * background-color. Returns luminance 0-1, or null if none found.
+ */
+export function effectiveBgLuminance(el: Element): number | null {
+  const c = effectiveBgColor(el)
+  return c ? relativeLuminance(c[0], c[1], c[2]) : null
 }

--- a/extensions/some-filter/src/lib/content/prepaint.ts
+++ b/extensions/some-filter/src/lib/content/prepaint.ts
@@ -31,10 +31,28 @@
  */
 
 export const PREPAINT_VEIL_ID = "__sw_prepaint_veil"
-const DIRTY_CLASS = "sw-dirty"
+
+/**
+ * The veil's ownership signal on `<html>`. Exported because it is one of the
+ * very few *extension* writes that lands on a *vendor* node, which makes it
+ * indistinguishable from vendor churn to anything watching `class` — the
+ * Sensor (`adapter/pipeline.ts`) needs the name to recognise its own echo
+ * (Axiom 3.5).
+ */
+export const PREPAINT_DIRTY_CLASS = "sw-dirty"
+
+const DIRTY_CLASS = PREPAINT_DIRTY_CLASS
 
 function getVeil(): HTMLElement | null {
   return document.getElementById(PREPAINT_VEIL_ID)
+}
+
+/** True while the veil is up in either of its two halves (element, CSS backstop). */
+export function isPrepaintActive(): boolean {
+  return (
+    document.documentElement.classList.contains(DIRTY_CLASS) ||
+    getVeil() !== null
+  )
 }
 
 /**
@@ -47,7 +65,17 @@ function getVeil(): HTMLElement | null {
  * remove it. Also adds the sw-dirty class which activates the CSS backstop.
  */
 export function enablePrepaint(): void {
-  document.documentElement.classList.add(DIRTY_CLASS)
+  // `classList.add`/`remove` run the DOM's "update steps" unconditionally —
+  // they re-serialize and re-set the `class` attribute even when the token
+  // set is unchanged, and a same-value `setAttribute` still queues a
+  // MutationRecord. The Sensor watches `class` on every node including
+  // <html>, so an unguarded no-op call here is not free: it is a mutation
+  // the pipeline sees, reacts to, and (via commitVisualState -> this
+  // module) causes again — a self-sustaining rescan loop with no vendor
+  // change anywhere in it (#831). Only write when the bit actually flips.
+  if (!document.documentElement.classList.contains(DIRTY_CLASS)) {
+    document.documentElement.classList.add(DIRTY_CLASS)
+  }
 
   if (getVeil()) return
 
@@ -80,7 +108,12 @@ export function enablePrepaint(): void {
 export function disablePrepaint(): void {
   // Remove dirty class first — this is what the self-healing observer checks
   // to distinguish intentional teardown from an accidental vendor removal.
-  document.documentElement.classList.remove(DIRTY_CLASS)
+  // Guarded for the same reason as enablePrepaint()'s add: an already-down
+  // veil must produce *zero* DOM writes, or every fire re-notifies the
+  // Sensor of a change that never happened (#831).
+  if (document.documentElement.classList.contains(DIRTY_CLASS)) {
+    document.documentElement.classList.remove(DIRTY_CLASS)
+  }
 
   const veil = getVeil()
   if (!veil) return
@@ -141,6 +174,12 @@ export function withPrepaintSuppressed<T>(fn: () => T): T {
 const COMMIT_FALLBACK_MS = 100
 
 export function commitVisualState(): void {
+  // Called on *every* pipeline fire (content.ts's onFire), not just the
+  // first. Once the veil is down there is nothing left to commit, and
+  // scheduling another rAF pair + fallback timer per fire only creates work
+  // whose sole effect would be a redundant disablePrepaint().
+  if (!isPrepaintActive()) return
+
   let dropped = false
   const drop = (): void => {
     if (dropped) return

--- a/extensions/some-filter/src/lib/content/prepaint.ts
+++ b/extensions/some-filter/src/lib/content/prepaint.ts
@@ -30,6 +30,10 @@
  *                       from re-creating) then removes veil element
  */
 
+import { parseColor } from "./color"
+import { rgbaToCss } from "./modify-colors"
+import { counterInvertColor, detectVendorInvert } from "./vendor-filter"
+
 export const PREPAINT_VEIL_ID = "__sw_prepaint_veil"
 
 /**
@@ -43,6 +47,10 @@ export const PREPAINT_DIRTY_CLASS = "sw-dirty"
 
 const DIRTY_CLASS = PREPAINT_DIRTY_CLASS
 
+// Matches --sw-bg-0 (SWATCHES.default.bg0) / prepaint.css's own dirty-canvas
+// color — the veil's default, uncompensated dark fill.
+const VEIL_BG = "#171c25"
+
 function getVeil(): HTMLElement | null {
   return document.getElementById(PREPAINT_VEIL_ID)
 }
@@ -52,6 +60,33 @@ export function isPrepaintActive(): boolean {
   return (
     document.documentElement.classList.contains(DIRTY_CLASS) ||
     getVeil() !== null
+  )
+}
+
+/**
+ * Counter-inverts the veil's background so it still reads dark once
+ * composited through a *vendor's own*, still-active `filter:
+ * invert(...)` (#741) — prepaint.css already does the analogous thing for
+ * this extension's own legacy filter (`html[data-sw-legacy]`), but that
+ * CSS-only rule has no way to see a filter the vendor, not this extension,
+ * applied. `!important` inline (highest-specificity, author-origin) beats
+ * prepaint.css's own `!important` class rule. A no-op (`invertAmount = 0`,
+ * the overwhelming majority case) clears any previous override instead —
+ * enablePrepaint() reuses an existing veil across repeated calls, and an
+ * override from a filter that is no longer active must not linger.
+ */
+function compensateVeilBackground(veil: HTMLElement): void {
+  const invertAmount = detectVendorInvert()
+  if (invertAmount === 0) {
+    veil.style.removeProperty("background-color")
+    return
+  }
+  const base = parseColor(VEIL_BG)
+  if (base === null) return
+  veil.style.setProperty(
+    "background-color",
+    rgbaToCss(counterInvertColor(base, invertAmount)),
+    "important"
   )
 }
 
@@ -77,7 +112,15 @@ export function enablePrepaint(): void {
     document.documentElement.classList.add(DIRTY_CLASS)
   }
 
-  if (getVeil()) return
+  const existing = getVeil()
+  if (existing) {
+    // Re-entrant call (e.g. an SPA re-navigation re-arming an already-live
+    // veil, #741's second symptom): re-check the vendor filter every time,
+    // not just at creation — it can still be active, or have changed, since
+    // the veil was first created.
+    compensateVeilBackground(existing)
+    return
+  }
 
   const veil = document.createElement("div")
   veil.id = PREPAINT_VEIL_ID
@@ -88,6 +131,7 @@ export function enablePrepaint(): void {
   // remove a sibling of <body>; only a full documentElement.replaceChildren
   // could do so, and the CSS backstop covers that extreme case.
   document.documentElement.appendChild(veil)
+  compensateVeilBackground(veil)
 
   try {
     veil.showPopover()

--- a/extensions/some-filter/src/lib/content/theme-apply.ts
+++ b/extensions/some-filter/src/lib/content/theme-apply.ts
@@ -29,7 +29,10 @@ import {
 } from "@filter/adapter/swatches"
 import type { FilterConfig } from "@filter/types/config"
 
+import { parseColor } from "./color"
+import { rgbaToCss } from "./modify-colors"
 import { commitVisualState } from "./prepaint"
+import { counterInvertColor, detectVendorInvert } from "./vendor-filter"
 
 /**
  * Every `<style>` this extension injects carries `[data-my-ext]`. Two
@@ -63,6 +66,45 @@ function setStyleText(style: HTMLStyleElement, css: string): void {
 
 export const DARK_THEME_ATTR = "data-sw-dark"
 export const LEGACY_THEME_ATTR = "data-sw-legacy"
+
+/**
+ * Counter-inverts every color a `Swatch` carries so that, once composited
+ * through a still-active *vendor* `filter: invert(...)` (#741 — a real
+ * accessibility toggle some sites ship on their own `<html>`, distinct from
+ * this extension's own legacy filter mode), a human/screenshot sees the
+ * swatch's real, intended dark tokens rather than their bright inverse. A
+ * no-op (`invertAmount = 0`, the overwhelming majority case) returns
+ * `swatch` unchanged.
+ */
+function compensateSwatch(swatch: Swatch, invertAmount: number): Swatch {
+  if (invertAmount === 0) return swatch
+
+  const counter = (css: string): string => {
+    const parsed = parseColor(css)
+    return parsed === null
+      ? css
+      : rgbaToCss(counterInvertColor(parsed, invertAmount))
+  }
+
+  return {
+    ...swatch,
+    bg0: counter(swatch.bg0),
+    bg1: counter(swatch.bg1),
+    bg2: counter(swatch.bg2),
+    bg3: counter(swatch.bg3),
+    surface: counter(swatch.surface),
+    border: counter(swatch.border),
+    text0: counter(swatch.text0),
+    text1: counter(swatch.text1),
+    text2: counter(swatch.text2),
+    link: counter(swatch.link),
+    linkVisited: counter(swatch.linkVisited),
+    inputBg: counter(swatch.inputBg),
+    inputBorder: counter(swatch.inputBorder),
+    selectionBg: counter(swatch.selectionBg),
+    codeFg: counter(swatch.codeFg),
+  }
+}
 
 // ── Tokens ────────────────────────────────────────────────────────────────────
 // Values come from the active swatch (default: SWATCHES.default, byte-for-byte
@@ -257,7 +299,14 @@ export function injectDarkTheme(
   if (!(existing instanceof HTMLStyleElement)) {
     document.head.appendChild(style)
   }
-  setStyleText(style, buildDarkThemeCSS(swatch))
+  // The compensation is recomputed per call (a vendor's own invert toggle
+  // can flip at any time), but the assignment still goes through
+  // setStyleText: an unchanged filter state rebuilds byte-identical CSS,
+  // and rewriting it would be a mutation the Sensor reacts to (#831).
+  setStyleText(
+    style,
+    buildDarkThemeCSS(compensateSwatch(swatch, detectVendorInvert()))
+  )
   // Per-surface tagging and the dynamic color stylesheet are the actuator's
   // job now (adapter/actuator.ts), driven by decide()'s returned actions —
   // not this function's. Veil removal is the caller's responsibility: inject

--- a/extensions/some-filter/src/lib/content/theme-apply.ts
+++ b/extensions/some-filter/src/lib/content/theme-apply.ts
@@ -31,6 +31,36 @@ import type { FilterConfig } from "@filter/types/config"
 
 import { commitVisualState } from "./prepaint"
 
+/**
+ * Every `<style>` this extension injects carries `[data-my-ext]`. Two
+ * separate consumers depend on it: `EXT_GUARD` (below) keeps theme rules
+ * off extension-owned nodes, and the Sensor (`adapter/pipeline.ts`) uses
+ * the same marker to recognise a mutation record as its own actuation echo
+ * rather than vendor evidence (Axiom 3.5). An unmarked stylesheet is
+ * invisible to the first and indistinguishable from vendor churn to the
+ * second — which is how injecting one ended up re-triggering the very scan
+ * that injected it (#831).
+ */
+function createExtensionStyle(id: string): HTMLStyleElement {
+  const style = document.createElement("style")
+  style.id = id
+  style.setAttribute("data-my-ext", "")
+  return style
+}
+
+/**
+ * Assigns `css` only when it differs from what the element already holds.
+ * `textContent =` replaces the element's child text node unconditionally,
+ * which is a childList mutation the Sensor observes — so an unguarded
+ * re-assignment of identical CSS is a phantom "the page changed" signal
+ * (Theorem 7.2's idempotence requirement, at the level of *DOM writes*, not
+ * just of resulting state).
+ */
+function setStyleText(style: HTMLStyleElement, css: string): void {
+  if (style.textContent === css) return
+  style.textContent = css
+}
+
 export const DARK_THEME_ATTR = "data-sw-dark"
 export const LEGACY_THEME_ATTR = "data-sw-legacy"
 
@@ -212,7 +242,9 @@ body${EXT_GUARD} {
 
 // ── Dark theme injection (static layer only) ───────────────────────────────────
 
-const STYLE_ID = "__sw_dark_theme"
+export const DARK_THEME_STYLE_ID = "__sw_dark_theme"
+
+const STYLE_ID = DARK_THEME_STYLE_ID
 
 export function injectDarkTheme(
   swatch: Swatch = SWATCHES[DEFAULT_SWATCH_ID]
@@ -221,12 +253,11 @@ export function injectDarkTheme(
   const style: HTMLStyleElement =
     existing instanceof HTMLStyleElement
       ? existing
-      : document.createElement("style")
+      : createExtensionStyle(STYLE_ID)
   if (!(existing instanceof HTMLStyleElement)) {
-    style.id = STYLE_ID
     document.head.appendChild(style)
   }
-  style.textContent = buildDarkThemeCSS(swatch)
+  setStyleText(style, buildDarkThemeCSS(swatch))
   // Per-surface tagging and the dynamic color stylesheet are the actuator's
   // job now (adapter/actuator.ts), driven by decide()'s returned actions —
   // not this function's. Veil removal is the caller's responsibility: inject
@@ -261,14 +292,14 @@ function applyLegacyFilter(config: FilterConfig): void {
   // Set the attribute on html so prepaint CSS can react instantly
   document.documentElement.setAttribute(LEGACY_THEME_ATTR, "")
 
-  let style = document.getElementById(LEGACY_FILTER_STYLE_ID)
+  const existing = document.getElementById(LEGACY_FILTER_STYLE_ID)
+  const style =
+    existing instanceof HTMLStyleElement
+      ? existing
+      : createExtensionStyle(LEGACY_FILTER_STYLE_ID)
 
-  if (!style) {
-    style = document.createElement("style")
-    style.id = LEGACY_FILTER_STYLE_ID
-
-    const root = document.head
-    root.appendChild(style)
+  if (existing === null) {
+    document.head.appendChild(style)
   }
 
   // "dim" style (no invert): the browser's native dark theme already darkened
@@ -281,10 +312,13 @@ function applyLegacyFilter(config: FilterConfig): void {
     ? "img, video, canvas, picture { filter: invert(1) hue-rotate(180deg) !important; }"
     : ""
 
-  style.textContent = `
+  setStyleText(
+    style,
+    `
     html { filter: ${buildFilterString(config)} !important; ${canvasRule} }
     ${mediaRule}
   `
+  )
 }
 
 function removeLegacyFilter(): void {

--- a/extensions/some-filter/src/lib/content/theme-detector.ts
+++ b/extensions/some-filter/src/lib/content/theme-detector.ts
@@ -18,12 +18,34 @@
  * Tier 3 samples `body > *` directly (vendor DOM is not wrapped). Extension-owned
  * nodes are excluded via the [data-my-ext] attribute filter.
  *
+ * Filter-aware sampling (#741): every sampled color is a *declared* value —
+ * getComputedStyle never reflects a `filter` an ancestor (typically <html>)
+ * has applied, so a page wrapped in its own `filter: invert(...)` (a real
+ * vendor accessibility toggle, or this extension's own legacy style) reads
+ * exactly backwards to a human/screenshot versus what raw backgroundColor
+ * says. `vendor-filter.ts`'s `detectVendorInvert()` reads the net invert
+ * amount once per call and every tier composites its raw samples through it
+ * before computing luminance, so the verdict tracks what is actually
+ * rendered, not just what was declared.
+ *
  * NOTE: the `isLight` framing is retained from the classify-then-apply era. The
  * always-apply / already-dark reframe is tracked in #236; this module's split
  * (#233) is structural only and preserves the existing decision semantics.
  */
 
-import { effectiveBgLuminance, parseColor, relativeLuminance } from "./color"
+import {
+  effectiveBgColor,
+  parseColor,
+  relativeLuminance,
+  type RGBA,
+} from "./color"
+import { applyInvertToColor, detectVendorInvert } from "./vendor-filter"
+
+/** Luminance of `color` as it actually renders once composited through a still-active ancestor `invert(amount)` filter. */
+function renderedLuminance(color: RGBA, invertAmount: number): number {
+  const [r, g, b] = applyInvertToColor(color, invertAmount)
+  return relativeLuminance(r, g, b)
+}
 
 function viewportCoverage(el: Element): number {
   const rect = el.getBoundingClientRect()
@@ -52,6 +74,7 @@ export type ClassificationResult = {
  */
 export function classifyPage(threshold = 0.4): ClassificationResult {
   const samples: Array<{ lum: number; weight: number }> = []
+  const invertAmount = detectVendorInvert()
 
   // Tier 1: html and body
   const root = document.documentElement
@@ -63,7 +86,7 @@ export function classifyPage(threshold = 0.4): ClassificationResult {
     if (el == null) continue
     const bg = getComputedStyle(el).backgroundColor
     const c = parseColor(bg)
-    if (c) samples.push({ lum: relativeLuminance(c[0], c[1], c[2]), weight: 2 })
+    if (c) samples.push({ lum: renderedLuminance(c, invertAmount), weight: 2 })
   }
 
   // Tier 2: semantic containers
@@ -84,8 +107,9 @@ export function classifyPage(threshold = 0.4): ClassificationResult {
     const el = document.querySelector(sel)
     if (!el) continue
     if (el.hasAttribute("data-my-ext") || el.closest("[data-my-ext]")) continue
-    const lum = effectiveBgLuminance(el)
-    if (lum !== null) samples.push({ lum, weight: 1.5 })
+    const c = effectiveBgColor(el)
+    if (c !== null)
+      samples.push({ lum: renderedLuminance(c, invertAmount), weight: 1.5 })
   }
 
   // Tier 3: largest visible containers by viewport coverage.
@@ -112,7 +136,7 @@ export function classifyPage(threshold = 0.4): ClassificationResult {
     const c = parseColor(bg)
     if (c)
       samples.push({
-        lum: relativeLuminance(c[0], c[1], c[2]),
+        lum: renderedLuminance(c, invertAmount),
         weight: coverage,
       })
   }

--- a/extensions/some-filter/src/lib/content/vendor-filter.ts
+++ b/extensions/some-filter/src/lib/content/vendor-filter.ts
@@ -1,0 +1,99 @@
+/**
+ * Detects a `filter: invert(...)` a *vendor page* has applied to `<html>`
+ * on its own — a real, common pattern (an accessibility "invert colours"
+ * toggle some sites ship themselves) that silently defeats every color
+ * this extension injects (#741). `getComputedStyle` never reflects
+ * `filter` compositing: it reports the literal declared value, not what a
+ * human (or a screenshot) actually sees once the browser paints that value
+ * through the still-active ancestor filter. Left unaccounted for, this is
+ * the root cause behind three of #741's symptoms — the classifier reading
+ * a page exactly backwards, and the live pipeline's own dark-theme tokens
+ * (both the static canvas and the prepaint veil) compositing back to a
+ * bright, near-white result once the vendor's filter is applied on top.
+ *
+ * Deliberately scoped to `invert()` only — the one filter function both
+ * real vendor toggles and this extension's own legacy mode
+ * (`theme-apply.ts`'s `applyLegacyFilter`) use to fully reverse a page's
+ * rendered colors. Other filter functions (`blur`, `brightness`, …) are
+ * out of scope: no known fixture or reported symptom implicates them, and
+ * guessing at a compensation for them would be unverifiable.
+ *
+ * Pure math + a single read-only `getComputedStyle` call — no DOM writes,
+ * mirroring `color.ts`'s own read-only discipline.
+ */
+
+import type { RGBA } from "./color"
+
+const INVERT_RE = /invert\(\s*([\d.]+)(%?)\s*\)/i
+
+function clamp01(v: number): number {
+  return Math.min(1, Math.max(0, v))
+}
+
+/**
+ * Net `invert()` amount (0–1) found in a computed `filter` value, e.g.
+ * `"invert(1)"` → 1, `"invert(50%)"` → 0.5, `"none"` / `"blur(2px)"` → 0.
+ */
+export function parseInvertAmount(filterValue: string): number {
+  const match = filterValue.match(INVERT_RE)
+  if (match === null) return 0
+
+  const [, raw, pct] = match
+  if (raw === undefined) return 0
+
+  const amount = Number.parseFloat(raw) / (pct === "%" ? 100 : 1)
+  return Number.isFinite(amount) ? clamp01(amount) : 0
+}
+
+/**
+ * Detects a vendor-authored `invert()` filter currently active on
+ * `<html>`. Read at call time (not cached) since a vendor's own
+ * accessibility toggle can be flipped at any point in a page's lifetime.
+ */
+export function detectVendorInvert(): number {
+  return parseInvertAmount(getComputedStyle(document.documentElement).filter)
+}
+
+/** CSS Filter Effects Level 1's `invert()`: C' = (1 - 2a)C + a. */
+function applyInvert(channel: number, amount: number): number {
+  return (1 - 2 * amount) * channel + amount
+}
+
+/** The inverse of `applyInvert`: what raw channel value, once composited through a still-active `invert(amount)`, renders as `target`. Undefined at amount=0.5 (every input maps to the same output) — falls back to `target` unchanged rather than dividing by zero. */
+function counterInvert(target: number, amount: number): number {
+  const denom = 1 - 2 * amount
+  if (Math.abs(denom) < 1e-6) return target
+  return clamp01((target - amount) / denom)
+}
+
+/**
+ * What color must be *declared* so that, once the browser composites it
+ * through a still-active `invert(amount)` filter, a human sees `target`.
+ * `amount = 0` is a no-op (nothing to counter).
+ */
+export function counterInvertColor([r, g, b, a]: RGBA, amount: number): RGBA {
+  if (amount === 0) return [r, g, b, a]
+  return [
+    counterInvert(r, amount),
+    counterInvert(g, amount),
+    counterInvert(b, amount),
+    a,
+  ]
+}
+
+/**
+ * The forward direction of `counterInvertColor`: what a human actually
+ * sees once `declared` is composited through a still-active
+ * `invert(amount)` filter. Used to judge *existing* declared colors (the
+ * classifier's sampled backgrounds) rather than to compensate colors this
+ * extension is about to inject.
+ */
+export function applyInvertToColor([r, g, b, a]: RGBA, amount: number): RGBA {
+  if (amount === 0) return [r, g, b, a]
+  return [
+    applyInvert(r, amount),
+    applyInvert(g, amount),
+    applyInvert(b, amount),
+    a,
+  ]
+}

--- a/extensions/some-filter/tests/e2e/fixtures/self-feedback-page.html
+++ b/extensions/some-filter/tests/e2e/fixtures/self-feedback-page.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<!--
+  Self-feedback fixture (#831).
+
+  A plainly light page that carries the surfaces buildDarkThemeCSS() recolors
+  *without* tagging them — input, textarea, select, pre, code, th, dialog. The
+  Actuator only ever writes data-sw-patched on surfaces decide() named, so
+  these carriers are invisible to the Sensor's [data-sw-patched] skip: after
+  activation their computed background is the extension's own swatch, and a
+  scan that reads it folds our output back into an append-only hypothesis as
+  if it were fresh vendor evidence. Enough of that and pageAlreadyDark()'s
+  mean crosses the threshold, decide() emits restore-native, and the theme
+  strips itself off a page whose vendor colors never changed — the reported
+  "another loop runs and reveals the white bg".
+
+  The one delayed mutation at the bottom is the trigger: a single reactive
+  round is all it takes. Everything after that must be quiescent — no timer,
+  no polling, no further extension writes — which is the other half of what
+  this fixture is here to make observable.
+
+  The colors here are deliberately lopsided in the direction real pages lean:
+  exactly ONE distinct vendor background (white) against several surfaces the
+  static layer paints from distinct swatch tokens (--sw-bg-2 for pre/th,
+  --sw-bg-3 for code, --sw-surface for dialog). Ĥ is keyed by color, so a
+  post-activation scan turns that into one light key against three dark ones
+  — mean ≈ 0.25, under theme-adapter.ts's 0.4 threshold — and the page
+  concludes it was dark all along. A scan that reads vendor truth instead
+  sees one light key and no dark ones at all.
+
+  Expected outcome: data-sw-theme-applied="dark" and data-sw-dark on <html>,
+  both still true seconds later, with zero extension-authored DOM churn in
+  between.
+-->
+<html class="vendor-root" style="background-color: rgb(255, 255, 255)">
+  <head>
+    <meta charset="utf-8" />
+    <title>Self-feedback Page Fixture</title>
+  </head>
+  <body style="background-color: rgb(255, 255, 255); margin: 0">
+    <main style="background-color: rgb(255, 255, 255)">
+      <h1>Self-feedback Page Fixture</h1>
+      <p style="background-color: rgb(255, 255, 255)">
+        White page. The dark theme should apply — and stay applied.
+      </p>
+
+      <!-- Static-layer recolor targets, all with transparent vendor
+           backgrounds: they contribute no evidence at all until the theme
+           paints them, and are never tagged data-sw-patched because decide()
+           never named their (nonexistent) vendor key. -->
+      <pre id="block">preformatted</pre>
+      <code id="inline">inline code</code>
+      <table>
+        <thead>
+          <tr>
+            <th id="head-cell">Header</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td id="body-cell">Cell</td>
+          </tr>
+        </tbody>
+      </table>
+      <dialog id="sheet">dialog surface</dialog>
+
+      <div id="churn" style="background-color: rgb(255, 255, 255)">
+        vendor subtree
+      </div>
+    </main>
+
+    <script>
+      // One vendor mutation, well after classification settles, so exactly one
+      // reactive round runs. A page that keeps mutating would make continuous
+      // rescans legitimate and hide the loop this fixture exists to expose.
+      setTimeout(function () {
+        document.getElementById("churn").classList.add("vendor-churned")
+      }, 400)
+    </script>
+  </body>
+</html>

--- a/extensions/some-filter/tests/e2e/specs/issue-831-quiescence.spec.ts
+++ b/extensions/some-filter/tests/e2e/specs/issue-831-quiescence.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * #831 — "polling pattern causing constant rerenders and flushing state?"
+ *
+ * Two symptoms, one root cause family, both asserted here against the real
+ * --load-extension pipeline:
+ *
+ *   1. The theme applies correctly and is then undone by a later round,
+ *      revealing the white vendor background. The Sensor was reading the
+ *      *extension's own* static-layer output (html/body/input/pre/th/... —
+ *      recolored by buildDarkThemeCSS but never tagged data-sw-patched) back
+ *      in as vendor evidence; since Ĥ is append-only, pageAlreadyDark()'s
+ *      mean drifted down until decide() emitted restore-native.
+ *
+ *   2. Rounds never stop on a page that is not changing. Realizing a verdict
+ *      is itself a DOM write (the theme sheet into <head>, the dynamic
+ *      sheet's text, the veil's sw-dirty class on <html>) — mutations the
+ *      Sensor's own observer sees, schedules another round for, and thereby
+ *      causes again. The tell in the issue is a log line that keeps ticking
+ *      up on an idle tab.
+ *
+ * Both are stated as invariants of a *settled* page: once classification has
+ * resolved, an untouched page must hold its verdict and cost nothing.
+ */
+
+import { expect, test, waitForClassification } from "@filter/playwright/fixture"
+
+/** Long enough to span many reconcile windows (RECONCILE_POLICY.debounceMs = 50). */
+const QUIET_WINDOW_MS = 1_500
+
+test.describe("auto theme quiescence on a settled page (#831)", () => {
+  test("the theme survives the rounds that follow the one that applied it", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("self-feedback-page")
+    const settled = await waitForClassification(page)
+
+    expect(settled.themeApplied).toBe("dark")
+
+    // Past the fixture's own delayed mutation (400ms), so at least one
+    // reactive round has run against a page already wearing the theme.
+    await page.waitForTimeout(QUIET_WINDOW_MS)
+
+    const after = await page.evaluate(() => ({
+      themeApplied: document.body.dataset["swThemeApplied"],
+      hasDarkAttr: document.documentElement.hasAttribute("data-sw-dark"),
+      hasThemeSheet: document.getElementById("__sw_dark_theme") !== null,
+      bodyBg: getComputedStyle(document.body).backgroundColor,
+    }))
+
+    expect(
+      after.themeApplied,
+      "the page's vendor colors never changed, so no later round may reach a " +
+        "different verdict than the one that applied the theme"
+    ).toBe("dark")
+    expect(after.hasDarkAttr).toBe(true)
+    expect(after.hasThemeSheet).toBe(true)
+    expect(after.bodyBg).not.toBe("rgb(255, 255, 255)")
+  })
+
+  test("a settled, untouched page costs zero further extension DOM writes", async ({
+    fixture,
+  }) => {
+    const page = await fixture.goto("self-feedback-page")
+    await waitForClassification(page)
+
+    // Let the fixture's single delayed mutation land and settle first — the
+    // round it triggers is legitimate. What follows must be silence.
+    await page.waitForTimeout(800)
+
+    const churn = await page.evaluate(async (windowMs: number) => {
+      // Count only mutations to artifacts the extension owns: its two
+      // stylesheets (rebuilt per round) and <html>'s class attribute (the
+      // prepaint veil's ownership signal, rewritten by every
+      // commitVisualState -> disablePrepaint). This page's own script is
+      // done mutating by now, so anything counted here is self-inflicted.
+      let count = 0
+      const observer = new MutationObserver((records) => {
+        count += records.length
+      })
+
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
+      })
+      for (const id of ["__sw_dark_theme", "__sw_dark_dynamic"]) {
+        const sheet = document.getElementById(id)
+        if (sheet !== null) {
+          observer.observe(sheet, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+          })
+        }
+      }
+      observer.observe(document.head, { childList: true })
+
+      await new Promise((resolve) => setTimeout(resolve, windowMs))
+      observer.disconnect()
+      return count
+    }, QUIET_WINDOW_MS)
+
+    expect(
+      churn,
+      `the extension rewrote its own artifacts ${churn} time(s) over ` +
+        `${QUIET_WINDOW_MS}ms on a page nothing was changing — each of those ` +
+        `writes is a mutation its own Sensor reacts to, which is the loop`
+    ).toBe(0)
+  })
+})


### PR DESCRIPTION
## Description

Fixes #831 by addressing two related symptoms of self-feedback in the theme application pipeline:

1. **Theme undoing itself**: The Sensor was reading the extension's own static-layer output (recolored elements like `html`, `body`, `input`, `pre`, `th`, etc.) back into the hypothesis as vendor evidence. Since the hypothesis is append-only, this caused `pageAlreadyDark()`'s mean to drift until `decide()` emitted `restore-native`, undoing the theme on an unchanged page.

2. **Infinite re-triggering**: Realizing a verdict writes to the DOM (theme stylesheet, dynamic sheet text, veil's `sw-dirty` class), which the observer sees and reacts to, causing another round. On a settled page, this created a closed loop with zero vendor mutations involved.

## Root Causes & Solutions

**Axiom 3.5 (Actuator re-entrance)**: Implemented two-part defense:
- **Write side**: Added `[data-my-ext]` markers to all extension-owned stylesheets and guarded all DOM writes with idempotence checks (only write when content actually differs)
- **Read side**: Implemented `isSelfAuthored()` to filter out extension-authored mutations from triggering new scans, and `withVendorColorsVisible()` to temporarily disable extension color sheets during scanning so the Sensor reads vendor truth, not the theme we painted

**Vendor filter compensation (#741)**: Added `vendor-filter.ts` to detect and counter-invert vendor-applied `filter: invert(...)` (real accessibility toggles some sites ship), ensuring the classifier and live pipeline read colors as they actually render to users.

## Changes

### Core Pipeline (`adapter/pipeline.ts`)
- Exported `isSelfAuthored()` and `withVendorColorsVisible()` functions
- Updated `readAttr()` to capture element's own text color and detect gradient backgrounds
- Wrapped all scans with `withVendorColorsVisible()` to read vendor colors only
- Filtered mutation records through `isSelfAuthored()` to ignore extension writes

### DOM Write Guards
- `theme-apply.ts`: Created `createExtensionStyle()` helper and `setStyleText()` guard to prevent phantom mutations
- `prepaint.ts`: Added idempotence checks to `enablePrepaint()` and `disablePrepaint()` 
- `actuator.ts`: Ensured dynamic stylesheet only updates when content differs

### Vendor Filter Support (`vendor-filter.ts`)
- `detectVendorInvert()`: Reads vendor's `filter: invert()` amount
- `counterInvertColor()`: Calculates what color to declare so it renders correctly through vendor's filter
- Integrated into `theme-apply.ts` and `prepaint.ts` for swatch and veil compensation

### Surface Attributes (`contracts.ts`)
- Added `text` field to capture element's own text color for re-targeting
- Added `imageOnly` flag for gradient-only backgrounds

### Theme Adapter (`theme-adapter.ts`)
- Emits `emit-foreground-color` actions for surfaces with own text colors

### Tests
- Added comprehensive test suite for `isSelfAuthored()` covering stylesheets, veil toggles, and node removal
- Added tests for `withVendorColorsVisible()` ensuring sheets are disabled/re-enabled correctly
- Added e2e test fixture (`self-feedback-page.html`) and spec (`issue-831-quiescence.spec.ts`) verifying theme stability and zero churn on settled pages
- Added unit tests for idempotence in `prepaint.test.ts` and `actuator.test.ts`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my

https://claude.ai/code/session_013NTfeSnd8jrqHJoUb8gip2