### PR TITLE
feat(suspender): local observability subsystem + fix sporadic no-suspend bug

### DIFF
--- a/extensions/common/package.json
+++ b/extensions/common/package.json
@@ -17,6 +17,10 @@
       "import": "./vite/index.ts",
       "types": "./vite/index.ts"
     },
+    "./observability": {
+      "import": "./src/observability/index.ts",
+      "types": "./src/observability/index.ts"
+    },
     "./*": {
       "import": "./src/*.ts",
       "types": "./src/*.ts"

--- a/extensions/common/src/observability/index.ts
+++ b/extensions/common/src/observability/index.ts
@@ -1,0 +1,55 @@
+/**
+ * `@some-extension/common/observability` — the workspace's shared flight
+ * recorder.
+ *
+ * ## Why this is a shared package rather than one extension's module
+ *
+ * Every extension in this repo has the same reliability question ("is it
+ * actually doing the thing, months into real-world use?") and the same two
+ * constraints: it must answer that question **without shipping data off the
+ * machine** (AMO's privacy posture, and ours), and **without unbounded storage
+ * growth**. Those constraints are identical everywhere, so the machinery is
+ * hoisted here and each extension supplies only what is genuinely its own:
+ *
+ *     Extension-specific (the adapter)      Shared (this package)
+ *     ────────────────────────────────      ─────────────────────
+ *     event-kind union                      RingBuffer
+ *     counter / aggregate names             MetricsStore
+ *     invariants + their context            invariant runner, health scoring
+ *     what to record, and where             Recorder, persistence ports
+ *
+ * An adapter is a few dozen lines: declare the unions, list the invariants,
+ * construct a {@link Recorder}. See `suspender-ledger/src/worker/core/
+ * observability.ts` for the reference implementation.
+ *
+ * ## Observability, not telemetry
+ *
+ * Telemetry implies data leaving the machine. Nothing here has a network path.
+ * The extension explains itself locally; the user exports a bundle by hand if
+ * and when they choose to file a bug.
+ */
+
+export { RingBuffer } from "./ring-buffer"
+export { MetricsStore } from "./metrics"
+export { runInvariants, scoreHealth } from "./invariants"
+export {
+  extensionStoragePersistence,
+  memoryPersistence,
+  type ExtensionPersistenceOptions,
+  type StorageAreaLike,
+} from "./persistence"
+export { Recorder, type RecordInput, type RecorderOptions } from "./recorder"
+export type {
+  Aggregate,
+  DiagnosticsBundle,
+  HealthReport,
+  Invariant,
+  InvariantOutcome,
+  InvariantResult,
+  JsonValue,
+  MetricsSnapshot,
+  ObservabilityEvent,
+  ObservabilityPersistence,
+  PersistedState,
+  Severity,
+} from "./types"

--- a/extensions/common/src/observability/invariants.ts
+++ b/extensions/common/src/observability/invariants.ts
@@ -1,0 +1,80 @@
+/**
+ * Invariant registry and runner — tier-0 (pure, no browser globals).
+ *
+ * An invariant is a statement that must hold every time it is checked ("no
+ * active tab is suspended", "the scheduler's alarm exists"). Running them on a
+ * cadence catches logic bugs *before* a user notices, and — more usefully for
+ * an intermittent bug — records **which invariant broke first**, which is
+ * almost always nearer the root cause than the symptom the user reports.
+ *
+ * Checks are pure with respect to a caller-supplied context: gathering the
+ * context (querying tabs, reading alarms) is the adapter's job, so the checks
+ * themselves are unit-testable with a plain object and no browser mock.
+ */
+
+import type { Invariant, InvariantOutcome, InvariantResult } from "./types"
+
+/** Evaluate every invariant against one context snapshot. */
+export async function runInvariants<Ctx>(
+  invariants: ReadonlyArray<Invariant<Ctx>>,
+  ctx: Ctx,
+  now: number = Date.now()
+): Promise<Array<InvariantResult>> {
+  const results: Array<InvariantResult> = []
+  for (const inv of invariants) {
+    let outcome: InvariantOutcome
+    try {
+      outcome = await inv.check(ctx)
+    } catch (error) {
+      // A check that throws is itself a defect, but it must not take the
+      // health report down with it — report it as unknown, not as a violation
+      // of the property it was meant to test.
+      outcome = {
+        ok: "unknown",
+        details: error instanceof Error ? error.message : String(error),
+      }
+    }
+    results.push({
+      name: inv.name,
+      description: inv.description,
+      status:
+        outcome.ok === true
+          ? "ok"
+          : outcome.ok === false
+            ? "violated"
+            : "unknown",
+      details: outcome.ok === true ? undefined : outcome.details,
+      t: now,
+    })
+  }
+  return results
+}
+
+/**
+ * Reduce invariant results plus a recent-error count into a single score.
+ *
+ * Scoring is intentionally blunt: violations dominate, recent errors shave a
+ * few points, and `unknown` costs nothing (an un-evaluable check is not
+ * evidence of breakage). The number exists to make a *trend* legible on the
+ * debug page and to decide when the popup should warn — not to be precise.
+ */
+export function scoreHealth(
+  results: ReadonlyArray<InvariantResult>,
+  recentErrors: number
+): { score: number; status: "healthy" | "degraded" | "unhealthy" } {
+  const evaluated = results.filter((r) => r.status !== "unknown")
+  const violated = evaluated.filter((r) => r.status === "violated").length
+  const base =
+    evaluated.length === 0
+      ? 100
+      : Math.round(((evaluated.length - violated) / evaluated.length) * 100)
+  const errorPenalty = Math.min(20, recentErrors * 2)
+  const score = Math.max(0, base - errorPenalty)
+  const status =
+    violated > 0 || score < 60
+      ? "unhealthy"
+      : score < 95
+        ? "degraded"
+        : "healthy"
+  return { score, status }
+}

--- a/extensions/common/src/observability/metrics.ts
+++ b/extensions/common/src/observability/metrics.ts
@@ -1,0 +1,118 @@
+/**
+ * Counters and numeric aggregates — tier-0 (pure, no browser globals).
+ *
+ * Borrowed from Prometheus in spirit, not in shape. Two deliberate omissions
+ * keep this bounded on a user's disk:
+ *
+ *   - **No labels.** A counter is a name, not a name plus a cardinality
+ *     explosion. Per-tab or per-host breakdowns belong in the event timeline,
+ *     which is ring-buffered; a labelled counter map is not.
+ *   - **No histogram buckets.** An {@link Aggregate} is five numbers
+ *     (count/sum/min/max/last). That answers "is suspend latency drifting?"
+ *     without storing a distribution per metric forever.
+ *
+ * Names are typed by the adapting extension, so a typo is a compile error
+ * rather than a silently orphaned metric.
+ */
+
+import type { Aggregate, MetricsSnapshot } from "./types"
+
+export class MetricsStore<
+  TCounter extends string = string,
+  TAggregate extends string = string,
+> {
+  // Keyed by plain string, written and read only through the typed methods
+  // below. Persisted snapshots arrive string-keyed, and narrowing them back to
+  // the name unions would need a cast that proves nothing.
+  private counters = new Map<string, number>()
+  private aggregates = new Map<string, Aggregate>()
+
+  /** Add to a monotonic counter (`by` may be >1 for batch outcomes). */
+  increment(name: TCounter, by = 1): void {
+    this.counters.set(name, (this.counters.get(name) ?? 0) + by)
+  }
+
+  /** Read one counter without materializing the whole snapshot. */
+  counter(name: TCounter): number {
+    return this.counters.get(name) ?? 0
+  }
+
+  /** Fold one observation into a named aggregate. Non-finite values are ignored. */
+  observe(name: TAggregate, value: number): void {
+    if (!Number.isFinite(value)) {
+      return
+    }
+    const prior = this.aggregates.get(name)
+    if (!prior) {
+      this.aggregates.set(name, {
+        count: 1,
+        sum: value,
+        min: value,
+        max: value,
+        last: value,
+      })
+      return
+    }
+    this.aggregates.set(name, {
+      count: prior.count + 1,
+      sum: prior.sum + value,
+      min: Math.min(prior.min, value),
+      max: Math.max(prior.max, value),
+      last: value,
+    })
+  }
+
+  /** Read one aggregate, or undefined if nothing has been observed yet. */
+  aggregate(name: TAggregate): Aggregate | undefined {
+    const found = this.aggregates.get(name)
+    return found ? { ...found } : undefined
+  }
+
+  /** Serializable readout of every counter and aggregate. */
+  snapshot(): MetricsSnapshot {
+    const counters: Record<string, number> = {}
+    for (const [name, value] of this.counters) {
+      counters[name] = value
+    }
+    const aggregates: Record<string, Aggregate> = {}
+    for (const [name, value] of this.aggregates) {
+      aggregates[name] = { ...value }
+    }
+    return { counters, aggregates }
+  }
+
+  /**
+   * Restore from a persisted snapshot. Used once per worker generation: MV3
+   * event pages are recycled constantly, and counters that reset on every
+   * respawn would measure the worker's lifetime rather than the extension's.
+   */
+  hydrate(snapshot: MetricsSnapshot | undefined): void {
+    if (!snapshot) {
+      return
+    }
+    for (const [name, value] of Object.entries(snapshot.counters)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        this.counters.set(name, value)
+      }
+    }
+    for (const [name, value] of Object.entries(snapshot.aggregates)) {
+      if (isAggregate(value)) {
+        this.aggregates.set(name, { ...value })
+      }
+    }
+  }
+
+  /** Zero everything — the debug page's "reset counters" action. */
+  reset(): void {
+    this.counters.clear()
+    this.aggregates.clear()
+  }
+}
+
+function isAggregate(value: unknown): value is Aggregate {
+  if (value === null || typeof value !== "object") {
+    return false
+  }
+  const fields: Array<keyof Aggregate> = ["count", "sum", "min", "max", "last"]
+  return fields.every((f) => typeof Reflect.get(value, f) === "number")
+}

--- a/extensions/common/src/observability/persistence.ts
+++ b/extensions/common/src/observability/persistence.ts
@@ -1,0 +1,164 @@
+/**
+ * Persistence ports for the recorder — tier-1 (the extension-storage port
+ * touches `browser.storage`; the memory port is tier-0 and safe anywhere).
+ *
+ * The recorder never imports a storage API directly. That indirection is what
+ * lets the same core run under vitest with no browser mock, and lets a future
+ * extension swap in IndexedDB when its event volume outgrows `storage.local`
+ * without any change to the recording call sites.
+ */
+
+import type { ObservabilityPersistence, PersistedState } from "./types"
+
+/** In-memory port. Tests, and any surface that must not touch disk. */
+export function memoryPersistence(): ObservabilityPersistence & {
+  peek(): PersistedState | undefined
+} {
+  let state: PersistedState | undefined
+  return {
+    load: (): Promise<PersistedState | undefined> => Promise.resolve(state),
+    save: (next: PersistedState): Promise<void> => {
+      state = next
+      return Promise.resolve()
+    },
+    clear: (): Promise<void> => {
+      state = undefined
+      return Promise.resolve()
+    },
+    peek: (): PersistedState | undefined => state,
+  }
+}
+
+/** The minimum storage-area surface the port needs. */
+export type StorageAreaLike = {
+  get(keys: string | Array<string> | Record<string, unknown>): Promise<unknown>
+  set(items: Record<string, unknown>): Promise<void>
+  remove(keys: string | Array<string>): Promise<void>
+}
+
+export type ExtensionPersistenceOptions = {
+  /** Storage key. Namespace it per workspace (Good-Citizen Charter §4). */
+  key: string
+  /** The area to write to. Defaults to `browser.storage.local`. */
+  area?: StorageAreaLike
+  /**
+   * Hard ceiling on the serialized payload. Events are shed oldest-first until
+   * the bundle fits — the last line of defence against storage creep when an
+   * adapter records unexpectedly fat `detail` payloads.
+   */
+  maxBytes?: number
+}
+
+/** Default ceiling: ~256 KB, comfortably inside every engine's quota. */
+const DEFAULT_MAX_BYTES = 256 * 1024
+
+/**
+ * `browser.storage`-backed port.
+ *
+ * Writes are whole-bundle rather than incremental. That is the right trade for
+ * a flight recorder: the recorder already debounces, so writes are rare, and a
+ * single atomic key means a worker killed mid-write leaves the previous
+ * generation's bundle intact instead of a half-applied delta.
+ */
+export function extensionStoragePersistence(
+  options: ExtensionPersistenceOptions
+): ObservabilityPersistence {
+  const { key, maxBytes = DEFAULT_MAX_BYTES } = options
+  const area = options.area ?? defaultArea()
+
+  return {
+    async load(): Promise<PersistedState | undefined> {
+      try {
+        const raw: unknown = await area.get(key)
+        if (raw === null || typeof raw !== "object") {
+          return undefined
+        }
+        const value: unknown = Reflect.get(raw, key)
+        return isPersistedState(value) ? value : undefined
+      } catch {
+        // A storage read failure must never break the thing being observed.
+        return undefined
+      }
+    },
+
+    async save(state: PersistedState): Promise<void> {
+      try {
+        await area.set({ [key]: fitToBudget(state, maxBytes) })
+      } catch {
+        // Same contract as load: observability degrades, the extension does not.
+      }
+    },
+
+    async clear(): Promise<void> {
+      try {
+        await area.remove(key)
+      } catch {
+        // ignore
+      }
+    },
+  }
+}
+
+function defaultArea(): StorageAreaLike {
+  // eslint-disable-next-line no-restricted-globals -- `browser` is absent on Chrome; this port is used by both engines
+  const api: unknown = typeof browser === "undefined" ? chrome : browser
+  const storage: unknown =
+    api !== null && typeof api === "object"
+      ? Reflect.get(api, "storage")
+      : undefined
+  const local: unknown =
+    storage !== null && typeof storage === "object"
+      ? Reflect.get(storage, "local")
+      : undefined
+  if (local === null || typeof local !== "object") {
+    throw new Error("extensionStoragePersistence: no storage.local available")
+  }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowed structurally above
+  return local as StorageAreaLike
+}
+
+/**
+ * Shed the oldest events until the serialized bundle fits `maxBytes`. Metrics
+ * and snapshots are never shed: they are small, fixed-size, and are the part a
+ * bug report needs most.
+ */
+function fitToBudget(state: PersistedState, maxBytes: number): PersistedState {
+  let candidate = state
+  let size = byteLength(candidate)
+  if (size <= maxBytes) {
+    return candidate
+  }
+  let events = candidate.events
+  let dropped = candidate.dropped
+  // Halve repeatedly rather than shedding one at a time: this runs on the
+  // worker's thread and an O(n) stringify per event would be pathological.
+  while (size > maxBytes && events.length > 1) {
+    const keep = Math.floor(events.length / 2)
+    dropped += events.length - keep
+    events = events.slice(events.length - keep)
+    candidate = { ...state, events, dropped }
+    size = byteLength(candidate)
+  }
+  return candidate
+}
+
+function byteLength(value: unknown): number {
+  try {
+    return JSON.stringify(value).length
+  } catch {
+    // A cyclic or exotic payload cannot be budgeted; report it as infinite so
+    // the caller sheds events rather than writing something unbounded.
+    return Number.POSITIVE_INFINITY
+  }
+}
+
+function isPersistedState(value: unknown): value is PersistedState {
+  if (value === null || typeof value !== "object") {
+    return false
+  }
+  return (
+    Reflect.get(value, "version") === 1 &&
+    Array.isArray(Reflect.get(value, "events")) &&
+    typeof Reflect.get(value, "namespace") === "string"
+  )
+}

--- a/extensions/common/src/observability/recorder.ts
+++ b/extensions/common/src/observability/recorder.ts
@@ -1,0 +1,397 @@
+/**
+ * The recorder — the facade every extension's observability adapter wraps.
+ * Tier-1: it persists through a port, so it is safe in a background worker or
+ * a page, and safe under test with {@link memoryPersistence}.
+ *
+ * Composition (the "flight recorder" arrangement):
+ *
+ *     record(event)
+ *          │
+ *          ├──► RingBuffer      bounded event timeline
+ *          ├──► MetricsStore    counters + aggregates
+ *          └──► snapshots       "what does the extension currently believe"
+ *                    │
+ *                    ├──► invariants ──► HealthReport
+ *                    └──► export()   ──► DiagnosticsBundle (user-attachable)
+ *
+ * Three constraints shape every decision here:
+ *
+ *   1. **Nothing leaves the machine.** There is no network path in this module
+ *      and none is intended. Diagnostics are exported by the user, explicitly.
+ *   2. **Bounded footprint.** Fixed ring capacity, no metric labels, capped
+ *      snapshot map, byte-budgeted persistence.
+ *   3. **MV3 is lossy.** The worker can be killed at any instant, so state is
+ *      rehydrated on construction and flushed on a short debounce, with
+ *      `error`-severity events forcing an immediate write.
+ */
+
+import { runInvariants, scoreHealth } from "./invariants"
+import { MetricsStore } from "./metrics"
+import { memoryPersistence } from "./persistence"
+import { RingBuffer } from "./ring-buffer"
+import type {
+  DiagnosticsBundle,
+  HealthReport,
+  Invariant,
+  JsonValue,
+  ObservabilityEvent,
+  ObservabilityPersistence,
+  PersistedState,
+  Severity,
+} from "./types"
+
+export type RecorderOptions<Ctx> = {
+  /** Workspace-scoped name; also the storage-key prefix on the debug page. */
+  namespace: string
+  /** Ring capacity. Default 500 — a few hours of a busy extension's decisions. */
+  capacity?: number
+  /** Debounce before a persistence write. Default 1000 ms. */
+  flushIntervalMs?: number
+  /** Cap on one event's serialized `detail`. Default 2 KB; overflow is elided. */
+  maxDetailBytes?: number
+  /** Cap on the snapshot map. Default 200 keys; oldest-written keys evicted. */
+  maxSnapshots?: number
+  /** Where to persist. Defaults to in-memory (i.e. nothing survives a restart). */
+  persistence?: ObservabilityPersistence
+  /** Consistency checks evaluated by {@link Recorder.health}. */
+  invariants?: ReadonlyArray<Invariant<Ctx>>
+  /** Injectable clock, for deterministic tests. */
+  now?: () => number
+  /**
+   * Optional live echo, e.g. `console.debug`. Off by default: an always-on
+   * console firehose is its own kind of bad citizenship. The adapter decides
+   * whether a debug preference turns it on.
+   */
+  echo?: (event: ObservabilityEvent) => void
+}
+
+/** Fields an adapter supplies when recording. */
+export type RecordInput<TKind extends string> = {
+  kind: TKind
+  severity?: Severity
+  subject?: number | string
+  detail?: JsonValue
+}
+
+export class Recorder<
+  TKind extends string = string,
+  TCounter extends string = string,
+  TAggregate extends string = string,
+  Ctx = void,
+> {
+  readonly namespace: string
+  readonly metrics: MetricsStore<TCounter, TAggregate>
+
+  // Events are written through `record`, whose input is typed to the adapter's
+  // `TKind` union — that is where a typo is a real bug and where the union
+  // earns its keep. On the read side they are plain string-kinded: a bundle
+  // rehydrated from disk was written by some build of this extension, possibly
+  // an older one, and disk cannot vouch for today's union. Widening here is
+  // what lets hydration be honest instead of asserting a claim it cannot check.
+  private readonly buffer: RingBuffer<ObservabilityEvent>
+  private readonly persistence: ObservabilityPersistence
+  private readonly invariants: ReadonlyArray<Invariant<Ctx>>
+  private readonly now: () => number
+  private readonly flushIntervalMs: number
+  private readonly maxDetailBytes: number
+  private readonly maxSnapshots: number
+  private readonly echo?: (event: ObservabilityEvent) => void
+
+  private snapshots = new Map<string, JsonValue>()
+  private seq = 0
+  private errorCount = 0
+  private flushTimer: ReturnType<typeof setTimeout> | undefined
+  private pendingFlush: Promise<void> | undefined
+  private paused = false
+  private disposed = false
+  private hydrated = false
+
+  constructor(options: RecorderOptions<Ctx>) {
+    this.namespace = options.namespace
+    this.buffer = new RingBuffer(options.capacity ?? 500)
+    this.persistence = options.persistence ?? memoryPersistence()
+    this.invariants = options.invariants ?? []
+    this.now = options.now ?? ((): number => Date.now())
+    this.flushIntervalMs = options.flushIntervalMs ?? 1000
+    this.maxDetailBytes = options.maxDetailBytes ?? 2048
+    this.maxSnapshots = options.maxSnapshots ?? 200
+    this.echo = options.echo
+    this.metrics = new MetricsStore<TCounter, TAggregate>()
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────────────────
+  //
+  // Every subsystem that starts something must be able to stop it. The only
+  // thing this one starts is a debounce timer, and `dispose` flushes it rather
+  // than dropping the events it was holding.
+
+  /**
+   * Load persisted state. Call once, early in worker startup: an MV3 event
+   * page is recycled constantly, and a recorder that starts empty on every
+   * respawn measures the worker's lifetime instead of the extension's.
+   */
+  async hydrate(): Promise<void> {
+    if (this.hydrated || this.disposed) {
+      return
+    }
+    this.hydrated = true
+    const stored = await this.persistence.load()
+    if (stored?.namespace !== this.namespace) {
+      // Absent, or written by a different workspace sharing the storage area.
+      return
+    }
+    const events = stored.events.filter(isEventShape)
+    const restored = RingBuffer.from(
+      this.buffer.capacity,
+      events,
+      stored.dropped
+    )
+    this.buffer.clear()
+    this.buffer.extend(restored.toArray())
+    this.metrics.hydrate(stored.metrics)
+    for (const [key, value] of Object.entries(stored.snapshots)) {
+      this.snapshots.set(key, value)
+    }
+    this.errorCount = events.filter((e) => e.severity === "error").length
+    this.seq = events.reduce((max, e) => Math.max(max, e.seq), 0)
+  }
+
+  /** Stop recording without losing what is already held. */
+  pause(): void {
+    this.paused = true
+  }
+
+  resume(): void {
+    if (!this.disposed) {
+      this.paused = false
+    }
+  }
+
+  /** Cancel the debounce timer and write out whatever it was holding. */
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
+    this.paused = true
+    this.cancelTimer()
+    await this.flush()
+  }
+
+  // ── Recording ───────────────────────────────────────────────────────────
+
+  /** Record one event. Never throws; observability must not break the subject. */
+  record(input: RecordInput<TKind>): void {
+    if (this.paused || this.disposed) {
+      return
+    }
+    const severity = input.severity ?? "info"
+    this.seq += 1
+    const event: ObservabilityEvent = {
+      seq: this.seq,
+      t: this.now(),
+      kind: input.kind,
+      severity,
+      ...(input.subject === undefined ? {} : { subject: input.subject }),
+      ...(input.detail === undefined
+        ? {}
+        : { detail: clamp(input.detail, this.maxDetailBytes) }),
+    }
+    this.buffer.push(event)
+    if (severity === "error") {
+      this.errorCount += 1
+    }
+    this.echo?.(event)
+    // An error is exactly the event most likely to be followed by the worker
+    // dying, so it does not get to wait out a debounce window.
+    if (severity === "error") {
+      void this.flush()
+    } else {
+      this.scheduleFlush()
+    }
+  }
+
+  /** Increment a counter. Sugar over `recorder.metrics.increment`. */
+  count(name: TCounter, by = 1): void {
+    if (this.paused || this.disposed) {
+      return
+    }
+    this.metrics.increment(name, by)
+    this.scheduleFlush()
+  }
+
+  /** Fold one numeric observation (a latency, a duration) into an aggregate. */
+  observe(name: TAggregate, value: number): void {
+    if (this.paused || this.disposed) {
+      return
+    }
+    this.metrics.observe(name, value)
+    this.scheduleFlush()
+  }
+
+  /**
+   * Publish "what the extension currently believes" about one subject. Events
+   * say what happened; snapshots say what state that left behind — which is
+   * the question a user's "this tab never woke up" actually asks.
+   */
+  setSnapshot(key: string, value: JsonValue): void {
+    if (this.paused || this.disposed) {
+      return
+    }
+    // Re-insert so the map's insertion order tracks recency for eviction.
+    this.snapshots.delete(key)
+    this.snapshots.set(key, clamp(value, this.maxDetailBytes))
+    while (this.snapshots.size > this.maxSnapshots) {
+      const oldest = this.snapshots.keys().next()
+      if (oldest.done === true) {
+        break
+      }
+      this.snapshots.delete(oldest.value)
+    }
+    this.scheduleFlush()
+  }
+
+  deleteSnapshot(key: string): void {
+    if (this.snapshots.delete(key)) {
+      this.scheduleFlush()
+    }
+  }
+
+  // ── Reading ─────────────────────────────────────────────────────────────
+
+  /** The timeline, oldest first. */
+  events(): Array<ObservabilityEvent> {
+    return this.buffer.toArray()
+  }
+
+  /** Events evicted by the ring buffer since install. */
+  get dropped(): number {
+    return this.buffer.dropped
+  }
+
+  snapshotEntries(): Record<string, JsonValue> {
+    return Object.fromEntries(this.snapshots)
+  }
+
+  /** Run every invariant and score the result. */
+  async health(ctx: Ctx): Promise<HealthReport> {
+    const t = this.now()
+    const results = await runInvariants(this.invariants, ctx, t)
+    const recentErrors = this.buffer
+      .toArray()
+      .filter((e) => e.severity === "error").length
+    const { score, status } = scoreHealth(results, recentErrors)
+    return {
+      score,
+      status,
+      invariants: results,
+      recentErrors,
+      generatedAt: t,
+    }
+  }
+
+  /**
+   * The user-attachable bundle. `runtime`/`extension` are supplied by the
+   * caller rather than read here, because this module must stay usable from a
+   * page, a worker, and a test without branching on which globals exist.
+   */
+  async export(
+    ctx: Ctx,
+    meta: {
+      extension: { name: string; version: string }
+      runtime: { userAgent: string; platform?: string }
+    }
+  ): Promise<DiagnosticsBundle> {
+    return {
+      version: 1,
+      namespace: this.namespace,
+      generatedAt: this.now(),
+      extension: meta.extension,
+      runtime: meta.runtime,
+      health: await this.health(ctx),
+      metrics: this.metrics.snapshot(),
+      snapshots: this.snapshotEntries(),
+      events: this.events(),
+      dropped: this.buffer.dropped,
+    }
+  }
+
+  // ── Persistence ─────────────────────────────────────────────────────────
+
+  /** Write current state through the port immediately. */
+  flush(): Promise<void> {
+    this.cancelTimer()
+    const state: PersistedState = {
+      version: 1,
+      namespace: this.namespace,
+      events: this.buffer.toArray(),
+      metrics: this.metrics.snapshot(),
+      snapshots: this.snapshotEntries(),
+      dropped: this.buffer.dropped,
+      updatedAt: this.now(),
+    }
+    this.pendingFlush = this.persistence.save(state)
+    return this.pendingFlush
+  }
+
+  /** Reset everything, on disk and in memory. The debug page's "clear". */
+  async clear(): Promise<void> {
+    this.cancelTimer()
+    this.buffer.clear()
+    this.metrics.reset()
+    this.snapshots.clear()
+    this.errorCount = 0
+    this.seq = 0
+    await this.persistence.clear()
+  }
+
+  /** Total `error`-severity events recorded this generation (pre-eviction). */
+  get errors(): number {
+    return this.errorCount
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer !== undefined || this.disposed) {
+      return
+    }
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = undefined
+      void this.flush()
+    }, this.flushIntervalMs)
+  }
+
+  private cancelTimer(): void {
+    if (this.flushTimer !== undefined) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = undefined
+    }
+  }
+}
+
+/**
+ * Bound one `detail` payload's serialized size. An adapter that accidentally
+ * records a whole DOM string should cost one elided event, not the buffer.
+ */
+function clamp(value: JsonValue, maxBytes: number): JsonValue {
+  let serialized: string
+  try {
+    serialized = JSON.stringify(value)
+  } catch {
+    return "[unserializable]"
+  }
+  if (serialized.length <= maxBytes) {
+    return value
+  }
+  return `${serialized.slice(0, maxBytes)}…[truncated ${serialized.length - maxBytes} chars]`
+}
+
+function isEventShape(value: unknown): value is ObservabilityEvent {
+  if (value === null || typeof value !== "object") {
+    return false
+  }
+  return (
+    typeof Reflect.get(value, "seq") === "number" &&
+    typeof Reflect.get(value, "t") === "number" &&
+    typeof Reflect.get(value, "kind") === "string"
+  )
+}

--- a/extensions/common/src/observability/ring-buffer.ts
+++ b/extensions/common/src/observability/ring-buffer.ts
@@ -1,0 +1,102 @@
+/**
+ * Fixed-capacity ring buffer — tier-0 (pure, no browser globals).
+ *
+ * The flight recorder's storage primitive. Capacity is fixed at construction
+ * and never grows: once full, the oldest entry is overwritten. That is the
+ * whole point — an extension that runs for months must have a *constant* upper
+ * bound on what it keeps, both in memory and in `storage.local`.
+ *
+ * `dropped` is exposed rather than hidden because "how much history did I lose
+ * before the bug reproduced?" is a real question when reading a timeline.
+ */
+export class RingBuffer<T> {
+  readonly capacity: number
+
+  /** Backing store. Physical order; {@link toArray} restores logical order. */
+  private items: Array<T> = []
+  /** Index of the next write. */
+  private cursor = 0
+  private evicted = 0
+
+  constructor(capacity: number) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new RangeError(
+        `RingBuffer capacity must be a positive integer, got ${String(capacity)}`
+      )
+    }
+    this.capacity = capacity
+  }
+
+  /** Number of entries currently held (≤ capacity). */
+  get size(): number {
+    return this.items.length
+  }
+
+  /** Total entries overwritten since construction. */
+  get dropped(): number {
+    return this.evicted
+  }
+
+  /** Append one entry, evicting the oldest when at capacity. */
+  push(item: T): void {
+    if (this.items.length < this.capacity) {
+      this.items.push(item)
+      this.cursor = this.items.length % this.capacity
+      return
+    }
+    this.items[this.cursor] = item
+    this.cursor = (this.cursor + 1) % this.capacity
+    this.evicted += 1
+  }
+
+  /** Append many entries in order. */
+  extend(items: Iterable<T>): void {
+    for (const item of items) {
+      this.push(item)
+    }
+  }
+
+  /** Entries in insertion order, oldest first. Always a fresh array. */
+  toArray(): Array<T> {
+    if (this.items.length < this.capacity) {
+      return [...this.items]
+    }
+    return [
+      ...this.items.slice(this.cursor),
+      ...this.items.slice(0, this.cursor),
+    ]
+  }
+
+  /** The `n` most recent entries, oldest first. */
+  tail(n: number): Array<T> {
+    if (n <= 0) {
+      return []
+    }
+    const all = this.toArray()
+    return all.slice(Math.max(0, all.length - n))
+  }
+
+  /** Drop every entry. The eviction counter is preserved deliberately. */
+  clear(): void {
+    this.items = []
+    this.cursor = 0
+  }
+
+  /**
+   * Rebuild a buffer from persisted entries. Entries beyond `capacity` are
+   * discarded oldest-first and counted as dropped, so a capacity *reduction*
+   * between versions shrinks the footprint immediately instead of on the next
+   * few hundred writes.
+   */
+  static from<T>(
+    capacity: number,
+    items: ReadonlyArray<T>,
+    dropped = 0
+  ): RingBuffer<T> {
+    const buffer = new RingBuffer<T>(capacity)
+    const overflow = Math.max(0, items.length - capacity)
+    buffer.extend(items.slice(overflow))
+    buffer.evicted = dropped + overflow
+    return buffer
+  }
+}

--- a/extensions/common/src/observability/types.ts
+++ b/extensions/common/src/observability/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared observability vocabulary — tier-0 (pure types, no browser globals).
+ *
+ * This subsystem is deliberately **observability**, not telemetry: nothing here
+ * ever leaves the machine. Every primitive is bounded (ring buffer, fixed
+ * counter set, capped snapshot map) so a long-lived extension cannot grow its
+ * `storage.local` footprint without limit — the constraint that makes this
+ * pattern safe to ship on an AMO-signed extension.
+ *
+ * Extensions do not use these types directly; they instantiate a
+ * {@link "./recorder".Recorder} with their own event-kind union, counter names
+ * and invariants. That is the whole adapter seam: the core knows about
+ * *shapes*, the extension knows about *meanings*.
+ */
+
+/** JSON the recorder is willing to persist. Structurally serializable only. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Array<JsonValue>
+  | { [key: string]: JsonValue }
+
+/** How loud an event is. `error` forces an immediate persistence flush. */
+export type Severity = "debug" | "info" | "warn" | "error"
+
+/**
+ * One recorded event. `TKind` is supplied by the adapting extension as a string
+ * union, which is what makes the timeline greppable and the debug page able to
+ * filter without stringly-typed guesswork.
+ */
+export type ObservabilityEvent<TKind extends string = string> = {
+  /** Monotonic within one worker generation; resets when the worker respawns. */
+  seq: number
+  /** Epoch milliseconds. */
+  t: number
+  kind: TKind
+  severity: Severity
+  /**
+   * What the event is about — a tab id, a request id, an alarm name. Optional
+   * because plenty of events are about the extension as a whole.
+   */
+  subject?: number | string
+  /** Bounded, JSON-serializable payload. Large values are clamped on record. */
+  detail?: JsonValue
+}
+
+/** Aggregated form of an observed numeric series (no buckets — storage creep). */
+export type Aggregate = {
+  count: number
+  sum: number
+  min: number
+  max: number
+  /** Most recent observation, which is usually the one being debugged. */
+  last: number
+}
+
+/**
+ * Point-in-time metric readout.
+ *
+ * Keys are plain strings rather than the store's name unions on purpose: a
+ * snapshot is a serialization artifact — it round-trips through storage and is
+ * rendered by a debug page that iterates it — so a union here would buy nothing
+ * and force a cast at every boundary. The typing that matters is on
+ * `MetricsStore`'s write and read methods, where a typo is a real bug.
+ */
+export type MetricsSnapshot = {
+  counters: Record<string, number>
+  aggregates: Record<string, Aggregate>
+}
+
+/** The result of evaluating one invariant. */
+export type InvariantOutcome =
+  | { ok: true }
+  | { ok: false; details: JsonValue }
+  /**
+   * The invariant could not be evaluated (a browser API was unavailable, state
+   * had not hydrated yet). Distinct from a violation on purpose: an unknown
+   * must never be reported to the user as a failure.
+   */
+  | { ok: "unknown"; details?: JsonValue }
+
+/**
+ * A consistency check over some caller-supplied context. Invariants are pure
+ * with respect to `Ctx` — gathering the context is the caller's job, so the
+ * checks themselves stay testable without any browser mock.
+ */
+export type Invariant<Ctx> = {
+  name: string
+  /** Human-readable statement of what must hold, shown on the debug page. */
+  description: string
+  check(ctx: Ctx): InvariantOutcome | Promise<InvariantOutcome>
+}
+
+/** One invariant's evaluation, as rendered on the debug page. */
+export type InvariantResult = {
+  name: string
+  description: string
+  status: "ok" | "violated" | "unknown"
+  details?: JsonValue
+  /** Epoch ms the check ran. */
+  t: number
+}
+
+/**
+ * The extension's own answer to "am I working?" — computed locally from
+ * invariants and recent error events, never from a remote service.
+ */
+export type HealthReport = {
+  /** 0–100. 100 = every invariant holds and nothing recently errored. */
+  score: number
+  status: "healthy" | "degraded" | "unhealthy"
+  invariants: Array<InvariantResult>
+  /** Count of `error`-severity events still inside the ring buffer. */
+  recentErrors: number
+  generatedAt: number
+}
+
+/**
+ * Everything the recorder persists. Kept flat and versioned so a schema change
+ * can be detected and discarded rather than mis-parsed.
+ */
+export type PersistedState<TKind extends string = string> = {
+  version: 1
+  namespace: string
+  events: Array<ObservabilityEvent<TKind>>
+  metrics: MetricsSnapshot
+  snapshots: Record<string, JsonValue>
+  /** Events evicted by the ring buffer since install — the creep counter. */
+  dropped: number
+  updatedAt: number
+}
+
+/**
+ * The user-exportable diagnostics bundle: what someone attaches to a GitHub
+ * issue instead of describing the bug in prose. Contains no browsing content
+ * beyond what the adapter chose to record.
+ */
+export type DiagnosticsBundle<TKind extends string = string> = {
+  version: 1
+  namespace: string
+  generatedAt: number
+  extension: { name: string; version: string }
+  runtime: { userAgent: string; platform?: string }
+  health: HealthReport
+  metrics: MetricsSnapshot
+  snapshots: Record<string, JsonValue>
+  events: Array<ObservabilityEvent<TKind>>
+  dropped: number
+}
+
+/**
+ * Where persisted state lives. The core never touches `browser.storage`
+ * itself — an extension can back this with session storage, IndexedDB, or a
+ * plain in-memory object under test.
+ */
+export type ObservabilityPersistence = {
+  load(): Promise<PersistedState | undefined>
+  save(state: PersistedState): Promise<void>
+  clear(): Promise<void>
+}

--- a/extensions/suspender-ledger/README.md
+++ b/extensions/suspender-ledger/README.md
@@ -30,10 +30,12 @@ entry point by `vite.config.ts` (the shared `extensionConfig` build):
 | Service worker | `src/worker/worker.ts`              | `worker.js` | Background logic: discard scheduling, prefs, context menu, keyboard commands |
 | Content script | `src/content/watch.ts`              | `watch.js`  | Per-page activity detection (input/scroll/visibility) reported to the worker |
 | Popup          | `popup.html` → `src/popup/index.ts` | `popup.js`  | Toolbar UI: per-tab actions, whitelist toggle, settings form                 |
+| Diagnostics    | `debug.html` → `src/debug/index.ts` | `debug.js`  | Local health, metrics and event timeline ([docs](docs/observability.md))     |
 
 Supporting modules:
 
-- `src/worker/core/` — `discard`, `navigate`, `prefs`, `startup`, `utils`
+- `src/worker/core/` — `discard`, `navigate`, `prefs`, `startup`, `utils`,
+  `observability` (the local flight recorder — see `docs/observability.md`)
   (the suspension engine and storage layer)
 - `src/worker/menu.ts`, `src/worker/modes/number.ts` — context menu and the
   "keep N most-recent tabs loaded" mode

--- a/extensions/suspender-ledger/amo-notes.md
+++ b/extensions/suspender-ledger/amo-notes.md
@@ -11,3 +11,25 @@ No page content, tab data, or user activity is transmitted off-device; all
 processing is local. The content script (`watch.js`) only tracks whether the
 page has unsaved form input and the time of the last visibility change — both
 are used solely to decide whether a tab is safe to suspend.
+
+## Local diagnostics (`debug.html`)
+
+The extension keeps a local, bounded diagnostic log so users can self-diagnose
+reliability problems and attach a report to a GitHub issue. This is offline
+diagnostics, not telemetry — there is no network code anywhere in the
+subsystem, and nothing is uploaded, ever.
+
+- **Where it is stored:** a single `storage.local` key (`sl.observability.v1`).
+- **How much:** a fixed-capacity ring buffer of 500 events, hard-capped at
+  256 KB. It cannot grow beyond that regardless of how long the extension runs.
+- **What it contains:** the extension's own decisions — alarm scheduling, sweep
+  results, per-tab suspend outcomes and skip reasons — plus counters and its own
+  invariant checks.
+- **Tab identity:** origin only (`https://example.com`). Paths, query strings,
+  page titles and page content are never recorded.
+- **How it leaves the machine:** only if the user clicks "Export JSON" on
+  `debug.html`, which produces a file they choose what to do with.
+
+`data_collection_permissions` is declared as `["none"]`, which remains accurate:
+nothing is collected in the sense the policy means. Full design notes are in
+`docs/observability.md`.

--- a/extensions/suspender-ledger/debug.html
+++ b/extensions/suspender-ledger/debug.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <title>Suspender Ledger — Diagnostics</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: var(--sl-bg, #1a1a1a);
+        color: var(--sl-fg, #e0e0e0);
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">Loading diagnostics…</div>
+    <script type="module" src="./src/debug/index.ts"></script>
+  </body>
+</html>

--- a/extensions/suspender-ledger/docs/observability.md
+++ b/extensions/suspender-ledger/docs/observability.md
@@ -1,0 +1,204 @@
+# Observability
+
+Suspender Ledger can explain itself. It records what it decided, what it
+believes, and whether its own invariants still hold — all locally, all bounded,
+and all readable from `debug.html`.
+
+The distinction that shapes every decision below: **telemetry** implies data
+leaving the machine; **observability** just means the system can account for
+itself. This is the second thing. There is no network path anywhere in the
+subsystem, and none is planned.
+
+---
+
+## Why this exists
+
+The extension had a reliability bug that was effectively undiagnosable with the
+tools available: tabs sporadically stopped being suspended, with no error, no
+failing call, and nothing in any log — because nothing was failing. The
+scheduler simply never ran (see [The scheduler bug](#the-scheduler-bug) below).
+
+`console.log` cannot answer that class of question. By the time a user notices
+"my tabs stopped suspending", the console is closed, the event page has been
+recycled a hundred times, and every line of evidence is gone. What is needed is
+a flight recorder: bounded, persistent, and readable after the fact.
+
+---
+
+## Architecture
+
+Everything generic lives in `@some-extension/common/observability`; this
+extension supplies only the parts that carry domain meaning.
+
+```
+              browser APIs / decisions
+                        │
+                        ▼
+                 record(event)                  ← worker/core/observability.ts
+                        │
+     ┌──────────────────┼──────────────────┐
+     ▼                  ▼                  ▼
+ RingBuffer        MetricsStore        snapshots
+ (500 events)   (counters + timings)  ("what I believe")
+     │                  │                  │
+     └──────────────────┼──────────────────┘
+                        ▼
+                 invariant checks  ──► HealthReport
+                        │
+                        ▼
+                    debug.html  ──► Export JSON (user-initiated)
+```
+
+| Layer                                                                     | Where                                  |
+| ------------------------------------------------------------------------- | -------------------------------------- |
+| Ring buffer, metrics, invariant runner, health scoring, persistence ports | `extensions/common/src/observability/` |
+| Event kinds, counters, invariants, context collector                      | `src/worker/core/observability.ts`     |
+| `trace()` shim over the recorder                                          | `src/worker/core/trace.ts`             |
+| Diagnostics page                                                          | `debug.html` + `src/debug/`            |
+
+### The adapter seam
+
+Adapting a second extension means writing one file — its own
+`observability.ts` — and nothing else:
+
+```ts
+export type MyEventKind = "job.started" | "job.failed" | …
+export type MyCounter   = "jobs_run" | "jobs_failed" | …
+export type MyAggregate = "job_duration_ms"
+
+export const myInvariants: ReadonlyArray<Invariant<MyContext>> = [ … ]
+
+export const obs = new Recorder<MyEventKind, MyCounter, MyAggregate, MyContext>({
+  namespace: "my-extension",
+  invariants: myInvariants,
+  persistence: extensionStoragePersistence({ key: "mx.observability.v1" }),
+})
+```
+
+The core knows about _shapes_; the adapter knows about _meanings_. Invariants
+are pure functions of a context object the adapter gathers, so they unit-test
+against plain object literals with no browser mock at all.
+
+---
+
+## Storage discipline
+
+An extension that runs for months must have a **constant** upper bound on what
+it keeps. Four independent limits enforce that:
+
+| Limit                    | Default  | What it bounds                          |
+| ------------------------ | -------- | --------------------------------------- |
+| Ring buffer capacity     | 500      | Retained events; oldest overwritten     |
+| Per-event `detail` clamp | 2 KB     | One fat payload cannot eat the buffer   |
+| Snapshot map cap         | 200 keys | Per-tab beliefs; oldest-written evicted |
+| Persisted bundle budget  | 256 KB   | Events shed oldest-first until it fits  |
+
+Writes are debounced (1 s) and whole-bundle under a single key, so a worker
+killed mid-write leaves the previous bundle intact rather than a half-applied
+delta. `error`-severity events bypass the debounce, because an error is the
+event most likely to be followed by the worker dying.
+
+Per-tab snapshots are dropped on `tabs.onRemoved`, so the map tracks the
+current profile rather than every tab ever opened.
+
+---
+
+## What is recorded — and what is not
+
+Tab URLs are recorded as **origin only** (`https://example.com`, never the path
+or query string). The questions this subsystem exists to answer — "why wasn't
+this tab suspended?" — are fully answerable from the origin plus the skip
+reason. A full URL is browsing content, and browsing content has no business
+being written to disk for diagnostics.
+
+Nothing is recorded from page content. No titles are stored (only whether a
+title _changed_), no form values, no history.
+
+**AMO posture:** this is offline diagnostics, the model Mozilla is most
+comfortable with — everything stays on the user's machine unless they
+explicitly choose to share it, via the Export JSON button. The manifest's
+`data_collection_permissions` remains `["none"]`, correctly: no data is
+collected in the sense AMO means it.
+
+---
+
+## The diagnostics page
+
+Reachable from the popup's **Diagnostics** link, or directly at
+`moz-extension://<id>/debug.html`.
+
+- **Health** — the 0–100 score, plus every invariant with its current status.
+  A violated invariant names the thing that broke, which is usually much nearer
+  the root cause than the symptom a user reports.
+- **Metrics** — counters (`suspend_attempts`, `suspend_noop`, `alarm_fires`, …)
+  and timing aggregates (avg/min/max, no histogram buckets — see storage
+  discipline).
+- **Current beliefs** — snapshots. Events say what happened; these say what
+  state that left behind. This is what answers "this tab never woke up."
+- **Timeline** — the ring buffer, newest first, filterable by event kind and by
+  tab id. Filtering to one tab id gives that tab's whole story in order.
+- **Export JSON** — the user-attachable bundle for a GitHub issue: health,
+  metrics, beliefs, and the full retained timeline.
+
+The page asks the _worker_ for its bundle rather than reading storage directly.
+The worker holds the live in-memory buffer (fresher than the last debounced
+flush), only the worker can evaluate invariants needing `tabs.query`, and
+sending a message wakes a recycled event page — so the page never reports on a
+worker that is merely asleep.
+
+---
+
+## Invariants
+
+| Name                        | What it catches                                                 |
+| --------------------------- | --------------------------------------------------------------- |
+| `SchedulerAlarmExists`      | Suspending is enabled but no sweep alarm is registered          |
+| `SchedulerAlarmNotStale`    | The alarm exists but is long past due                           |
+| `CheckRanRecently`          | No sweep in three intervals — **the scheduler bug's signature** |
+| `NoActiveTabSuspended`      | The foreground tab is discarded                                 |
+| `NoStrandedMarkerOnLiveTab` | A live tab wears 💤 — a rollback that never completed           |
+| `NoStuckInFlightSuspend`    | An attempt has been in flight over a minute, blocking that tab  |
+
+An invariant that cannot be evaluated reports `unknown`, never `violated`. An
+un-evaluable check is not evidence of breakage, and a health score that cries
+wolf on a fresh profile is worse than no score.
+
+---
+
+## The scheduler bug
+
+Recorded here because it is the reason the subsystem exists, and because the
+shape of it is worth recognising again.
+
+`number.install()` created the periodic sweep alarm with
+`when: Date.now() + period`. It is called from a `starters` callback, and
+`starters` run at **module evaluation on every worker generation** — MV3 event
+pages are recycled aggressively, and neither `onStartup` nor `onInstalled`
+fires on a respawn, so the startup gate has to open unconditionally.
+
+The extension registers `tabs.onUpdated`, `tabs.onActivated`,
+`runtime.onMessage` and more, so during active browsing the event page is woken
+every few seconds. Every wake re-armed the alarm from zero, pushing the next
+sweep another full interval into the future. The alarm could therefore only
+ever fire during a lull longer than the entire interval.
+
+Hence the symptom: suspension works fine on an idle machine and silently never
+happens while you are actually using the browser. Sporadic, not reproducible on
+demand, and invisible in logs — because nothing failed. Nothing _ran_.
+
+The fix is idempotency: create the alarm only when it is missing or its cadence
+changed (`src/worker/modes/number.ts`), with a startup watchdog that notices an
+absent or overdue alarm and sweeps immediately. `number.scheduler.test.ts` is
+the regression suite.
+
+Two secondary hardenings landed alongside it:
+
+- **Silent discard no-ops.** `chrome.tabs.discard` resolves for tabs the browser
+  then declines to discard. The tab stays live and keeps its 💤 marker forever,
+  indistinguishable from success at the call site. The outcome is now verified
+  against `tabs.get` (which reads cached metadata and cannot materialize a
+  discarded tab), counted as `suspend_noop`, and rolled back.
+- **Swallowed injection failures.** `executeScript` rejections in the sweep were
+  discarded whole (`() => []`), making "this tab is silently never eligible"
+  indistinguishable from "this tab is fine". The reason is now recorded as
+  `tab.meta_error`.

--- a/extensions/suspender-ledger/src/debug/debug.css
+++ b/extensions/suspender-ledger/src/debug/debug.css
@@ -1,0 +1,215 @@
+/* Copyright (c) 2026 paulgsc — MIT License
+ *
+ * Diagnostics page styling. Deliberately plain: this page is a debugging
+ * instrument, not product surface, and it must stay readable when the thing it
+ * reports on is broken. Everything is theme-token driven so it inherits the
+ * popup's palette. */
+
+:root {
+  --sl-bg: #1a1a1a;
+  --sl-fg: #e0e0e0;
+  --sl-muted: #8a8a8a;
+  --sl-panel: #232323;
+  --sl-border: #383838;
+  --sl-ok: #4ade80;
+  --sl-warn: #fbbf24;
+  --sl-bad: #f87171;
+  --sl-accent: #60a5fa;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --sl-bg: #fafafa;
+    --sl-fg: #1a1a1a;
+    --sl-muted: #666;
+    --sl-panel: #fff;
+    --sl-border: #ddd;
+    --sl-ok: #15803d;
+    --sl-warn: #a16207;
+    --sl-bad: #b91c1c;
+    --sl-accent: #1d4ed8;
+  }
+}
+
+#app {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 4rem;
+}
+
+.sl-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.sl-head h1 {
+  font-size: 1.15rem;
+  margin: 0;
+}
+
+.sl-sub {
+  color: var(--sl-muted);
+  font-size: 0.8rem;
+}
+
+.sl-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.35rem;
+  border: 1px solid var(--sl-border);
+  background: var(--sl-panel);
+  color: var(--sl-fg);
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--sl-accent);
+}
+
+section {
+  background: var(--sl-panel);
+  border: 1px solid var(--sl-border);
+  border-radius: 0.5rem;
+  padding: 0.9rem 1rem;
+  margin-bottom: 1rem;
+}
+
+section > h2 {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--sl-muted);
+  margin: 0 0 0.75rem;
+}
+
+.sl-score {
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.sl-score small {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--sl-muted);
+}
+
+.ok {
+  color: var(--sl-ok);
+}
+.warn {
+  color: var(--sl-warn);
+}
+.bad {
+  color: var(--sl-bad);
+}
+.muted {
+  color: var(--sl-muted);
+}
+
+ul.sl-checks {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+}
+
+ul.sl-checks li {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  border-top: 1px solid var(--sl-border);
+}
+
+ul.sl-checks .sl-desc {
+  color: var(--sl-muted);
+  font-size: 0.8rem;
+}
+
+.sl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+  gap: 0.5rem 1rem;
+}
+
+.sl-metric {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-bottom: 1px dotted var(--sl-border);
+  padding: 0.2rem 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.sl-metric .k {
+  color: var(--sl-muted);
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+table.sl-events {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+table.sl-events th {
+  text-align: left;
+  color: var(--sl-muted);
+  font-weight: 500;
+  padding: 0.25rem 0.5rem 0.4rem 0;
+}
+
+table.sl-events td {
+  padding: 0.2rem 0.5rem 0.2rem 0;
+  border-top: 1px solid var(--sl-border);
+  vertical-align: top;
+}
+
+table.sl-events td.detail {
+  color: var(--sl-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-word;
+}
+
+.sl-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.sl-filter input,
+.sl-filter select {
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 0.35rem;
+  border: 1px solid var(--sl-border);
+  background: var(--sl-bg);
+  color: var(--sl-fg);
+}
+
+.sl-empty {
+  color: var(--sl-muted);
+  font-size: 0.85rem;
+  padding: 0.5rem 0;
+}
+
+.sl-scroll {
+  max-height: 28rem;
+  overflow-y: auto;
+}

--- a/extensions/suspender-ledger/src/debug/index.ts
+++ b/extensions/suspender-ledger/src/debug/index.ts
@@ -1,0 +1,436 @@
+// Copyright (c) 2026 paulgsc — MIT License
+//
+// Diagnostics page (`debug.html`) — a miniature Grafana for one extension.
+//
+// It answers, without a server and without any data leaving the machine:
+//
+//   - is the extension healthy right now, and which invariant broke first?
+//   - how many suspends has it attempted, landed, and silently failed?
+//   - what happened to *this* tab, in order?
+//
+// The page is a pure projection of worker state (Good-Citizen Charter: a view,
+// never a state authority). It holds no state of its own beyond the current
+// filter, re-fetches on every refresh, and every action it offers is a message
+// to the worker.
+
+import type {
+  DiagnosticsBundle,
+  InvariantResult,
+  JsonValue,
+  ObservabilityEvent,
+} from "@some-extension/common/observability"
+import type { DebugToWorkerMessage } from "@suspender/types/messages"
+
+import "./debug.css"
+
+type Bundle = DiagnosticsBundle
+
+/** Current view filter. The only state this page owns. */
+type Filter = { kind: string; subject: string }
+
+let filter: Filter = { kind: "", subject: "" }
+let bundle: Bundle | undefined
+
+function send(message: DebugToWorkerMessage): Promise<unknown> {
+  return Promise.resolve(browser.runtime.sendMessage(message))
+}
+
+function isBundle(value: unknown): value is Bundle {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    Reflect.get(value, "version") === 1 &&
+    Array.isArray(Reflect.get(value, "events"))
+  )
+}
+
+// ── Formatting ───────────────────────────────────────────────────────────────
+
+const pad = (n: number): string => String(n).padStart(2, "0")
+
+function clockTime(t: number): string {
+  const d = new Date(t)
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
+function relative(t: number, now: number): string {
+  const seconds = Math.round((now - t) / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h ago`
+  return `${Math.round(seconds / 86400)}d ago`
+}
+
+function compact(value: JsonValue | undefined): string {
+  if (value === undefined) return ""
+  if (typeof value === "string") return value
+  if (typeof value !== "object" || value === null) return String(value)
+  if (Array.isArray(value)) return value.map((v) => compact(v)).join(" ")
+  return Object.entries(value)
+    .filter(([, v]) => v !== null && v !== "")
+    .map(([k, v]) =>
+      typeof v === "object" && v !== null
+        ? `${k}=${compact(v)}`
+        : `${k}=${String(v)}`
+    )
+    .join(" ")
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  attrs: { class?: string; text?: string } = {},
+  children: Array<Node> = []
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag)
+  if (attrs.class !== undefined) node.className = attrs.class
+  if (attrs.text !== undefined) node.textContent = attrs.text
+  for (const child of children) node.appendChild(child)
+  return node
+}
+
+// ── Sections ─────────────────────────────────────────────────────────────────
+
+function severityClass(status: InvariantResult["status"]): string {
+  return status === "ok" ? "ok" : status === "violated" ? "bad" : "muted"
+}
+
+function healthSection(b: Bundle): HTMLElement {
+  const { health } = b
+  const cls =
+    health.status === "healthy"
+      ? "ok"
+      : health.status === "degraded"
+        ? "warn"
+        : "bad"
+
+  const score = el("div", { class: `sl-score ${cls}` })
+  score.append(
+    document.createTextNode(String(health.score)),
+    el("small", { text: ` / 100 · ${health.status}` })
+  )
+
+  const checks = el("ul", { class: "sl-checks" })
+  for (const inv of health.invariants) {
+    const mark =
+      inv.status === "ok" ? "✓" : inv.status === "violated" ? "✕" : "–"
+    const body = el("div")
+    body.append(
+      el("div", { text: inv.name }),
+      el("div", { class: "sl-desc", text: inv.description })
+    )
+    if (inv.details !== undefined) {
+      body.appendChild(
+        el("div", { class: "sl-desc bad", text: compact(inv.details) })
+      )
+    }
+    checks.appendChild(
+      el("li", {}, [
+        el("span", { class: severityClass(inv.status), text: mark }),
+        body,
+      ])
+    )
+  }
+
+  const section = el("section")
+  section.append(
+    el("h2", { text: "Health" }),
+    score,
+    el("div", {
+      class: "sl-sub",
+      text:
+        health.recentErrors === 0
+          ? "No errors in the retained window."
+          : `${health.recentErrors} error event(s) in the retained window.`,
+    }),
+    checks
+  )
+  return section
+}
+
+/** Counters worth reading first, in the order a reliability question asks them. */
+const COUNTER_ORDER = [
+  "worker_starts",
+  "alarm_installs",
+  "alarm_kept",
+  "alarm_fires",
+  "alarm_missed",
+  "alarm_repairs",
+  "checks_run",
+  "checks_skipped",
+  "check_errors",
+  "tabs_scanned",
+  "tabs_skipped",
+  "tabs_selected",
+  "suspend_attempts",
+  "suspend_succeeded",
+  "suspend_noop",
+  "suspend_failed",
+  "suspend_rolled_back",
+  "suspend_queued",
+  "meta_errors",
+  "fsm_violations",
+  "reconcile_repairs",
+]
+
+function metricsSection(b: Bundle): HTMLElement {
+  const grid = el("div", { class: "sl-grid" })
+  const counters = b.metrics.counters
+  const names = [
+    ...COUNTER_ORDER.filter((n) => n in counters),
+    ...Object.keys(counters).filter((n) => !COUNTER_ORDER.includes(n)),
+  ]
+  for (const name of names) {
+    const row = el("div", { class: "sl-metric" })
+    row.append(
+      el("span", { class: "k", text: name }),
+      el("span", { text: String(counters[name] ?? 0) })
+    )
+    grid.appendChild(row)
+  }
+  if (names.length === 0) {
+    grid.appendChild(el("div", { class: "sl-empty", text: "No counters yet." }))
+  }
+
+  const aggregates = el("div", { class: "sl-grid" })
+  for (const [name, agg] of Object.entries(b.metrics.aggregates)) {
+    const mean = agg.count > 0 ? Math.round(agg.sum / agg.count) : 0
+    const row = el("div", { class: "sl-metric" })
+    row.append(
+      el("span", { class: "k", text: name }),
+      el("span", {
+        text: `avg ${mean} · min ${Math.round(agg.min)} · max ${Math.round(agg.max)} · n=${agg.count}`,
+      })
+    )
+    aggregates.appendChild(row)
+  }
+
+  const section = el("section")
+  section.append(el("h2", { text: "Metrics" }), grid)
+  if (aggregates.childElementCount > 0) {
+    section.append(el("h2", { text: "Timings (ms)" }), aggregates)
+  }
+  return section
+}
+
+function stateSection(b: Bundle): HTMLElement {
+  const now = b.generatedAt
+  const grid = el("div", { class: "sl-grid" })
+  const entries = Object.entries(b.snapshots)
+  for (const [key, value] of entries) {
+    const row = el("div", { class: "sl-metric" })
+    const rendered =
+      typeof value === "number" && key.includes("check")
+        ? `${clockTime(value)} (${relative(value, now)})`
+        : compact(value)
+    row.append(
+      el("span", { class: "k", text: key }),
+      el("span", { text: rendered })
+    )
+    grid.appendChild(row)
+  }
+  if (entries.length === 0) {
+    grid.appendChild(
+      el("div", { class: "sl-empty", text: "No state recorded yet." })
+    )
+  }
+  const section = el("section")
+  section.append(
+    el("h2", { text: "Current beliefs" }),
+    el("div", {
+      class: "sl-sub",
+      text: "Events say what happened; these say what the extension currently thinks is true.",
+    }),
+    grid
+  )
+  return section
+}
+
+function matches(event: ObservabilityEvent, f: Filter): boolean {
+  if (f.kind && !event.kind.startsWith(f.kind)) return false
+  if (f.subject && String(event.subject ?? "") !== f.subject) return false
+  return true
+}
+
+function timelineSection(b: Bundle, rerender: () => void): HTMLElement {
+  const kinds = [...new Set(b.events.map((e) => e.kind))].sort()
+
+  const kindSelect = el("select")
+  kindSelect.appendChild(new Option("all events", ""))
+  for (const k of kinds) kindSelect.appendChild(new Option(k, k))
+  kindSelect.value = filter.kind
+  kindSelect.addEventListener("change", () => {
+    filter = { ...filter, kind: kindSelect.value }
+    rerender()
+  })
+
+  const subjectInput = el("input")
+  subjectInput.placeholder = "tab id"
+  subjectInput.value = filter.subject
+  subjectInput.addEventListener("change", () => {
+    filter = { ...filter, subject: subjectInput.value.trim() }
+    rerender()
+  })
+
+  const controls = el("div", { class: "sl-filter" }, [kindSelect, subjectInput])
+
+  const table = el("table", { class: "sl-events" })
+  const head = el("tr")
+  for (const label of ["time", "kind", "subject", "detail"]) {
+    head.appendChild(el("th", { text: label }))
+  }
+  table.appendChild(el("thead", {}, [head]))
+
+  const body = el("tbody")
+  // Newest first: when something just broke, the last few lines are the ones
+  // being read, and scrolling to the bottom of 500 rows to find them is hostile.
+  const shown = b.events.filter((e) => matches(e, filter)).reverse()
+  for (const event of shown) {
+    const row = el("tr")
+    row.append(
+      el("td", { class: "muted", text: clockTime(event.t) }),
+      el("td", {
+        class:
+          event.severity === "error"
+            ? "bad"
+            : event.severity === "warn"
+              ? "warn"
+              : "",
+        text: event.kind,
+      }),
+      el("td", { class: "muted", text: String(event.subject ?? "") }),
+      el("td", { class: "detail", text: compact(event.detail) })
+    )
+    body.appendChild(row)
+  }
+  table.appendChild(body)
+
+  const section = el("section")
+  section.append(
+    el("h2", { text: `Timeline (${shown.length} of ${b.events.length})` }),
+    controls
+  )
+  if (shown.length === 0) {
+    section.appendChild(
+      el("div", { class: "sl-empty", text: "No events match this filter." })
+    )
+  } else {
+    section.appendChild(el("div", { class: "sl-scroll" }, [table]))
+  }
+  if (b.dropped > 0) {
+    section.appendChild(
+      el("div", {
+        class: "sl-sub",
+        text: `${b.dropped} older event(s) have rolled out of the ring buffer.`,
+      })
+    )
+  }
+  return section
+}
+
+// ── Actions ──────────────────────────────────────────────────────────────────
+
+function downloadBundle(b: Bundle): void {
+  // Export is a deliberate, user-initiated act — the only way anything here
+  // ever leaves the machine, and it leaves via the user's own download folder.
+  const blob = new Blob([JSON.stringify(b, null, 2)], {
+    type: "application/json",
+  })
+  const url = URL.createObjectURL(blob)
+  const anchor = el("a")
+  anchor.href = url
+  anchor.download = `suspender-ledger-diagnostics-${new Date(b.generatedAt)
+    .toISOString()
+    .replace(/[:.]/g, "-")}.json`
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+// ── Render ───────────────────────────────────────────────────────────────────
+
+function header(b: Bundle | undefined, busy: boolean): HTMLElement {
+  const title = el("div")
+  title.append(
+    el("h1", { text: "Suspender Ledger — Diagnostics" }),
+    el("div", {
+      class: "sl-sub",
+      text: b
+        ? `${b.extension.name} ${b.extension.version} · generated ${clockTime(b.generatedAt)}`
+        : "Waiting for the background worker…",
+    })
+  )
+
+  const refresh = el("button", { text: busy ? "Refreshing…" : "Refresh" })
+  refresh.disabled = busy
+  refresh.addEventListener("click", () => void load())
+
+  const actions = el("div", { class: "sl-actions" }, [refresh])
+
+  if (b) {
+    const exportBtn = el("button", { text: "Export JSON" })
+    exportBtn.addEventListener("click", () => downloadBundle(b))
+
+    const clearBtn = el("button", { text: "Clear" })
+    clearBtn.addEventListener("click", () => {
+      void send({ method: "observability", cmd: "clear" }).then(() => load())
+    })
+    actions.append(exportBtn, clearBtn)
+  }
+
+  return el("div", { class: "sl-head" }, [title, actions])
+}
+
+function render(busy = false, error?: string): void {
+  const root = document.getElementById("app")
+  if (!root) return
+  root.replaceChildren()
+  root.appendChild(header(bundle, busy))
+
+  if (error !== undefined) {
+    const section = el("section")
+    section.append(
+      el("h2", { text: "Unavailable" }),
+      el("div", { class: "sl-empty bad", text: error }),
+      el("div", {
+        class: "sl-sub",
+        text: "The background worker did not answer. Open the extension's popup or reload the extension, then refresh.",
+      })
+    )
+    root.appendChild(section)
+    return
+  }
+
+  if (!bundle) {
+    root.appendChild(
+      el("div", { class: "sl-empty", text: "Loading diagnostics…" })
+    )
+    return
+  }
+
+  root.append(
+    healthSection(bundle),
+    metricsSection(bundle),
+    stateSection(bundle),
+    timelineSection(bundle, () => render())
+  )
+}
+
+async function load(): Promise<void> {
+  render(true)
+  try {
+    const reply: unknown = await send({
+      method: "observability",
+      cmd: "export",
+    })
+    if (!isBundle(reply)) {
+      const message = Reflect.get(reply ?? {}, "error")
+      render(false, typeof message === "string" ? message : "Malformed reply.")
+      return
+    }
+    bundle = reply
+    render()
+  } catch (e) {
+    render(false, e instanceof Error ? e.message : String(e))
+  }
+}
+
+void load()

--- a/extensions/suspender-ledger/src/popup/index.ts
+++ b/extensions/suspender-ledger/src/popup/index.ts
@@ -9,15 +9,21 @@
 // embedded settings form, then bridges UI intent onto the worker message
 // protocol (`PopupToWorkerMessage`) and `storage.local`.
 
-import type { Prefs } from "@suspender/worker/core/prefs"
 import { ActionMenu } from "@suspender/popup/components/action-menu"
 import {
   SettingsForm,
   type SettingsValues,
   type ShortcutHint,
 } from "@suspender/popup/components/settings-form"
-import { TabStatus, type TabState } from "@suspender/popup/components/tab-status"
-import type { PopupCommand, PopupToWorkerMessage } from "@suspender/types/messages"
+import {
+  TabStatus,
+  type TabState,
+} from "@suspender/popup/components/tab-status"
+import type {
+  PopupCommand,
+  PopupToWorkerMessage,
+} from "@suspender/types/messages"
+import type { Prefs } from "@suspender/worker/core/prefs"
 
 import "./popup.css"
 
@@ -29,7 +35,13 @@ import "./popup.css"
 
 type PopupPrefKeys = Pick<
   Prefs,
-  "whitelist" | "idle-timeout" | "period" | "number" | "favicon" | "prepends" | "pinned"
+  | "whitelist"
+  | "idle-timeout"
+  | "period"
+  | "number"
+  | "favicon"
+  | "prepends"
+  | "pinned"
 >
 
 const PREF_DEFAULTS: PopupPrefKeys = {
@@ -144,7 +156,10 @@ function isWhitelisted(): boolean {
 
 function settingsValues(): SettingsValues {
   return {
-    idleTimeoutMinutes: Math.max(1, Math.round(state.prefs["idle-timeout"] / 60)),
+    idleTimeoutMinutes: Math.max(
+      1,
+      Math.round(state.prefs["idle-timeout"] / 60)
+    ),
     discardPeriodMinutes: Math.max(0, Math.round(state.prefs.period / 60)),
     minTabs: state.prefs.number,
     showFavicon: state.prefs.favicon,
@@ -265,6 +280,31 @@ function render(): void {
       onWhitelistRemove,
     })
   )
+
+  root.appendChild(diagnosticsLink())
+}
+
+/**
+ * Entry point to `debug.html`.
+ *
+ * Deliberately just a link: the popup must stay fast to open, and rendering a
+ * health summary here would mean a message round trip to the worker on every
+ * open. The page it opens computes health on demand instead.
+ */
+function diagnosticsLink(): HTMLElement {
+  const footer = document.createElement("footer")
+  footer.className = "popup__footer"
+
+  const link = document.createElement("a")
+  link.className = "popup__diagnostics"
+  link.href = browser.runtime.getURL("debug.html")
+  link.target = "_blank"
+  link.rel = "noopener"
+  link.textContent = "Diagnostics"
+  link.title = "Health, metrics and the suspend event timeline"
+
+  footer.appendChild(link)
+  return footer
 }
 
 // ── Hydration ─────────────────────────────────────────────────────────────────

--- a/extensions/suspender-ledger/src/popup/popup.css
+++ b/extensions/suspender-ledger/src/popup/popup.css
@@ -404,6 +404,23 @@ body {
   font-size: 11px;
 }
 
+.popup__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px 12px 10px;
+}
+
+.popup__diagnostics {
+  color: var(--sl-fg-faint);
+  font-size: 11px;
+  text-decoration: none;
+}
+
+.popup__diagnostics:hover {
+  color: var(--sl-fg);
+  text-decoration: underline;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     --sl-bg: #f6f6f7;

--- a/extensions/suspender-ledger/src/types/messages.ts
+++ b/extensions/suspender-ledger/src/types/messages.ts
@@ -78,6 +78,37 @@ export type PopupToWorkerMessage =
     }
 
 /**
+ * What the diagnostics page (`debug.html`) can ask the worker for.
+ *
+ * The page could read the recorder's persisted bundle out of `storage.local`
+ * directly, but it asks the worker instead: the worker holds the *live*
+ * in-memory ring buffer, which is by definition fresher than the last debounced
+ * flush, and only the worker can evaluate invariants that need `tabs.query`.
+ * Sending a message also wakes a recycled event page, so the page never reports
+ * on a worker that is merely asleep.
+ */
+export type ObservabilityCommand = "export" | "clear"
+
+export type DebugToWorkerMessage = {
+  method: "observability"
+  cmd: ObservabilityCommand
+}
+
+/** Narrowing guard for the debug-page protocol. */
+export function isDebugToWorkerMessage(
+  value: unknown
+): value is DebugToWorkerMessage {
+  if (value === null || typeof value !== "object" || !("method" in value)) {
+    return false
+  }
+  if (value.method !== "observability") {
+    return false
+  }
+  const cmd: unknown = Reflect.get(value, "cmd")
+  return cmd === "export" || cmd === "clear"
+}
+
+/**
  * The worker's reply to a {@link PopupToWorkerMessage} `storage` read: the
  * merged `local` + `session` preference snapshot. Keys are untyped at the wire
  * boundary; callers narrow against the `Prefs` schema before use.

--- a/extensions/suspender-ledger/src/worker/core/discard.concurrency.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.concurrency.test.ts
@@ -75,6 +75,17 @@ beforeEach(() => {
     const result = opts.func(...(opts.args ?? []))
     return Promise.resolve([{ frameId: 0, result }])
   }) as never)
+
+  // The browser's own view of a tab, which the post-discard verification reads
+  // to tell a real suspend from a silent no-op. Note this is deliberately NOT
+  // the *caller's* snapshot: the property below is about a caller whose cached
+  // tab object stays stale across attempts, which is a different thing from
+  // the browser lying about what it did.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  vi.mocked(chrome.tabs.get).mockImplementation(((
+    id: number,
+    cb: (t?: chrome.tabs.Tab) => void
+  ) => cb(tab({ id, discarded: true }))) as never)
 })
 
 afterEach(() => {

--- a/extensions/suspender-ledger/src/worker/core/discard.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.test.ts
@@ -25,6 +25,24 @@ const tab = (over: Partial<chrome.tabs.Tab>): chrome.tabs.Tab => ({
   ...over,
 })
 
+/** Tab ids the fake browser currently considers discarded. */
+const discarded = new Set<number>()
+
+/**
+ * Resolve a `tabs.discard` call the way a real browser does: the tab is now
+ * discarded, and every later `tabs.get` must agree. Tests that install their
+ * own `tabs.discard` mock go through this so the fake browser stays
+ * self-consistent — post-discard verification reads `tabs.get`, so a discard
+ * that "succeeds" without updating it is indistinguishable from a silent
+ * no-op, which is exactly the failure that verification exists to catch.
+ */
+const settleDiscard = (id: number | undefined): chrome.tabs.Tab => {
+  if (id !== undefined) {
+    discarded.add(id)
+  }
+  return tab({ id, discarded: true })
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   discard.count = 0
@@ -50,20 +68,24 @@ beforeEach(() => {
   // chrome.tabs.discard does not support the callback overload the
   // @types/chrome bindings advertise; only the promise form works
   // cross-browser (see discard-adapter.ts's discardOnce docstring).
+  //
+  // The two mocks below share `discarded` state on purpose. `tabs.get` is
+  // consulted as ground truth on two paths — the rollback path (is this tab
+  // genuinely still live?) and the post-success verification (did the discard
+  // actually land, or silently no-op?) — so a mock where `discard` reports
+  // success while `get` keeps reporting the tab live models a browser that
+  // cannot exist, and would make every successful suspend look like a no-op.
+  discarded.clear()
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   vi.mocked(chrome.tabs.discard).mockImplementation((id?: number) =>
-    Promise.resolve(tab({ id, discarded: true }))
+    Promise.resolve(settleDiscard(id))
   )
 
-  // tabs.get resolves a live (non-discarded) snapshot by default. The rollback
-  // path consults it as ground truth: a marker is only stripped from a tab
-  // that is genuinely still live, so we never inject into (and thereby reload)
-  // a tab the browser has already discarded.
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   vi.mocked(chrome.tabs.get).mockImplementation(((
     id: number,
     cb: (t?: chrome.tabs.Tab) => void
-  ) => cb(tab({ id, discarded: false }))) as never)
+  ) => cb(tab({ id, discarded: discarded.has(id) }))) as never)
 })
 
 describe("discard", () => {
@@ -209,7 +231,7 @@ describe("discard", () => {
         if (calls === 1) {
           return Promise.reject(new Error("Tabs cannot be discarded."))
         }
-        return Promise.resolve(tab({ id, discarded: true }))
+        return Promise.resolve(settleDiscard(id))
       })
 
       const done = discard(
@@ -223,6 +245,62 @@ describe("discard", () => {
       expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1)
       prefs.prepends = ""
     } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("rolls back the marker when discard reports success but the tab is still live", async () => {
+    // The silent no-op. Firefox resolves `tabs.discard` for tabs it then
+    // declines to discard (a beforeunload handler, a tab it considers too
+    // recently used). Before verification this was indistinguishable from
+    // success at the call site: the tab stayed live, kept working, and wore a
+    // 💤 marker forever — with nothing in any log to say so.
+    prefs.prepends = "💤"
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      vi.mocked(chrome.tabs.discard).mockImplementation((id?: number) =>
+        // Resolves happily; deliberately does NOT mark the tab discarded.
+        Promise.resolve(tab({ id, discarded: false }))
+      )
+
+      await discard(
+        tab({ id: 77, url: "https://example.com/", title: "Example" })
+      )
+
+      // mark, then unmark: the marker must not be stranded on a live tab.
+      expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(2)
+    } finally {
+      prefs.prepends = ""
+    }
+  })
+
+  it("accepts a discard that lands slightly after the promise resolves", async () => {
+    // The browser updates `discarded` asynchronously with respect to the
+    // discard promise, so a slow-but-real suspend must not be misread as a
+    // no-op and rolled back.
+    vi.useFakeTimers()
+    prefs.prepends = "💤"
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      vi.mocked(chrome.tabs.discard).mockImplementation((id?: number) => {
+        setTimeout(() => {
+          if (id !== undefined) {
+            discarded.add(id)
+          }
+        }, 100)
+        return Promise.resolve(tab({ id, discarded: true }))
+      })
+
+      const done = discard(
+        tab({ id: 78, url: "https://example.com/", title: "Example" })
+      )
+      await vi.advanceTimersByTimeAsync(3000)
+      await done
+
+      // Only the mark ran — nothing was rolled back.
+      expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1)
+    } finally {
+      prefs.prepends = ""
       vi.useRealTimers()
     }
   })
@@ -255,9 +333,12 @@ describe("discard", () => {
 
     /* eslint-disable @typescript-eslint/no-misused-promises -- mockImplementation's typed overloads include a void-returning form; the promise form is the one that's actually cross-browser-correct, see discard-adapter.ts */
     vi.mocked(chrome.tabs.discard).mockImplementation(
-      () =>
+      (id?: number) =>
         new Promise<chrome.tabs.Tab>((resolve) => {
-          resolvers.push(resolve)
+          resolvers.push((t) => {
+            settleDiscard(id)
+            resolve(t)
+          })
         })
     )
     /* eslint-enable @typescript-eslint/no-misused-promises */

--- a/extensions/suspender-ledger/src/worker/core/discard.ts
+++ b/extensions/suspender-ledger/src/worker/core/discard.ts
@@ -26,6 +26,15 @@ import {
   injectUnmark,
   requestDiscard,
 } from "./discard-adapter"
+import {
+  count,
+  forgetTab,
+  observe,
+  record,
+  registerStateProbe,
+  safeOrigin,
+  snapshotTab,
+} from "./observability"
 import { prefs, storage } from "./prefs"
 import {
   INITIAL_STATE,
@@ -70,7 +79,13 @@ function transition(
     // Unreachable given the fixed transition table (see suspend-fsm.ts) — a
     // future edge that produces this has a bug, not this tab a bad day.
     log("suspend-fsm invariant violated", { tabId, from, event, next })
-    trace("fsm.INVARIANT_VIOLATED", tabId, { from, event, next })
+    count("fsm_violations")
+    record(
+      "fsm.violation",
+      tabId,
+      { from: from.kind, event: event.type, next: next.kind },
+      "error"
+    )
   }
   if (isSettled(next)) {
     tabStates.delete(tabId)
@@ -80,8 +95,21 @@ function transition(
   return next
 }
 
-/** Tab ids currently mid-suspend, used to debounce duplicate requests. */
-const inprogress = new Set<number>()
+/**
+ * Tab ids currently mid-suspend, mapped to when the attempt started. Used to
+ * debounce duplicate requests; the timestamps additionally let the
+ * NoStuckInFlightSuspend invariant notice an attempt that never settles, which
+ * would otherwise block every later suspend of that tab forever and in total
+ * silence.
+ */
+const inprogress = new Map<number, number>()
+
+// Publish in-flight state to the health checks. Registered rather than
+// imported so `observability.ts` — which this module records into — never has
+// to import back.
+registerStateProbe(() => ({
+  inFlight: [...inprogress].map(([tabId, startedAt]) => ({ tabId, startedAt })),
+}))
 
 /**
  * The queued discard mechanism. `discard.count` tracks in-flight discards;
@@ -95,6 +123,41 @@ type DiscardFn = {
   time: number
   perform(tab: chrome.tabs.Tab): Promise<void>
 }
+
+/**
+ * Did the discard actually land?
+ *
+ * Returns `true` when the browser now reports the tab as discarded, `false`
+ * when it is demonstrably still live (the silent no-op), and `undefined` when
+ * we cannot tell — the tab is gone, or `tabs.get` failed. Unknown is
+ * deliberately *not* folded into failure: rolling a marker back on a guess
+ * would run `executeScript` against a possibly-discarded tab and reload it,
+ * which is a strictly worse bug than the one being detected.
+ *
+ * The browser updates a tab's `discarded` flag asynchronously with respect to
+ * the `discard()` promise, so a single immediate read would report a false
+ * no-op on a discard that was merely still settling. One short re-check is
+ * enough to separate "slow" from "didn't happen".
+ */
+async function confirmDiscarded(tabId: number): Promise<boolean | undefined> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (attempt > 0) {
+      await new Promise<void>((r) => setTimeout(r, VERIFY_DELAY_MS))
+    }
+    const snapshot = await getTabSnapshot(tabId)
+    if (!snapshot) {
+      // Tab closed out from under us — nothing left to be wrong about.
+      return undefined
+    }
+    if (snapshot.discarded) {
+      return true
+    }
+  }
+  return false
+}
+
+/** How long to let a discard settle before calling it a no-op. */
+const VERIFY_DELAY_MS = 250
 
 /**
  * The terminal action: drive one tab through its suspend lifecycle by
@@ -116,7 +179,19 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
       return
     }
     const tabId = tab.id
+    const startedAt = Date.now()
+    const origin = safeOrigin(tab.url)
     trace("perform:start", tabId, { url: tab.url, title: tab.title })
+    count("suspend_attempts")
+    snapshotTab(tabId, { fsm: "PREPARING", origin, lastAttemptAt: startedAt })
+
+    /** Terminal bookkeeping for one suspend attempt. */
+    const settle = (
+      outcome: "succeeded" | "noop" | "failed" | "rolled_back"
+    ): void => {
+      observe("suspend_latency_ms", Date.now() - startedAt)
+      snapshotTab(tabId, { origin, lastAttemptAt: startedAt, outcome })
+    }
 
     let state = transition(tabId, tabStates.get(tabId) ?? INITIAL_STATE, {
       type: "SUSPEND_REQUESTED",
@@ -130,13 +205,57 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
           ? { type: "MARK_APPLIED" }
           : { type: "MARK_SKIPPED" }
       )
+      record("suspend.marked", tabId, { outcome, origin })
 
       void requestDiscard(tabId).then(async (attempt) => {
         trace("perform:requestDiscard-result", tabId, attempt)
         if (attempt.ok) {
-          transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
-          trace("perform:done-success", tabId)
-          resolve()
+          // A resolved `tabs.discard` is a claim, not a receipt. Firefox
+          // resolves it happily for tabs it then declines to discard (a
+          // beforeunload handler, a tab the browser considers too recently
+          // used) — a silent no-op that leaves the tab live and wearing the
+          // sleep marker, which is indistinguishable from success at this
+          // call site and was invisible in every log we had. Confirm against
+          // the browser's own view before believing it. `tabs.get` reads
+          // cached metadata, so unlike executeScript it can never
+          // materialize (reload) a tab that really did discard.
+          const landed = await confirmDiscarded(tabId)
+          if (landed !== false) {
+            transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
+            count("suspend_succeeded")
+            record("suspend.discarded", tabId, {
+              origin,
+              verified: landed === true,
+            })
+            settle("succeeded")
+            trace("perform:done-success", tabId)
+            resolve()
+            return
+          }
+
+          // Reported success, still live: the silent no-op. Treat it exactly
+          // as a refusal — strip the marker rather than strand it on a tab the
+          // user can still see and use.
+          count("suspend_noop")
+          record(
+            "suspend.noop",
+            tabId,
+            { origin, why: "discard resolved but tab is still live" },
+            "warn"
+          )
+          state = transition(tabId, state, { type: "DISCARD_FAILED" })
+          if (state.kind !== "ROLLING_BACK") {
+            settle("noop")
+            resolve()
+            return
+          }
+          void injectUnmark(tabId, prefs.prepends).then(() => {
+            transition(tabId, state, { type: "MARKER_CLEARED" })
+            count("suspend_rolled_back")
+            record("suspend.rolled_back", tabId, { origin, after: "noop" })
+            settle("rolled_back")
+            resolve()
+          })
           return
         }
 
@@ -168,6 +287,13 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
             attempt.message
           )
           transition(tabId, state, { type: "DISCARD_SUCCEEDED" })
+          count("suspend_succeeded")
+          record("suspend.discarded", tabId, {
+            origin,
+            verified: true,
+            despiteError: attempt.message,
+          })
+          settle("succeeded")
           trace("perform:done-false-negative", tabId)
           resolve()
           return
@@ -180,10 +306,18 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
           "discard refused; tab still live, rolling back marker",
           attempt.message
         )
+        count("suspend_failed")
+        record(
+          "suspend.failed",
+          tabId,
+          { origin, error: attempt.message },
+          "warn"
+        )
         state = transition(tabId, state, { type: "DISCARD_FAILED" })
 
         if (state.kind !== "ROLLING_BACK") {
           // Bare tab (never marked) — nothing to strip, just fall back to ACTIVE.
+          settle("failed")
           trace("perform:done-bare-refused", tabId)
           resolve()
           return
@@ -191,6 +325,9 @@ const perform = (tab: chrome.tabs.Tab): Promise<void> =>
 
         void injectUnmark(tabId, prefs.prepends).then(() => {
           transition(tabId, state, { type: "MARKER_CLEARED" })
+          count("suspend_rolled_back")
+          record("suspend.rolled_back", tabId, { origin, after: "refused" })
+          settle("rolled_back")
           trace("perform:done-rolled-back", tabId)
           resolve()
         })
@@ -221,7 +358,7 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
   // timer alone can expire while a queued or slow-to-complete suspend is still
   // in flight, letting a second concurrent request re-enter and re-mark the
   // same live tab.
-  inprogress.add(tabId)
+  inprogress.set(tabId, Date.now())
   const cooldown = new Promise<void>((resolve) => setTimeout(resolve, 2000))
   const release = (op: Promise<void>): void => {
     void Promise.all([cooldown, op]).finally(() => inprogress.delete(tabId))
@@ -266,6 +403,12 @@ function discardImpl(tab: chrome.tabs.Tab): Promise<void> | void {
       // the same tab and re-mark a title the first copy already marked.
       if (!discard.tabs.some((qt) => qt.id === tabId)) {
         log("discarding queue for", tab)
+        count("suspend_queued")
+        record("suspend.queued", tabId, {
+          origin: safeOrigin(tab.url),
+          depth: discard.tabs.length + 1,
+          inFlight: discard.count,
+        })
         discard.tabs.push(tab)
       }
       return
@@ -334,8 +477,11 @@ function reconcileActivatedTab(tabId: number): void {
     trace("reconcileActivatedTab:refocus-mid-suspend", tabId)
     const rollingBack = transition(tabId, tracked, { type: "TAB_ACTIVATED" })
     if (rollingBack.kind === "ROLLING_BACK") {
+      record("reconcile.activated", tabId, { case: "refocus-mid-suspend" })
       void injectUnmark(tabId, marker).then(() => {
         transition(tabId, rollingBack, { type: "MARKER_CLEARED" })
+        count("reconcile_repairs")
+        record("reconcile.repaired", tabId, { via: "fsm-rollback" })
       })
     }
     return
@@ -348,6 +494,13 @@ function reconcileActivatedTab(tabId: number): void {
     if (typeof tab.title === "string" && tab.title.startsWith(`${marker} `)) {
       log("stripping stranded marker on activated tab", tabId)
       trace("reconcileActivatedTab:title-heuristic-rollback", tabId, tab.title)
+      count("reconcile_repairs")
+      record(
+        "reconcile.repaired",
+        tabId,
+        { via: "title-heuristic", origin: safeOrigin(tab.url) },
+        "warn"
+      )
       void injectUnmark(tabId, marker)
     }
   })
@@ -355,23 +508,40 @@ function reconcileActivatedTab(tabId: number): void {
 
 chrome.tabs.onActivated.addListener(({ tabId }) => reconcileActivatedTab(tabId))
 
-// TEMP DIAGNOSTIC LISTENERS for the silent-background-reload bug — delete
-// alongside trace.ts once found. These are the ground-truth signal: prior to
-// this, nothing in the extension observed onUpdated at all, so a tab
-// reloading in the background left no trace anywhere in our own logs.
+/**
+ * Ground truth from the browser about tabs we are mid-decision on.
+ *
+ * This listener used to record *every* `onUpdated` — every favicon, every
+ * title change, every load-progress tick across every tab. That is a firehose
+ * that would fill a 500-event ring in under a minute of normal browsing and
+ * bury the handful of events worth reading. It is filtered to the two signals
+ * that actually settle a question: a change in the `discarded` flag (did the
+ * suspend land? did something silently un-suspend it?), and any update at all
+ * on a tab we are currently acting on.
+ */
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  trace("browser.onUpdated", tabId, {
-    changeInfo,
-    discarded: tab.discarded,
-    status: tab.status,
+  const tracked = tabStates.get(tabId)?.kind
+  const acting = tracked !== undefined || inprogress.has(tabId)
+  if (changeInfo.discarded === undefined && !acting) {
+    return
+  }
+  record("browser.tab_updated", tabId, {
+    changeInfo: {
+      discarded: changeInfo.discarded ?? null,
+      status: changeInfo.status ?? null,
+      title: changeInfo.title === undefined ? null : "(changed)",
+    },
+    discarded: tab.discarded === true,
     active: tab.active,
-    title: tab.title,
-    tracked: tabStates.get(tabId)?.kind,
+    tracked: tracked ?? null,
     inprogress: inprogress.has(tabId),
   })
 })
 chrome.tabs.onRemoved.addListener((tabId) => {
-  trace("browser.onRemoved", tabId)
+  record("browser.tab_removed", tabId)
+  // Drop per-tab belief with the tab, so the snapshot map tracks the current
+  // profile rather than every tab ever opened.
+  forgetTab(tabId)
 })
 
 export { discard, inprogress, reconcileActivatedTab }

--- a/extensions/suspender-ledger/src/worker/core/observability.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/observability.test.ts
@@ -1,0 +1,396 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Covers both halves of the observability seam:
+ *
+ *   - the shared core in `@some-extension/common/observability` (ring buffer,
+ *     recorder, metrics, persistence budget) — exercised through its public
+ *     subpath, exactly as another extension's adapter would consume it;
+ *   - this extension's adapter — the invariants, which are pure functions of a
+ *     context object and so need no browser mock at all.
+ *
+ * The core's tests live here rather than in `extensions/common` because that
+ * workspace's `test` script currently runs Playwright only; they should move
+ * alongside the package the moment it gains a unit runner.
+ */
+
+import {
+  memoryPersistence,
+  Recorder,
+  RingBuffer,
+  runInvariants,
+  scoreHealth,
+  type InvariantResult,
+} from "@some-extension/common/observability"
+import { describe, expect, it } from "vitest"
+
+import {
+  clampCheckPeriodSeconds,
+  safeOrigin,
+  suspenderInvariants,
+  type InvariantContext,
+} from "./observability"
+
+// ── Shared core ──────────────────────────────────────────────────────────────
+
+describe("RingBuffer", () => {
+  it("keeps insertion order while below capacity", () => {
+    const buffer = new RingBuffer<number>(5)
+    buffer.extend([1, 2, 3])
+    expect(buffer.toArray()).toEqual([1, 2, 3])
+    expect(buffer.dropped).toBe(0)
+  })
+
+  it("overwrites oldest-first at capacity and counts the loss", () => {
+    const buffer = new RingBuffer<number>(3)
+    buffer.extend([1, 2, 3, 4, 5])
+
+    // Bounded footprint is the whole reason this exists: an extension running
+    // for months must never grow its retained history.
+    expect(buffer.size).toBe(3)
+    expect(buffer.toArray()).toEqual([3, 4, 5])
+    expect(buffer.dropped).toBe(2)
+  })
+
+  it("returns only the newest n from tail()", () => {
+    const buffer = new RingBuffer<number>(10)
+    buffer.extend([1, 2, 3, 4])
+    expect(buffer.tail(2)).toEqual([3, 4])
+    expect(buffer.tail(0)).toEqual([])
+  })
+
+  it("sheds overflow when rehydrated into a smaller capacity", () => {
+    // A capacity *reduction* between versions must shrink the footprint
+    // immediately, not gradually over the next few hundred writes.
+    const restored = RingBuffer.from(2, [1, 2, 3, 4], 7)
+    expect(restored.toArray()).toEqual([3, 4])
+    expect(restored.dropped).toBe(9)
+  })
+
+  it("rejects a nonsensical capacity rather than silently degrading", () => {
+    expect(() => new RingBuffer<number>(0)).toThrow(RangeError)
+  })
+})
+
+describe("Recorder", () => {
+  const makeRecorder = (
+    persistence = memoryPersistence()
+  ): Recorder<"a" | "b", "hits", "latency"> =>
+    new Recorder<"a" | "b", "hits", "latency">({
+      namespace: "test",
+      capacity: 3,
+      persistence,
+      flushIntervalMs: 5,
+    })
+
+  it("records events with a monotonic sequence and a timestamp", () => {
+    const rec = makeRecorder()
+    rec.record({ kind: "a", subject: 1 })
+    rec.record({ kind: "b", subject: 2, detail: { why: "because" } })
+
+    const events = rec.events()
+    expect(events.map((e) => e.kind)).toEqual(["a", "b"])
+    expect(events[1]?.seq).toBe(2)
+    expect(events[1]?.detail).toEqual({ why: "because" })
+    expect(typeof events[0]?.t).toBe("number")
+  })
+
+  it("bounds the timeline at capacity", () => {
+    const rec = makeRecorder()
+    for (let i = 0; i < 6; i += 1) {
+      rec.record({ kind: "a", subject: i })
+    }
+    expect(rec.events()).toHaveLength(3)
+    expect(rec.dropped).toBe(3)
+  })
+
+  it("survives a worker restart through the persistence port", async () => {
+    const persistence = memoryPersistence()
+    const first = makeRecorder(persistence)
+    first.count("hits", 4)
+    first.observe("latency", 120)
+    first.record({ kind: "a", subject: "x" })
+    await first.flush()
+
+    // A fresh Recorder is what a respawned event page gets: counters must span
+    // the extension's life, not this generation's.
+    const second = makeRecorder(persistence)
+    await second.hydrate()
+
+    expect(second.metrics.counter("hits")).toBe(4)
+    expect(second.metrics.aggregate("latency")?.count).toBe(1)
+    expect(second.events().map((e) => e.kind)).toEqual(["a"])
+  })
+
+  it("continues the sequence after hydrating rather than restarting at 1", async () => {
+    const persistence = memoryPersistence()
+    const first = makeRecorder(persistence)
+    first.record({ kind: "a" })
+    first.record({ kind: "a" })
+    await first.flush()
+
+    const second = makeRecorder(persistence)
+    await second.hydrate()
+    second.record({ kind: "b" })
+
+    const events = second.events()
+    expect(events[events.length - 1]?.seq).toBe(3)
+  })
+
+  it("flushes an error immediately instead of waiting out the debounce", async () => {
+    const persistence = memoryPersistence()
+    const rec = makeRecorder(persistence)
+
+    rec.record({ kind: "a", severity: "error", detail: "boom" })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // An error is the event most likely to be followed by the worker dying.
+    const persisted = persistence.peek()?.events ?? []
+    expect(persisted[persisted.length - 1]?.severity).toBe("error")
+  })
+
+  it("clamps an oversized detail payload instead of storing it whole", () => {
+    const rec = new Recorder<"a", "hits", "latency">({
+      namespace: "test",
+      capacity: 2,
+      maxDetailBytes: 32,
+      persistence: memoryPersistence(),
+    })
+    rec.record({ kind: "a", detail: { blob: "x".repeat(500) } })
+
+    const detail = rec.events()[0]?.detail
+    expect(typeof detail).toBe("string")
+    expect(String(detail)).toContain("truncated")
+  })
+
+  it("evicts the oldest snapshot key once the cap is reached", () => {
+    const rec = new Recorder<"a", "hits", "latency">({
+      namespace: "test",
+      maxSnapshots: 2,
+      persistence: memoryPersistence(),
+    })
+    rec.setSnapshot("tab:1", 1)
+    rec.setSnapshot("tab:2", 2)
+    rec.setSnapshot("tab:3", 3)
+
+    expect(Object.keys(rec.snapshotEntries())).toEqual(["tab:2", "tab:3"])
+  })
+
+  it("stops recording when paused and resumes cleanly", () => {
+    const rec = makeRecorder()
+    rec.pause()
+    rec.record({ kind: "a" })
+    expect(rec.events()).toHaveLength(0)
+
+    rec.resume()
+    rec.record({ kind: "a" })
+    expect(rec.events()).toHaveLength(1)
+  })
+
+  it("ignores persisted state written under a different namespace", async () => {
+    const persistence = memoryPersistence()
+    await persistence.save({
+      version: 1,
+      namespace: "some-other-extension",
+      events: [{ seq: 1, t: 1, kind: "a", severity: "info" }],
+      metrics: { counters: { hits: 99 }, aggregates: {} },
+      snapshots: {},
+      dropped: 0,
+      updatedAt: 1,
+    })
+
+    const rec = makeRecorder(persistence)
+    await rec.hydrate()
+
+    expect(rec.events()).toHaveLength(0)
+    expect(rec.metrics.counter("hits")).toBe(0)
+  })
+})
+
+describe("scoreHealth", () => {
+  const result = (
+    name: string,
+    status: InvariantResult["status"]
+  ): InvariantResult => ({ name, description: "", status, t: 0 })
+
+  it("is perfect when everything holds and nothing errored", () => {
+    expect(scoreHealth([result("a", "ok"), result("b", "ok")], 0)).toEqual({
+      score: 100,
+      status: "healthy",
+    })
+  })
+
+  it("reports unhealthy as soon as any invariant is violated", () => {
+    const { status } = scoreHealth(
+      [result("a", "ok"), result("b", "violated")],
+      0
+    )
+    expect(status).toBe("unhealthy")
+  })
+
+  it("does not penalise checks that could not be evaluated", () => {
+    // An un-evaluable check is not evidence of breakage; treating it as one
+    // would make the score cry wolf on a fresh profile.
+    expect(
+      scoreHealth([result("a", "ok"), result("b", "unknown")], 0).score
+    ).toBe(100)
+  })
+
+  it("shaves points for recent errors without collapsing the score", () => {
+    const { score } = scoreHealth([result("a", "ok")], 3)
+    expect(score).toBe(94)
+  })
+})
+
+// ── Adapter: the suspender's own invariants ──────────────────────────────────
+
+const NOW = 1_700_000_000_000
+const INTERVAL = 200_000
+
+const context = (over: Partial<InvariantContext> = {}): InvariantContext => ({
+  now: NOW,
+  schedulingEnabled: true,
+  expectedIntervalMs: INTERVAL,
+  alarmScheduledTime: NOW + INTERVAL,
+  lastCheckAt: NOW - 1000,
+  marker: "💤",
+  tabs: [],
+  inFlight: [],
+  ...over,
+})
+
+const check = async (
+  name: string,
+  ctx: InvariantContext
+): Promise<InvariantResult> => {
+  const results = await runInvariants(suspenderInvariants, ctx, NOW)
+  const found = results.find((r) => r.name === name)
+  if (!found) {
+    throw new Error(`no invariant named ${name}`)
+  }
+  return found
+}
+
+describe("suspender invariants", () => {
+  it("SchedulerAlarmExists holds when the alarm is registered", async () => {
+    expect((await check("SchedulerAlarmExists", context())).status).toBe("ok")
+  })
+
+  it("SchedulerAlarmExists fires when scheduling is on but no alarm exists", async () => {
+    const result = await check(
+      "SchedulerAlarmExists",
+      context({ alarmScheduledTime: undefined })
+    )
+    expect(result.status).toBe("violated")
+  })
+
+  it("SchedulerAlarmExists stays quiet when suspending is switched off", async () => {
+    const result = await check(
+      "SchedulerAlarmExists",
+      context({ schedulingEnabled: false, alarmScheduledTime: undefined })
+    )
+    expect(result.status).toBe("ok")
+  })
+
+  it("SchedulerAlarmNotStale catches an alarm long past due", async () => {
+    const result = await check(
+      "SchedulerAlarmNotStale",
+      context({ alarmScheduledTime: NOW - INTERVAL * 2 })
+    )
+    expect(result.status).toBe("violated")
+  })
+
+  it("CheckRanRecently catches a scheduler that stopped waking us", async () => {
+    // The signature of the bug this patch fixes, seen from the health page.
+    const result = await check(
+      "CheckRanRecently",
+      context({ lastCheckAt: NOW - INTERVAL * 5 })
+    )
+    expect(result.status).toBe("violated")
+  })
+
+  it("CheckRanRecently reports unknown on a profile that has never swept", async () => {
+    const result = await check(
+      "CheckRanRecently",
+      context({ lastCheckAt: undefined })
+    )
+    expect(result.status).toBe("unknown")
+  })
+
+  it("NoActiveTabSuspended catches a discarded foreground tab", async () => {
+    const result = await check(
+      "NoActiveTabSuspended",
+      context({
+        tabs: [{ id: 7, active: true, discarded: true, title: "Example" }],
+      })
+    )
+    expect(result.status).toBe("violated")
+    expect(result.details).toEqual({ tabIds: [7] })
+  })
+
+  it("NoStrandedMarkerOnLiveTab catches a rollback that never completed", async () => {
+    const result = await check(
+      "NoStrandedMarkerOnLiveTab",
+      context({
+        tabs: [{ id: 8, active: false, discarded: false, title: "💤 Example" }],
+      })
+    )
+    expect(result.status).toBe("violated")
+  })
+
+  it("NoStrandedMarkerOnLiveTab leaves a genuinely discarded tab alone", async () => {
+    // A discarded tab *should* wear the marker — that is the feature.
+    const result = await check(
+      "NoStrandedMarkerOnLiveTab",
+      context({
+        tabs: [{ id: 9, active: false, discarded: true, title: "💤 Example" }],
+      })
+    )
+    expect(result.status).toBe("ok")
+  })
+
+  it("NoStuckInFlightSuspend catches an attempt that never settled", async () => {
+    const result = await check(
+      "NoStuckInFlightSuspend",
+      context({ inFlight: [{ tabId: 11, startedAt: NOW - 120_000 }] })
+    )
+    expect(result.status).toBe("violated")
+  })
+
+  it("NoStuckInFlightSuspend tolerates a suspend that is merely in progress", async () => {
+    const result = await check(
+      "NoStuckInFlightSuspend",
+      context({ inFlight: [{ tabId: 11, startedAt: NOW - 500 }] })
+    )
+    expect(result.status).toBe("ok")
+  })
+})
+
+describe("safeOrigin", () => {
+  it("keeps the origin and discards path and query", () => {
+    // Browsing content has no business being written to disk; the origin is
+    // enough to answer "why wasn't this tab suspended?".
+    expect(safeOrigin("https://example.com/private/doc?token=secret")).toBe(
+      "https://example.com"
+    )
+  })
+
+  it("labels a missing or unparseable url instead of throwing", () => {
+    expect(safeOrigin(undefined)).toBe("(none)")
+    expect(safeOrigin("not a url")).toBe("(opaque)")
+  })
+})
+
+describe("clampCheckPeriodSeconds", () => {
+  it("sweeps at a third of the configured age threshold", () => {
+    expect(clampCheckPeriodSeconds(30 * 60)).toBe(600)
+  })
+
+  it("clamps to the 1–20 minute band the browser will honour", () => {
+    expect(clampCheckPeriodSeconds(30)).toBe(60)
+    expect(clampCheckPeriodSeconds(24 * 60 * 60)).toBe(1200)
+  })
+})

--- a/extensions/suspender-ledger/src/worker/core/observability.ts
+++ b/extensions/suspender-ledger/src/worker/core/observability.ts
@@ -1,0 +1,496 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * suspender-ledger's observability adapter — the reference implementation of
+ * the workspace-shared flight recorder (`@some-extension/common/observability`).
+ *
+ * Everything generic (ring buffer, metrics, invariant runner, persistence,
+ * health scoring) lives in the shared package. This file supplies only what is
+ * genuinely suspender-specific:
+ *
+ *   - the event-kind union — what decisions this extension makes;
+ *   - the counter/aggregate names — what "is it working?" means here;
+ *   - the invariants — what must always be true of a tab suspender;
+ *   - the context collector that feeds them from the browser.
+ *
+ * Adapting a second extension means writing this file again, ~200 lines, and
+ * nothing else. That is the seam.
+ *
+ * ## Scope discipline (AMO)
+ *
+ * Nothing recorded here leaves the machine: there is no network path in this
+ * module or the package behind it. Tab URLs are recorded as **origin only**
+ * (see {@link safeOrigin}) — the diagnostic questions this exists to answer
+ * ("why wasn't this tab suspended?") are answerable from the origin and the
+ * skip reason, and a full URL with its query string is browsing content we
+ * have no business writing to disk.
+ */
+
+import {
+  extensionStoragePersistence,
+  Recorder,
+  type DiagnosticsBundle,
+  type HealthReport,
+  type Invariant,
+  type InvariantOutcome,
+  type JsonValue,
+} from "@some-extension/common/observability"
+
+import { prefs } from "./prefs"
+
+/** The alarm that drives periodic suspend checks. */
+export const CHECK_ALARM = "number.check"
+
+/** Storage key for the persisted flight recorder (workspace-prefixed). */
+const STORAGE_KEY = "sl.observability.v1"
+
+/**
+ * Every decision this extension makes, as a closed union. Closed on purpose:
+ * the debug page filters on these, and a stringly-typed `kind` would let a new
+ * call site go un-renderable without a compile error.
+ */
+export type SuspenderEventKind =
+  // worker lifecycle
+  | "worker.start"
+  // the scheduler — the subsystem the sporadic no-suspend bug lived in
+  | "alarm.installed"
+  | "alarm.kept"
+  | "alarm.cleared"
+  | "alarm.fired"
+  | "alarm.missed"
+  | "alarm.repaired"
+  // one periodic sweep
+  | "check.start"
+  | "check.skipped"
+  | "check.done"
+  | "check.error"
+  | "tab.skipped"
+  | "tab.meta_error"
+  // one tab's suspend lifecycle
+  | "suspend.requested"
+  | "suspend.queued"
+  | "suspend.marked"
+  | "suspend.discarded"
+  | "suspend.noop"
+  | "suspend.failed"
+  | "suspend.rolled_back"
+  // domain FSM
+  | "fsm.transition"
+  | "fsm.violation"
+  // ground truth from the browser
+  | "browser.tab_updated"
+  | "browser.tab_removed"
+  | "reconcile.activated"
+  | "reconcile.repaired"
+  /** Free-form passthrough for `trace()` call sites not yet given a kind. */
+  | "trace"
+
+export type SuspenderCounter =
+  | "worker_starts"
+  | "alarm_installs"
+  | "alarm_kept"
+  | "alarm_fires"
+  | "alarm_missed"
+  | "alarm_repairs"
+  | "checks_run"
+  | "checks_skipped"
+  | "check_errors"
+  | "tabs_scanned"
+  | "tabs_selected"
+  | "tabs_skipped"
+  | "meta_errors"
+  | "suspend_attempts"
+  | "suspend_succeeded"
+  | "suspend_noop"
+  | "suspend_failed"
+  | "suspend_rolled_back"
+  | "suspend_queued"
+  | "fsm_violations"
+  | "reconcile_repairs"
+
+export type SuspenderAggregate =
+  | "suspend_latency_ms"
+  | "check_duration_ms"
+  | "alarm_interval_ms"
+
+// ── Invariants ───────────────────────────────────────────────────────────────
+//
+// Checks are pure functions of a context object. Gathering that context (which
+// needs the browser) is {@link collectInvariantContext}'s job, so each check
+// below is unit-testable with a plain object literal.
+
+/** Everything the invariants need to know, gathered once per evaluation. */
+export type InvariantContext = {
+  now: number
+  /** Whether periodic suspending is supposed to be running at all. */
+  schedulingEnabled: boolean
+  /** Configured sweep interval in ms (0 when scheduling is off). */
+  expectedIntervalMs: number
+  /** `scheduledTime` of the check alarm, or undefined when it does not exist. */
+  alarmScheduledTime: number | undefined
+  /** Epoch ms of the last completed sweep, if one has run since install. */
+  lastCheckAt: number | undefined
+  /** The configured title marker; "" disables marking entirely. */
+  marker: string
+  tabs: ReadonlyArray<{
+    id: number | undefined
+    active: boolean
+    discarded: boolean
+    title: string | undefined
+  }>
+  /** Tab ids the orchestrator currently considers mid-suspend, with start time. */
+  inFlight: ReadonlyArray<{ tabId: number; startedAt: number }>
+}
+
+/** A suspend that has been in flight this long is stuck, not slow. */
+const STUCK_SUSPEND_MS = 60_000
+
+const violated = (details: JsonValue): InvariantOutcome => ({
+  ok: false,
+  details,
+})
+
+export const suspenderInvariants: ReadonlyArray<Invariant<InvariantContext>> = [
+  {
+    name: "SchedulerAlarmExists",
+    description:
+      "While periodic suspending is enabled, the number.check alarm must exist — without it no sweep ever runs.",
+    check: (ctx): InvariantOutcome => {
+      if (!ctx.schedulingEnabled) {
+        return { ok: true }
+      }
+      return ctx.alarmScheduledTime === undefined
+        ? violated({ reason: "no number.check alarm registered" })
+        : { ok: true }
+    },
+  },
+  {
+    name: "SchedulerAlarmNotStale",
+    description:
+      "The check alarm's scheduled time must not be far in the past — a long-overdue alarm means the event page is not being woken.",
+    check: (ctx): InvariantOutcome => {
+      if (!ctx.schedulingEnabled || ctx.alarmScheduledTime === undefined) {
+        return { ok: "unknown" }
+      }
+      const overdueBy = ctx.now - ctx.alarmScheduledTime
+      return overdueBy > ctx.expectedIntervalMs
+        ? violated({ overdueBy, expectedIntervalMs: ctx.expectedIntervalMs })
+        : { ok: true }
+    },
+  },
+  {
+    name: "CheckRanRecently",
+    description:
+      "A sweep must have completed within three intervals. This is the invariant that catches a perpetually-deferred alarm.",
+    check: (ctx): InvariantOutcome => {
+      if (!ctx.schedulingEnabled || ctx.expectedIntervalMs <= 0) {
+        return { ok: "unknown" }
+      }
+      if (ctx.lastCheckAt === undefined) {
+        // No sweep since install/hydrate is normal for a fresh profile.
+        return { ok: "unknown" }
+      }
+      const since = ctx.now - ctx.lastCheckAt
+      return since > ctx.expectedIntervalMs * 3
+        ? violated({
+            msSinceLastCheck: since,
+            expectedIntervalMs: ctx.expectedIntervalMs,
+          })
+        : { ok: true }
+    },
+  },
+  {
+    name: "NoActiveTabSuspended",
+    description:
+      "The tab the user is looking at must never be in the discarded state.",
+    check: (ctx): InvariantOutcome => {
+      const offenders = ctx.tabs
+        .filter((t) => t.active && t.discarded)
+        .map((t) => t.id ?? -1)
+      return offenders.length > 0
+        ? violated({ tabIds: offenders })
+        : { ok: true }
+    },
+  },
+  {
+    name: "NoStrandedMarkerOnLiveTab",
+    description:
+      "A live (non-discarded) tab must not wear the sleep marker — that is a rolled-back suspend that never got cleaned up.",
+    check: (ctx): InvariantOutcome => {
+      if (!ctx.marker) {
+        return { ok: "unknown" }
+      }
+      const prefix = `${ctx.marker} `
+      const offenders = ctx.tabs
+        .filter((t) => !t.discarded && t.title?.startsWith(prefix) === true)
+        .map((t) => t.id ?? -1)
+      return offenders.length > 0
+        ? violated({ tabIds: offenders })
+        : { ok: true }
+    },
+  },
+  {
+    name: "NoStuckInFlightSuspend",
+    description:
+      "No tab may sit in the in-progress set for more than a minute; a suspend that never settles blocks every later attempt on that tab.",
+    check: (ctx): InvariantOutcome => {
+      const stuck = ctx.inFlight
+        .filter((e) => ctx.now - e.startedAt > STUCK_SUSPEND_MS)
+        .map((e) => ({ tabId: e.tabId, forMs: ctx.now - e.startedAt }))
+      return stuck.length > 0 ? violated({ stuck }) : { ok: true }
+    },
+  },
+]
+
+// ── The recorder ─────────────────────────────────────────────────────────────
+
+/**
+ * Live probe into the orchestrator's in-memory state. Registered by
+ * `discard.ts` at import time rather than imported from it, because
+ * `discard.ts` records events into this module — importing back would be a
+ * cycle. The seam also keeps the invariants honest: they read a snapshot, they
+ * cannot reach in and mutate anything.
+ */
+type StateProbe = () => {
+  inFlight: Array<{ tabId: number; startedAt: number }>
+}
+
+let stateProbe: StateProbe = () => ({ inFlight: [] })
+
+export function registerStateProbe(probe: StateProbe): void {
+  stateProbe = probe
+}
+
+/** Epoch ms of the last sweep. Mirrored into a snapshot so it survives the
+ *  worker being recycled — an in-memory-only value would reset on every
+ *  respawn and make the CheckRanRecently invariant permanently blind. */
+let lastCheckAt: number | undefined
+
+export function noteCheckCompleted(at: number): void {
+  lastCheckAt = at
+  obs.setSnapshot("check:last", at)
+}
+
+/**
+ * Restore the recorder from disk, then re-derive the in-memory mirrors that
+ * are computed from it. Call once, from a `starters` callback: MV3 event pages
+ * are recycled constantly, and a recorder that starts empty every generation
+ * measures the worker's lifetime rather than the extension's.
+ */
+export async function hydrateObservability(): Promise<void> {
+  await obs.hydrate()
+  const stored = obs.snapshotEntries()["check:last"]
+  if (typeof stored === "number") {
+    lastCheckAt = stored
+  }
+}
+
+export const obs = new Recorder<
+  SuspenderEventKind,
+  SuspenderCounter,
+  SuspenderAggregate,
+  InvariantContext
+>({
+  namespace: "suspender-ledger",
+  // ~500 events is several hours of a busy profile's decisions, and stays
+  // well inside the persistence port's byte budget.
+  capacity: 500,
+  invariants: suspenderInvariants,
+  persistence: extensionStoragePersistence({ key: STORAGE_KEY }),
+  // The console echo is opt-in behind the existing `log` preference — an
+  // always-on firehose is its own kind of bad citizenship, and the timeline is
+  // on the debug page regardless.
+  echo: (event): void => {
+    if (!prefs.log) {
+      return
+    }
+    // eslint-disable-next-line no-console -- gated on the user's own log preference
+    console.debug(
+      `[SL#${event.seq}] ${event.kind}`,
+      event.subject ?? "",
+      event.detail ?? ""
+    )
+  },
+})
+
+// ── Recording helpers ────────────────────────────────────────────────────────
+
+/**
+ * Record one event. Thin, but it keeps every call site in the worker free of
+ * the recorder's option-object shape.
+ */
+export function record(
+  kind: SuspenderEventKind,
+  subject?: number | string,
+  detail?: JsonValue,
+  severity?: "debug" | "info" | "warn" | "error"
+): void {
+  obs.record({ kind, subject, detail, severity })
+}
+
+export function count(name: SuspenderCounter, by = 1): void {
+  obs.count(name, by)
+}
+
+export function observe(name: SuspenderAggregate, value: number): void {
+  obs.observe(name, value)
+}
+
+/**
+ * Origin (scheme + host) of a URL, or a coarse label when it has none.
+ * Deliberately lossy: this is the most tab identity that belongs on disk.
+ */
+export function safeOrigin(url: string | undefined): string {
+  if (!url) {
+    return "(none)"
+  }
+  try {
+    return new URL(url).origin
+  } catch {
+    return "(opaque)"
+  }
+}
+
+/** Publish what the extension currently believes about one tab. */
+export function snapshotTab(
+  tabId: number,
+  state: {
+    fsm?: string
+    discarded?: boolean
+    active?: boolean
+    origin?: string
+    lastAttemptAt?: number
+    outcome?: string
+  }
+): void {
+  obs.setSnapshot(`tab:${tabId}`, { tabId, ...state, at: Date.now() })
+}
+
+export function forgetTab(tabId: number): void {
+  obs.deleteSnapshot(`tab:${tabId}`)
+}
+
+// ── Health and export ────────────────────────────────────────────────────────
+
+/**
+ * Gather the browser-side facts the invariants run against. Failures degrade
+ * to "unknown" rather than propagating: a health check that throws would be a
+ * worse outcome than one that admits it does not know.
+ */
+export async function collectInvariantContext(): Promise<InvariantContext> {
+  const now = Date.now()
+  const stored = await readSchedulingPrefs()
+  const schedulingEnabled =
+    stored.period > 0 &&
+    (stored.mode === "time-based" || stored.mode === "url-based") &&
+    stored.tmp_disable === 0
+
+  let alarmScheduledTime: number | undefined
+  try {
+    const alarm = await chrome.alarms.get(CHECK_ALARM)
+    // The typings mark the result non-optional; it is absent at runtime when
+    // no alarm is registered — which is precisely what this reads.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    alarmScheduledTime = alarm ? alarm.scheduledTime : undefined
+  } catch {
+    alarmScheduledTime = undefined
+  }
+
+  const tabs = await readTabs()
+
+  return {
+    now,
+    schedulingEnabled,
+    expectedIntervalMs: schedulingEnabled ? checkIntervalMs(stored.period) : 0,
+    alarmScheduledTime,
+    lastCheckAt,
+    marker: prefs.prepends,
+    tabs,
+    inFlight: stateProbe().inFlight,
+  }
+}
+
+/**
+ * The effective sweep interval for a configured age threshold, in ms.
+ *
+ * Shared with `modes/number.ts` so the scheduler and the invariant that judges
+ * the scheduler can never disagree about what "on time" means — the kind of
+ * quiet drift that makes a health check lie.
+ */
+export function checkIntervalMs(periodSeconds: number): number {
+  return clampCheckPeriodSeconds(periodSeconds) * 1000
+}
+
+/** Clamp a configured age threshold to the sweep cadence: 1–20 minutes. */
+export function clampCheckPeriodSeconds(periodSeconds: number): number {
+  return Math.min(20 * 60, Math.max(60, periodSeconds / 3))
+}
+
+/** Current tabs, reduced to the fields the invariants judge. */
+async function readTabs(): Promise<InvariantContext["tabs"]> {
+  try {
+    const queried = await chrome.tabs.query({})
+    return queried.map((t) => ({
+      id: t.id,
+      active: t.active,
+      discarded: t.discarded === true,
+      title: t.title,
+    }))
+  } catch {
+    // A failed query means the checks that need tabs report "unknown" rather
+    // than inventing a clean bill of health from an empty list.
+    return []
+  }
+}
+
+async function readSchedulingPrefs(): Promise<{
+  mode: string
+  period: number
+  tmp_disable: number
+}> {
+  const fallback = { mode: "time-based", period: 10 * 60, tmp_disable: 0 }
+  try {
+    const stored: unknown = await new Promise((resolve) =>
+      chrome.storage.local.get(fallback, resolve)
+    )
+    if (stored === null || typeof stored !== "object") {
+      return fallback
+    }
+    const mode = Reflect.get(stored, "mode")
+    const period = Reflect.get(stored, "period")
+    const tmpDisable = Reflect.get(stored, "tmp_disable")
+    return {
+      mode: typeof mode === "string" ? mode : fallback.mode,
+      period: typeof period === "number" ? period : fallback.period,
+      tmp_disable: typeof tmpDisable === "number" ? tmpDisable : 0,
+    }
+  } catch {
+    return fallback
+  }
+}
+
+/** The extension's own answer to "am I working?". */
+export async function healthReport(): Promise<HealthReport> {
+  return obs.health(await collectInvariantContext())
+}
+
+/**
+ * The user-attachable diagnostics bundle (the "export debug report" action).
+ *
+ * String-kinded rather than `DiagnosticsBundle<SuspenderEventKind>`: the
+ * timeline inside may have been written by an older build of this extension
+ * whose event names differ from today's union, and claiming otherwise would be
+ * a promise the storage boundary cannot keep.
+ */
+export async function exportDiagnostics(): Promise<DiagnosticsBundle> {
+  const manifest = chrome.runtime.getManifest()
+  return obs.export(await collectInvariantContext(), {
+    extension: { name: manifest.name, version: manifest.version },
+    runtime: {
+      userAgent:
+        typeof navigator === "undefined" ? "unknown" : navigator.userAgent,
+    },
+  })
+}

--- a/extensions/suspender-ledger/src/worker/core/trace.ts
+++ b/extensions/suspender-ledger/src/worker/core/trace.ts
@@ -3,30 +3,110 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * TEMPORARY diagnostic instrumentation for the "suspended tab silently
- * reloads in the background" bug (#409 follow-up). Unlike `log()` in
- * `utils.ts`, this is NOT gated on the `log` preference — it always prints,
- * because the whole point is visibility while chasing an intermittent
- * browser-behavior bug. Delete this file and its call sites once the bug is
- * found and fixed.
+ * `trace()` — the low-ceremony recording call, kept at its original signature
+ * so the ~30 existing call sites did not have to be rewritten in the same diff
+ * that introduced observability.
  *
- * Every line is prefixed with a monotonic sequence number and a
- * high-resolution timestamp so events from the background worker's console
- * and a page's own console (watch.ts / resume-veil.ts log there too) can be
- * interleaved by hand into one timeline.
+ * What changed is where the output goes. This used to be an always-on
+ * `console.log` firehose, explicitly marked temporary, whose entire value
+ * evaporated the moment the console was closed or the event page was recycled
+ * — which is exactly when the intermittent bug it was chasing occurred. It now
+ * writes into the flight recorder (`observability.ts`): bounded, persisted
+ * across worker generations, and readable after the fact on `debug.html`.
+ * Console output survives too, but gated on the user's `log` preference.
+ *
+ * Call sites that carry real diagnostic weight should graduate to a named
+ * {@link SuspenderEventKind} with a counter behind it. `trace` is for the
+ * long tail — the breadcrumbs that only matter once you are already reading a
+ * timeline.
  */
 
-let seq = 0
+import type { JsonValue } from "@some-extension/common/observability"
+
+import { record } from "./observability"
 
 export function trace(
   scope: string,
   tabId: number | undefined,
   ...args: Array<unknown>
 ): void {
-  seq += 1
-  const t = (
-    typeof performance !== "undefined" ? performance.now() : Date.now()
-  ).toFixed(1)
-  // eslint-disable-next-line no-console -- temporary diagnostic instrumentation, delete with this file
-  console.log(`[SL#${seq} ${t}ms] [${scope}] tab=${tabId ?? "?"}`, ...args)
+  const detail: Record<string, JsonValue> = { scope }
+  if (args.length > 0) {
+    detail.args = args.map((a) => toJson(a))
+  }
+  record("trace", tabId, detail)
+}
+
+/**
+ * Coerce an arbitrary logged value into something persistable. Errors keep
+ * their message (the part worth reading), unknown object graphs are passed
+ * through `JSON.stringify`'s own view of them, and anything cyclic or exotic
+ * degrades to a label rather than throwing inside the logging path.
+ */
+export function toJson(value: unknown): JsonValue {
+  if (value === null) {
+    return null
+  }
+  if (value === undefined) {
+    return "(undefined)"
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value
+  }
+  if (typeof value === "bigint" || typeof value === "symbol") {
+    return value.toString()
+  }
+  if (typeof value === "function") {
+    return "(function)"
+  }
+  if (value instanceof Error) {
+    return { error: value.name, message: value.message }
+  }
+  return walk(value, new WeakSet(), 0)
+}
+
+/** Deeper than this and a logged object is noise, not diagnosis. */
+const MAX_DEPTH = 4
+
+/**
+ * Convert an object graph into `JsonValue` explicitly, rather than via a
+ * `JSON.parse(JSON.stringify(…))` round trip.
+ *
+ * The round trip is shorter, but it returns `any` and it *throws* on a cycle —
+ * and the values `trace` is handed (`chrome.tabs.Tab`, `changeInfo` bags, FSM
+ * states) are exactly the kind of host objects that can be cyclic. A logging
+ * path that can throw is worse than useless: it turns a diagnostic into a new
+ * fault. Cycles and over-deep branches degrade to a label instead.
+ */
+function walk(value: object, seen: WeakSet<object>, depth: number): JsonValue {
+  if (seen.has(value)) {
+    return "(circular)"
+  }
+  if (depth >= MAX_DEPTH) {
+    return "(depth limit)"
+  }
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    return value.map((item: unknown) => step(item, seen, depth))
+  }
+
+  const out: Record<string, JsonValue> = {}
+  for (const [key, item] of Object.entries(value)) {
+    out[key] = step(item, seen, depth)
+  }
+  return out
+}
+
+function step(item: unknown, seen: WeakSet<object>, depth: number): JsonValue {
+  if (item !== null && typeof item === "object") {
+    return item instanceof Error
+      ? { error: item.name, message: item.message }
+      : walk(item, seen, depth + 1)
+  }
+  return toJson(item)
 }

--- a/extensions/suspender-ledger/src/worker/modes/number.scheduler.test.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.scheduler.test.ts
@@ -1,0 +1,156 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Regression suite for the sporadic "tabs are never suspended" bug.
+ *
+ * The failure had no error and no log line, because nothing failed — the
+ * periodic sweep alarm was simply re-armed from zero on every event-page
+ * respawn, so during active browsing (when the page is woken every few
+ * seconds) its scheduled time was pushed forward faster than it could ever
+ * arrive. The first test below is the one that would have caught it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { number } from "./number"
+
+type AlarmShape = {
+  name: string
+  scheduledTime: number
+  periodInMinutes?: number
+}
+
+/** The cadence `install` derives from the default 10-minute age threshold. */
+const DEFAULT_PERIOD_SECONDS = 10 * 60
+const EXPECTED_MINUTES = DEFAULT_PERIOD_SECONDS / 3 / 60 // period/3, clamped to 1–20m
+
+/** Install a fake `alarms.get` that resolves the given alarm (or nothing). */
+function withExistingAlarm(alarm: AlarmShape | undefined): void {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the callback overload is the one typed; we exercise the promise form Firefox implements
+  vi.mocked(chrome.alarms.get).mockImplementation((() =>
+    Promise.resolve(alarm)) as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("number.install — scheduler idempotency", () => {
+  it("creates the sweep alarm when none exists", async () => {
+    withExistingAlarm(undefined)
+
+    await number.install(DEFAULT_PERIOD_SECONDS)
+
+    expect(chrome.alarms.create).toHaveBeenCalledWith(
+      "number.check",
+      expect.objectContaining({ periodInMinutes: EXPECTED_MINUTES })
+    )
+  })
+
+  it("does NOT re-arm an alarm that already exists at the same cadence", async () => {
+    // This is the bug. `install` runs from a `starters` callback, and starters
+    // run at module evaluation on every worker generation — so an
+    // unconditional `alarms.create` here pushes the next sweep a full interval
+    // into the future every time the event page is woken by any listener.
+    withExistingAlarm({
+      name: "number.check",
+      scheduledTime: Date.now() + 60_000,
+      periodInMinutes: EXPECTED_MINUTES,
+    })
+
+    await number.install(DEFAULT_PERIOD_SECONDS)
+
+    expect(chrome.alarms.create).not.toHaveBeenCalled()
+  })
+
+  it("keeps the original due time across repeated worker respawns", async () => {
+    const scheduledTime = Date.now() + 90_000
+    withExistingAlarm({
+      name: "number.check",
+      scheduledTime,
+      periodInMinutes: EXPECTED_MINUTES,
+    })
+
+    // Ten wakes in a row — the shape of an active browsing session.
+    for (let i = 0; i < 10; i += 1) {
+      await number.install(DEFAULT_PERIOD_SECONDS)
+    }
+
+    expect(chrome.alarms.create).not.toHaveBeenCalled()
+  })
+
+  it("re-arms when the configured cadence changed", async () => {
+    withExistingAlarm({
+      name: "number.check",
+      scheduledTime: Date.now() + 60_000,
+      periodInMinutes: EXPECTED_MINUTES,
+    })
+
+    // 30-minute age threshold → 10-minute sweep cadence.
+    await number.install(30 * 60)
+
+    expect(chrome.alarms.create).toHaveBeenCalledWith(
+      "number.check",
+      expect.objectContaining({ periodInMinutes: 10 })
+    )
+  })
+
+  it("re-arms when the existing alarm has no cadence at all", async () => {
+    // A one-shot alarm left behind by an older version would otherwise be
+    // mistaken for a healthy periodic one and never replaced.
+    withExistingAlarm({
+      name: "number.check",
+      scheduledTime: Date.now() + 1000,
+    })
+
+    await number.install(DEFAULT_PERIOD_SECONDS)
+
+    expect(chrome.alarms.create).toHaveBeenCalledWith(
+      "number.check",
+      expect.objectContaining({ periodInMinutes: EXPECTED_MINUTES })
+    )
+  })
+
+  it("treats an unreadable alarms API as 'no alarm' and installs one", () => {
+    vi.mocked(chrome.alarms.get).mockImplementation(() => {
+      throw new Error("alarms unavailable")
+    })
+
+    return number.install(DEFAULT_PERIOD_SECONDS).then(() => {
+      expect(chrome.alarms.create).toHaveBeenCalled()
+    })
+  })
+
+  it("clamps the sweep cadence to at least one minute", async () => {
+    withExistingAlarm(undefined)
+
+    // A 30-second age threshold would otherwise ask for a 10-second alarm,
+    // which the browser silently refuses to honour.
+    await number.install(30)
+
+    expect(chrome.alarms.create).toHaveBeenCalledWith(
+      "number.check",
+      expect.objectContaining({ periodInMinutes: 1 })
+    )
+  })
+
+  it("clamps the sweep cadence to at most twenty minutes", async () => {
+    withExistingAlarm(undefined)
+
+    await number.install(24 * 60 * 60)
+
+    expect(chrome.alarms.create).toHaveBeenCalledWith(
+      "number.check",
+      expect.objectContaining({ periodInMinutes: 20 })
+    )
+  })
+})
+
+describe("number.remove", () => {
+  it("clears the sweep alarm", () => {
+    number.remove()
+    expect(chrome.alarms.clear).toHaveBeenCalledWith("number.check")
+  })
+})

--- a/extensions/suspender-ledger/src/worker/modes/number.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.ts
@@ -5,9 +5,20 @@
 // Ported from auto-tab-discard v3/worker/modes/number.mjs (MPL-2.0)
 // Copyright (C) auto-tab-discard contributors
 
+import type { JsonValue } from "@some-extension/common/observability"
 import { collectMeta } from "@suspender/content/meta"
 
 import { discard } from "../core/discard"
+import {
+  CHECK_ALARM,
+  clampCheckPeriodSeconds,
+  count,
+  noteCheckCompleted,
+  obs,
+  observe,
+  record,
+  safeOrigin,
+} from "../core/observability"
 import { storage } from "../core/prefs"
 import { starters } from "../core/startup"
 import { log, match, query } from "../core/utils"
@@ -74,13 +85,58 @@ type PluginFilter = {
 
 type NumberMode = {
   IGNORE: Partial<CheckPrefs>
-  install(period: number): void
+  install(period: number): Promise<void>
   remove(): void
   check(
     filterTabsFrom?: ReadonlyArray<{ id?: number }>,
     ops?: Partial<CheckPrefs>,
     reason?: string
   ): Promise<void>
+}
+
+/** Float-tolerant cadence comparison — `periodInMinutes` is seconds/60. */
+function closeEnough(a: number | undefined, b: number): boolean {
+  return a !== undefined && Math.abs(a - b) < 1e-6
+}
+
+/**
+ * Record the end of one sweep: duration into the aggregate, tallies into the
+ * timeline. Every exit path from `check()` goes through here or through the
+ * `check.skipped` branches, so a sweep that vanishes mid-flight is visible as
+ * a `check.start` with no matching terminal event.
+ */
+function finish(
+  startedAt: number,
+  tally: {
+    scanned: number
+    ignored: number
+    eligible: number
+    selected: number
+  }
+): void {
+  const duration = Date.now() - startedAt
+  observe("check_duration_ms", duration)
+  record("check.done", undefined, { ...tally, durationMs: duration })
+}
+
+/**
+ * Read the currently-registered check alarm, or `undefined` when none exists.
+ *
+ * `alarms.get` is promise-shaped on Firefox and promise-or-callback on Chrome;
+ * the shared wrapper keeps the two call sites (install, watchdog) honest and
+ * swallows a rejection as "no alarm", which is the safe reading — a scheduler
+ * we cannot see is a scheduler we must re-create.
+ */
+async function getCheckAlarm(): Promise<chrome.alarms.Alarm | undefined> {
+  try {
+    const alarm = await chrome.alarms.get(CHECK_ALARM)
+    // The typings mark the result non-optional; at runtime it is absent when
+    // no alarm is registered.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return alarm ?? undefined
+  } catch {
+    return undefined
+  }
 }
 
 const ICONS: Record<string, string> = {
@@ -116,19 +172,83 @@ const number: NumberMode = {
     "max.single.discard": Infinity,
     "ignore.meta.data": true,
   },
-  install(period) {
-    // clamp the check interval to between 1 and 20 minutes
-    period = Math.min(20 * 60, Math.max(60, period / 3))
-    void chrome.alarms.create("number.check", {
-      when: Date.now() + period * 1000,
-      periodInMinutes: period / 60,
+  /**
+   * Ensure the periodic sweep alarm exists — **without resetting it** when it
+   * already does.
+   *
+   * This idempotency is the fix for the sporadic "tabs never get suspended"
+   * bug, and the reason it is load-bearing is worth spelling out.
+   *
+   * `install` is called from a `starters` callback, and `starters` run at
+   * module evaluation on *every* worker generation (see `core/startup.ts`:
+   * MV3 event pages are recycled aggressively, and neither `onStartup` nor
+   * `onInstalled` fires on a respawn, so the gate has to open unconditionally).
+   * The previous implementation unconditionally called `alarms.create` with
+   * `when: Date.now() + period`, which **re-armed the alarm from zero on every
+   * respawn**.
+   *
+   * The extension registers `tabs.onUpdated`, `tabs.onActivated`,
+   * `runtime.onMessage` and friends — so during active browsing the event page
+   * is woken every few seconds. Each wake pushed the next sweep another full
+   * interval into the future, so the alarm could only ever fire during a lull
+   * longer than the whole interval. Hence the symptom: suspension works fine
+   * on an idle machine and silently never happens while you are actually using
+   * the browser — sporadic, unreproducible on demand, and invisible in logs
+   * because nothing was failing. Nothing *ran*.
+   *
+   * So: create the alarm only when it is missing or its cadence changed.
+   */
+  async install(period) {
+    const seconds = clampCheckPeriodSeconds(period)
+    const periodInMinutes = seconds / 60
+    const existing = await getCheckAlarm()
+
+    if (existing && closeEnough(existing.periodInMinutes, periodInMinutes)) {
+      count("alarm_kept")
+      record("alarm.kept", CHECK_ALARM, {
+        scheduledTime: existing.scheduledTime,
+        periodInMinutes,
+        dueInMs: existing.scheduledTime - Date.now(),
+      })
+      obs.setSnapshot("alarm:check", {
+        scheduledTime: existing.scheduledTime,
+        periodInMinutes,
+        origin: "kept",
+      })
+      return
+    }
+
+    const when = Date.now() + seconds * 1000
+    void chrome.alarms.create(CHECK_ALARM, { when, periodInMinutes })
+    count("alarm_installs")
+    record("alarm.installed", CHECK_ALARM, {
+      when,
+      periodInMinutes,
+      replaced: existing
+        ? { periodInMinutes: existing.periodInMinutes ?? null }
+        : null,
+    })
+    obs.setSnapshot("alarm:check", {
+      scheduledTime: when,
+      periodInMinutes,
+      origin: "installed",
     })
   },
   remove() {
-    void chrome.alarms.clear("number.check")
+    void chrome.alarms.clear(CHECK_ALARM)
+    record("alarm.cleared", CHECK_ALARM)
+    obs.deleteSnapshot("alarm:check")
   },
   async check(filterTabsFrom, ops = {}, reason) {
     log("number.check is called", reason)
+    const startedAt = Date.now()
+    count("checks_run")
+    record("check.start", reason ?? "manual")
+    // Noted at the *start*: what the CheckRanRecently invariant is really
+    // asking is "did the scheduler wake us", and a sweep that skips out early
+    // (machine not idle, tab count below threshold) answers that just as well
+    // as one that suspends something.
+    noteCheckCompleted(startedAt)
 
     const base = await storage<Omit<CheckPrefs, "whitelist.session">>({
       mode: "time-based",
@@ -164,12 +284,16 @@ const number: NumberMode = {
       )
       if (state !== "idle") {
         log("discarding is skipped", "not in the idle state")
+        count("checks_skipped")
+        record("check.skipped", reason ?? "manual", { why: "machine-not-idle" })
         return
       }
     }
     // only check if INTERNET is connected
     if (prefs.online && navigator.onLine === false) {
       log("discarding is skipped", "No INTERNET connection detected")
+      count("checks_skipped")
+      record("check.skipped", reason ?? "manual", { why: "offline" })
       return
     }
 
@@ -187,6 +311,22 @@ const number: NumberMode = {
       options.audible = false
     }
     let tbs = await query(options)
+    count("tabs_scanned", tbs.length)
+
+    /** Record why one tab was passed over. The "why wasn't this tab suspended?"
+     *  question is answered entirely from these events. */
+    const skipped = (
+      tb: chrome.tabs.Tab,
+      why: string,
+      extra: Record<string, JsonValue> = {}
+    ): void => {
+      count("tabs_skipped")
+      record("tab.skipped", tb.id, {
+        why,
+        origin: safeOrigin(tb.url),
+        ...extra,
+      })
+    }
 
     const icon = (tb: chrome.tabs.Tab, title: string): void => {
       void chrome.action.setTitle({ tabId: tb.id, title })
@@ -227,12 +367,14 @@ const number: NumberMode = {
           ) {
             icon(tb, "tab is in the whitelist")
             log("number.check", "tab is ignored", "url-based whitelist", tb.url)
+            skipped(tb, "url-whitelist")
             exceptionCount += 1
             return false
           }
           if (m(prefs.whitelist) || m(prefs["whitelist.session"])) {
             icon(tb, "tab is in the session or permanent whitelist")
             log("number.check", "tab is ignored", "whitelist", tb.url)
+            skipped(tb, "whitelist")
             exceptionCount += 1
             return false
           }
@@ -256,6 +398,13 @@ const number: NumberMode = {
           tbs.length,
           prefs.number
         )
+        count("checks_skipped")
+        record("check.skipped", reason ?? "manual", {
+          why: "below-tab-threshold",
+          candidates: tbs.length,
+          ignored: exceptionCount,
+          threshold: prefs.number,
+        })
         return
       }
     }
@@ -268,6 +417,11 @@ const number: NumberMode = {
         continue
       }
       try {
+        // An injection failure used to be swallowed whole (`() => []`), which
+        // made "this tab is silently never eligible" indistinguishable from
+        // "this tab is fine". Keep the same non-fatal behaviour, but keep the
+        // reason.
+        let injectionError: string | undefined
         const results =
           tb.status === "unloaded"
             ? []
@@ -280,8 +434,19 @@ const number: NumberMode = {
                 })
                 .then(
                   (r) => r,
-                  () => []
+                  (e: unknown) => {
+                    injectionError = e instanceof Error ? e.message : String(e)
+                    return []
+                  }
                 )
+        if (injectionError !== undefined) {
+          count("meta_errors")
+          record("tab.meta_error", tb.id, {
+            origin: safeOrigin(tb.url),
+            status: tb.status ?? null,
+            error: injectionError,
+          })
+        }
         const ms: Array<TabMeta> = results.map((o) => readMeta(o.result))
 
         // remove protected tabs (e.g. addons.mozilla.org)
@@ -292,6 +457,7 @@ const number: NumberMode = {
           ) {
             log("discarding aborted", "metadata fetch error", tb.url)
             icon(tb, "metadata fetch error")
+            skipped(tb, "metadata-unavailable", { status: tb.status ?? null })
             exceptionCount += 1
             continue
           }
@@ -320,52 +486,69 @@ const number: NumberMode = {
           meta.memory > prefs["memory-value"] * 1024 * 1024
         ) {
           log("forced discarding", "memory usage")
+          record("suspend.requested", tb.id, {
+            trigger: "memory-pressure",
+            origin: safeOrigin(tb.url),
+          })
           void discard(tb)
           continue
         }
         if (meta.ready !== true && ops["ignore.ready.state"] !== true) {
           log("discarding aborted", "tab is not ready", tb)
+          skipped(tb, "not-ready", { status: tb.status ?? null })
           exceptionCount += 1
           continue
         }
         if (prefs.audio && meta.audible) {
           log("discarding aborted", "audio is playing", tb)
           icon(tb, "tab plays an audio")
+          skipped(tb, "audible")
           exceptionCount += 1
           continue
         }
         if (prefs.paused && meta.paused) {
           log("discarding aborted", "player is paused", tb)
           icon(tb, "tab has a paused player")
+          skipped(tb, "paused-media")
           exceptionCount += 1
           continue
         }
         if (prefs.form && meta.forms) {
           log("discarding aborted", "active form", tb)
           icon(tb, "there is an active form on this tab")
+          skipped(tb, "unsaved-form")
           exceptionCount += 1
           continue
         }
         if (prefs["notification.permission"] && meta.permission) {
           log("discarding aborted", "tab has notification permission")
           icon(tb, "tab has notification permission")
+          skipped(tb, "notification-permission")
           exceptionCount += 1
           continue
         }
         if (tb.autoDiscardable === false) {
           log("discarding aborted", "tab is not discardable", tb)
+          skipped(tb, "not-auto-discardable")
           exceptionCount += 1
           icon(tb, "tab is not discardable")
           continue
         }
         if (now - (meta.time ?? tb.lastAccessed ?? now) < prefs.period * 1000) {
           log("discarding aborted", "tab is not old", tb)
+          skipped(tb, "too-young", {
+            ageMs: now - (meta.time ?? tb.lastAccessed ?? now),
+            thresholdMs: prefs.period * 1000,
+            ageSource:
+              meta.time !== undefined ? "content-script" : "lastAccessed",
+          })
           exceptionCount += 1
           icon.reset(tb)
           continue
         }
         if (tb.active) {
           log("discarding aborted", "tab is active", tb)
+          skipped(tb, "active")
           exceptionCount += 1
           icon.reset(tb)
           continue
@@ -378,6 +561,13 @@ const number: NumberMode = {
         }
       } catch (e) {
         log("number.check error", e)
+        count("check_errors")
+        record(
+          "check.error",
+          tb.id,
+          { error: e instanceof Error ? e.message : String(e) },
+          "error"
+        )
       }
     }
 
@@ -389,6 +579,13 @@ const number: NumberMode = {
           tbs.length,
           prefs.number
         )
+        count("checks_skipped")
+        record("check.skipped", reason ?? "manual", {
+          why: "below-tab-threshold",
+          candidates: tbs.length,
+          ignored: exceptionCount,
+          threshold: prefs.number,
+        })
         return
       }
     }
@@ -407,9 +604,21 @@ const number: NumberMode = {
       )
 
     log("number check", "discarding", tbds.length)
+    count("tabs_selected", tbds.length)
     for (const tb of tbds) {
+      record("suspend.requested", tb.id, {
+        trigger: reason ?? "manual",
+        origin: safeOrigin(tb.url),
+        ageMs: now - (map.get(tb)?.time ?? now),
+      })
       void discard(tb)
     }
+    finish(startedAt, {
+      scanned: tbs.length,
+      ignored: exceptionCount,
+      eligible: arr.length,
+      selected: tbds.length,
+    })
   },
 }
 
@@ -417,18 +626,99 @@ const number: NumberMode = {
 const pluginFilters: Record<string, PluginFilter> = {}
 
 chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === "number.check") {
-    log("alarm fire", "number.check", alarm.name)
-    // make sure alarm is firing next time
+  if (alarm.name === CHECK_ALARM) {
+    log("alarm fire", CHECK_ALARM, alarm.name)
+    const now = Date.now()
+    count("alarm_fires")
+
+    // Interval between consecutive fires is the single most diagnostic number
+    // this extension has: it is the difference between "the scheduler is
+    // running" and "the scheduler exists but never gets to run". The gap that
+    // exposed the deferred-alarm bug is visible here as a fire interval that
+    // simply never arrives.
+    const previous = readNumberSnapshot("alarm:lastFire")
+    if (previous !== undefined) {
+      const interval = now - previous
+      observe("alarm_interval_ms", interval)
+      const expected = alarm.periodInMinutes
+        ? alarm.periodInMinutes * 60 * 1000
+        : undefined
+      if (expected !== undefined && interval > expected * 2) {
+        count("alarm_missed")
+        record(
+          "alarm.missed",
+          CHECK_ALARM,
+          { intervalMs: interval, expectedMs: expected },
+          "warn"
+        )
+      }
+    }
+    obs.setSnapshot("alarm:lastFire", now)
+    record("alarm.fired", CHECK_ALARM, {
+      scheduledTime: alarm.scheduledTime,
+      lateByMs: now - alarm.scheduledTime,
+      periodInMinutes: alarm.periodInMinutes ?? null,
+    })
+
+    // Re-arm after firing. This is safe where `install` was not: it happens at
+    // fire time, not at every worker wake, so it advances the schedule by
+    // exactly one interval rather than deferring it indefinitely.
     if (alarm.periodInMinutes) {
       void chrome.alarms.create(alarm.name, {
-        when: Date.now() + alarm.periodInMinutes * 60 * 1000,
+        when: now + alarm.periodInMinutes * 60 * 1000,
         periodInMinutes: alarm.periodInMinutes,
       })
     }
     void number.check(undefined, undefined, "number/1")
   }
 })
+
+/** Read a numeric recorder snapshot, or undefined when absent/not a number. */
+function readNumberSnapshot(key: string): number | undefined {
+  const value = obs.snapshotEntries()[key]
+  return typeof value === "number" ? value : undefined
+}
+
+/**
+ * Watchdog: on every worker generation, notice a sweep that should already
+ * have happened and run it now.
+ *
+ * Defence in depth behind the `install` fix. An alarm can also be lost to a
+ * crash, a profile restore, or a browser bug — and the failure mode is
+ * completely silent, because nothing errors when a timer simply never fires.
+ * The cost of being wrong here is one extra sweep; the cost of not checking is
+ * the bug this patch exists to fix, back again by another route.
+ */
+async function watchdog(periodSeconds: number): Promise<void> {
+  const intervalMs = clampCheckPeriodSeconds(periodSeconds) * 1000
+  const alarm = await getCheckAlarm()
+  const now = Date.now()
+
+  if (!alarm) {
+    // `install` runs alongside this and will create it; the sweep it would
+    // have performed is what we owe the user right now.
+    count("alarm_repairs")
+    record("alarm.repaired", CHECK_ALARM, { why: "absent" }, "warn")
+    void number.check(undefined, undefined, "watchdog/absent")
+    return
+  }
+
+  const overdueBy = now - alarm.scheduledTime
+  if (overdueBy > intervalMs) {
+    count("alarm_repairs")
+    record(
+      "alarm.repaired",
+      CHECK_ALARM,
+      { why: "overdue", overdueBy, intervalMs },
+      "warn"
+    )
+    void chrome.alarms.create(CHECK_ALARM, {
+      when: now + intervalMs,
+      periodInMinutes: intervalMs / 60_000,
+    })
+    void number.check(undefined, undefined, "watchdog/overdue")
+  }
+}
 
 // fix outdated alarms when the machine wakes up
 chrome.idle.onStateChanged.addListener((state) => {
@@ -449,24 +739,30 @@ chrome.idle.onStateChanged.addListener((state) => {
 
 /* start: install/remove the alarm based on mode */
 {
-  const check = (): Promise<void> =>
+  /** Resolves with the active age threshold, or undefined when disabled. */
+  const check = (): Promise<number | undefined> =>
     storage<{ mode: string; period: number; tmp_disable: number }>({
       mode: "time-based",
       period: 10 * 60,
       tmp_disable: 0,
-    }).then((ps) => {
+    }).then(async (ps) => {
       if (
         ps.period &&
         (ps.mode === "time-based" || ps.mode === "url-based") &&
         ps.tmp_disable === 0
       ) {
-        number.install(ps.period)
-      } else {
-        number.remove()
+        await number.install(ps.period)
+        return ps.period
       }
+      number.remove()
+      return undefined
     })
   starters.push(() => {
-    void check()
+    void check().then(async (period) => {
+      if (period !== undefined) {
+        await watchdog(period)
+      }
+    })
   })
   chrome.storage.onChanged.addListener((ps) => {
     if (ps.period || ps.mode || ps.tmp_disable) {

--- a/extensions/suspender-ledger/src/worker/worker.ts
+++ b/extensions/suspender-ledger/src/worker/worker.ts
@@ -5,8 +5,17 @@
 // Ported from auto-tab-discard v3/worker/core.mjs (MPL-2.0)
 // Copyright (C) auto-tab-discard contributors
 
+import { isDebugToWorkerMessage } from "@suspender/types/messages"
+
 import { discard } from "./core/discard"
 import { isMoveCommand, navigate } from "./core/navigate"
+import {
+  count,
+  exportDiagnostics,
+  hydrateObservability,
+  obs,
+  record,
+} from "./core/observability"
 import { prefs, storage } from "./core/prefs"
 import { starters } from "./core/startup"
 import { log, query } from "./core/utils"
@@ -55,6 +64,22 @@ chrome.runtime.onMessageExternal.addListener((request, _sender, response) => {
 chrome.runtime.onMessage.addListener((request, sender, response) => {
   log("onMessage request received", request)
   const { method } = request
+  if (isDebugToWorkerMessage(request)) {
+    // The diagnostics page asks the live worker rather than reading the last
+    // flushed bundle out of storage — see DebugToWorkerMessage.
+    if (request.cmd === "clear") {
+      void obs.clear().then(() => response({ ok: true }))
+      return true
+    }
+    void exportDiagnostics().then(
+      (bundle) => response(bundle),
+      (error: unknown) =>
+        response({
+          error: error instanceof Error ? error.message : String(error),
+        })
+    )
+    return true
+  }
   if (method === "discard.on.load") {
     // for links discarded after the initial load
     if (sender.tab) {
@@ -70,6 +95,19 @@ chrome.runtime.onMessage.addListener((request, sender, response) => {
     return true
   }
   return undefined
+})
+
+// Flight recorder: rehydrate before anything else records, so counters span
+// the extension's whole life rather than this worker generation's. The
+// `worker.start` count is itself diagnostic — an implausibly high rate is the
+// signature of an event page being churned.
+starters.push(() => {
+  void hydrateObservability().then(() => {
+    count("worker_starts")
+    record("worker.start", chrome.runtime.getManifest().version, {
+      startedAt: Date.now(),
+    })
+  })
 })
 
 // left-click action: show the popup when configured, otherwise fall back to the

--- a/extensions/suspender-ledger/vite.config.ts
+++ b/extensions/suspender-ledger/vite.config.ts
@@ -18,6 +18,7 @@ export default extensionConfig({
     { name: "watch", input: "src/content/watch.ts" },
     { name: "resume-veil", input: "src/content/resume-veil.ts" },
     { name: "popup", input: "popup.html", classic: false },
+    { name: "debug", input: "debug.html", classic: false },
   ],
   copy: [{ from: "public/manifest.firefox.json", to: "manifest.json" }],
 })


### PR DESCRIPTION
## Description

Two changes that belong together: the reliability bug was effectively undiagnosable with the tools we had, and the observability work is what makes the next one diagnosable.

### The bug — tabs sporadically never suspended

`number.install()` created the periodic sweep alarm with `when: Date.now() + period`, unconditionally. It runs from a `starters` callback, and starters run at module evaluation on **every worker generation** — MV3 event pages are recycled aggressively, and neither `onStartup` nor `onInstalled` fires on a respawn, so the startup gate has to open unconditionally.

The extension registers `tabs.onUpdated`, `tabs.onActivated`, `runtime.onMessage` and more, so during active browsing the event page is woken every few seconds. Every wake re-armed the alarm from zero, pushing the next sweep another full interval into the future. The alarm could only ever fire during a lull longer than the entire interval.

Hence the symptom: suspension works fine on an idle machine and silently never happens while you are actually using the browser. Sporadic, not reproducible on demand, and invisible in logs — because nothing was failing. Nothing *ran*.

**Fix:** create the alarm only when it is missing or its cadence changed, plus a startup watchdog that sweeps immediately on an absent or overdue alarm. `number.scheduler.test.ts` is the regression suite.

Two secondary hardenings on the same theme (both were "happy path" assumptions about browser APIs):

- **Silent discard no-ops.** `chrome.tabs.discard` resolves for tabs the browser then declines to discard. The tab stayed live wearing its 💤 marker, indistinguishable from success at the call site. The outcome is now verified against `tabs.get` (a cached read that cannot materialize a discarded tab), counted as `suspend_noop`, and rolled back.
- **Swallowed injection failures.** `executeScript` rejections in the sweep were discarded whole (`() => []`), making "this tab is silently never eligible" look identical to "this tab is fine". The reason is now recorded as `tab.meta_error`.

### Observability

Offline diagnostics, **not** telemetry — there is no network path anywhere in the subsystem. The generic machinery is hoisted into `@some-extension/common/observability` so every extension in the workspace can adopt it; suspender-ledger is the reference adapter.

```
shared  → RingBuffer, MetricsStore, invariant runner, health scoring,
          persistence ports (memory + browser.storage)
adapter → event-kind union, counter names, invariants, context collector
```

Adapting extension N+1 means writing one ~200-line file and nothing else. Invariants are pure functions of a caller-gathered context, so they unit-test against plain object literals with no browser mock.

Bounded by construction — four independent limits: 500-event ring buffer, 2 KB per-event detail clamp, 200-key snapshot cap, 256 KB persisted budget. Debounced whole-bundle writes under one key; `error`-severity events bypass the debounce. Tab URLs are recorded as **origin only** — never paths, query strings, titles, or page content.

`debug.html` surfaces health (0–100 score + per-invariant status), metrics, current beliefs, a filterable timeline, and a user-initiated JSON export for bug reports. Reachable from the popup.

`trace()` keeps its signature but now writes into the recorder instead of an always-on console firehose, so its ~30 call sites became persisted timeline entries with no churn. The raw `tabs.onUpdated` firehose is filtered down to discarded-flag transitions and tabs we are mid-decision on.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Verified locally

| Check | Result |
| --- | --- |
| `pnpm lint` (suspender-ledger: eslint + MPL headers + tsc) | pass |
| `pnpm lint` (common: eslint + prettier + tsc) | pass |
| `pnpm vitest run` | 123 passed (14 files), up from 79 |
| `pnpm build` | pass |
| `assert-self-contained.mjs` | 3/3 classic entries self-contained |
| `web-ext lint --self-hosted` | 0 errors, 0 warnings, 0 notices |

Test mocks for `chrome.tabs.get` were updated so the fake browser stays self-consistent: previously `tabs.discard` reported success while `tabs.get` kept reporting the tab live, which models a browser that cannot exist — and is precisely the state the new verification is designed to flag.

## Screenshots

`debug.html` is new UI but is a plain diagnostic instrument (health panel, metric grid, event table) rather than product surface; no screenshot attached. Its layout is described in `docs/observability.md`.

## Docs

- `extensions/suspender-ledger/docs/observability.md` — design, storage discipline, adapter seam, and a write-up of the scheduler bug
- `extensions/suspender-ledger/amo-notes.md` — reviewer note on what is stored, how much, and how it leaves the machine (`data_collection_permissions` stays `["none"]`, correctly)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfpQe8VyqMhW2kX8SnRz4b)_