### PR TITLE
Fix sweep hangs and improve observability during startup

### DIFF
--- a/extensions/common/src/observability/metrics.ts
+++ b/extensions/common/src/observability/metrics.ts
@@ -102,6 +102,46 @@ export class MetricsStore<
     }
   }
 
+  /**
+   * Fold a snapshot into what is already held, rather than replacing it.
+   *
+   * The difference from {@link hydrate} is load-bearing during startup. An MV3
+   * worker records before `hydrate()`'s storage read resolves — the alarm
+   * listener and the startup sweep both run in that window — and those counts
+   * are real. Overwriting them with the on-disk value silently deletes exactly
+   * the evidence the startup window exists to produce.
+   */
+  merge(snapshot: MetricsSnapshot | undefined): void {
+    if (!snapshot) {
+      return
+    }
+    for (const [name, value] of Object.entries(snapshot.counters)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        this.counters.set(name, (this.counters.get(name) ?? 0) + value)
+      }
+    }
+    for (const [name, value] of Object.entries(snapshot.aggregates)) {
+      if (!isAggregate(value)) {
+        continue
+      }
+      const prior = this.aggregates.get(name)
+      if (!prior) {
+        this.aggregates.set(name, { ...value })
+        continue
+      }
+      this.aggregates.set(name, {
+        count: prior.count + value.count,
+        sum: prior.sum + value.sum,
+        min: Math.min(prior.min, value.min),
+        max: Math.max(prior.max, value.max),
+        // `prior` is the newer of the two: merge folds a just-loaded historical
+        // snapshot into counts taken moments ago, so the in-memory `last` is
+        // the more recent observation.
+        last: prior.last,
+      })
+    }
+  }
+
   /** Zero everything — the debug page's "reset counters" action. */
   reset(): void {
     this.counters.clear()

--- a/extensions/common/src/observability/recorder.ts
+++ b/extensions/common/src/observability/recorder.ts
@@ -129,6 +129,27 @@ export class Recorder<
    * Load persisted state. Call once, early in worker startup: an MV3 event
    * page is recycled constantly, and a recorder that starts empty on every
    * respawn measures the worker's lifetime instead of the extension's.
+   *
+   * ## Why this merges rather than replaces
+   *
+   * `hydrate` is asynchronous — it awaits a storage read — but recording is
+   * not, and the worker does not wait. Module evaluation registers the event
+   * listeners, and whatever those listeners fire during the read window (an
+   * alarm that fired *and is what woke the page*, the startup sweep it kicks
+   * off) records into a recorder that has not loaded yet.
+   *
+   * The previous implementation then did `buffer.clear()` and overwrote every
+   * counter with the on-disk value, so all of it vanished. The visible symptom
+   * was a timeline where a sweep's `tab.skipped` events appear with no
+   * preceding `check.start`, and where a worker generation woken *by* an alarm
+   * shows `worker.start` → `alarm.kept` and no `alarm.fired` — which then reads
+   * downstream as a phantom "missed alarm" whose interval is a clean multiple
+   * of the period. The scheduler was fine; the recorder was eating the proof.
+   *
+   * That window is the single most diagnostically valuable part of a worker's
+   * life, so it is the one part that must not be dropped. Stored history is
+   * folded in *underneath* what this generation has already seen: disk events
+   * first, then live events re-sequenced to follow them.
    */
   async hydrate(): Promise<void> {
     if (this.hydrated || this.disposed) {
@@ -140,6 +161,11 @@ export class Recorder<
       // Absent, or written by a different workspace sharing the storage area.
       return
     }
+
+    // Everything recorded while the load above was in flight.
+    const live = this.buffer.toArray()
+    const liveMetrics = this.metrics.snapshot()
+
     const events = stored.events.filter(isEventShape)
     const restored = RingBuffer.from(
       this.buffer.capacity,
@@ -148,12 +174,28 @@ export class Recorder<
     )
     this.buffer.clear()
     this.buffer.extend(restored.toArray())
+
+    this.metrics.reset()
     this.metrics.hydrate(stored.metrics)
+    this.metrics.merge(liveMetrics)
+
+    // Stored snapshots must not clobber a fresher value this generation already
+    // published — `alarm:lastFire` written by the very alarm that woke us is
+    // newer than the one on disk by definition.
     for (const [key, value] of Object.entries(stored.snapshots)) {
-      this.snapshots.set(key, value)
+      if (!this.snapshots.has(key)) {
+        this.snapshots.set(key, value)
+      }
     }
-    this.errorCount = events.filter((e) => e.severity === "error").length
+
     this.seq = events.reduce((max, e) => Math.max(max, e.seq), 0)
+    for (const event of live) {
+      this.seq += 1
+      this.buffer.push({ ...event, seq: this.seq })
+    }
+    this.errorCount =
+      events.filter((e) => e.severity === "error").length +
+      live.filter((e) => e.severity === "error").length
   }
 
   /** Stop recording without losing what is already held. */

--- a/extensions/suspender-ledger/debug.html
+++ b/extensions/suspender-ledger/debug.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="dark light" />
+    <meta name="color-scheme" content="dark" />
     <title>Suspender Ledger — Diagnostics</title>
     <style>
       html,

--- a/extensions/suspender-ledger/src/debug/debug.css
+++ b/extensions/suspender-ledger/src/debug/debug.css
@@ -3,45 +3,40 @@
  * Diagnostics page styling. Deliberately plain: this page is a debugging
  * instrument, not product surface, and it must stay readable when the thing it
  * reports on is broken. Everything is theme-token driven so it inherits the
- * popup's palette. */
+ * popup's palette.
+ *
+ * Dark unconditionally, matching popup.css — and matching the rest of this
+ * workspace, which ships an extension whose whole job is forcing vendor pages
+ * dark. Following `prefers-color-scheme` here meant our own surface was the one
+ * thing that ignored the preference every other surface is built to enforce:
+ * open the diagnostics page from a dark popup and get a white flash. A page we
+ * own should not need the filter extension pointed at it. */
 
 :root {
+  color-scheme: dark;
+
   --sl-bg: #1a1a1a;
   --sl-fg: #e0e0e0;
   --sl-muted: #8a8a8a;
-  --sl-panel: #232323;
-  --sl-border: #383838;
+  --sl-panel: #232326;
+  --sl-border: rgb(255 255 255 / 8%);
   --sl-ok: #4ade80;
   --sl-warn: #fbbf24;
   --sl-bad: #f87171;
-  --sl-accent: #60a5fa;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --sl-bg: #fafafa;
-    --sl-fg: #1a1a1a;
-    --sl-muted: #666;
-    --sl-panel: #fff;
-    --sl-border: #ddd;
-    --sl-ok: #15803d;
-    --sl-warn: #a16207;
-    --sl-bad: #b91c1c;
-    --sl-accent: #1d4ed8;
-  }
+  --sl-accent: #6aa6ff;
 }
 
 #app {
-  max-width: 60rem;
   margin: 0 auto;
+  max-width: 60rem;
   padding: 1.5rem 1rem 4rem;
 }
 
 .sl-head {
+  align-items: baseline;
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  align-items: baseline;
   justify-content: space-between;
   margin-bottom: 1.25rem;
 }
@@ -62,14 +57,14 @@
 }
 
 button {
+  background: var(--sl-panel);
+  border: 1px solid var(--sl-border);
+  border-radius: 0.35rem;
+  color: var(--sl-fg);
+  cursor: pointer;
   font: inherit;
   font-size: 0.8rem;
   padding: 0.35rem 0.75rem;
-  border-radius: 0.35rem;
-  border: 1px solid var(--sl-border);
-  background: var(--sl-panel);
-  color: var(--sl-fg);
-  cursor: pointer;
 }
 
 button:hover {
@@ -80,16 +75,16 @@ section {
   background: var(--sl-panel);
   border: 1px solid var(--sl-border);
   border-radius: 0.5rem;
-  padding: 0.9rem 1rem;
   margin-bottom: 1rem;
+  padding: 0.9rem 1rem;
 }
 
 section > h2 {
+  color: var(--sl-muted);
   font-size: 0.75rem;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--sl-muted);
   margin: 0 0 0.75rem;
+  text-transform: uppercase;
 }
 
 .sl-score {
@@ -99,20 +94,23 @@ section > h2 {
 }
 
 .sl-score small {
+  color: var(--sl-muted);
   font-size: 0.8rem;
   font-weight: 400;
-  color: var(--sl-muted);
 }
 
 .ok {
   color: var(--sl-ok);
 }
+
 .warn {
   color: var(--sl-warn);
 }
+
 .bad {
   color: var(--sl-bad);
 }
+
 .muted {
   color: var(--sl-muted);
 }
@@ -124,11 +122,11 @@ ul.sl-checks {
 }
 
 ul.sl-checks li {
-  display: grid;
-  grid-template-columns: 1.25rem 1fr;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
   border-top: 1px solid var(--sl-border);
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1.25rem 1fr;
+  padding: 0.35rem 0;
 }
 
 ul.sl-checks .sl-desc {
@@ -138,17 +136,17 @@ ul.sl-checks .sl-desc {
 
 .sl-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
   gap: 0.5rem 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
 }
 
 .sl-metric {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
   border-bottom: 1px dotted var(--sl-border);
-  padding: 0.2rem 0;
+  display: flex;
   font-variant-numeric: tabular-nums;
+  gap: 0.5rem;
+  justify-content: space-between;
+  padding: 0.2rem 0;
 }
 
 .sl-metric .k {
@@ -160,22 +158,22 @@ ul.sl-checks .sl-desc {
 }
 
 table.sl-events {
-  width: 100%;
   border-collapse: collapse;
   font-size: 0.78rem;
   font-variant-numeric: tabular-nums;
+  width: 100%;
 }
 
 table.sl-events th {
-  text-align: left;
   color: var(--sl-muted);
   font-weight: 500;
   padding: 0.25rem 0.5rem 0.4rem 0;
+  text-align: left;
 }
 
 table.sl-events td {
-  padding: 0.2rem 0.5rem 0.2rem 0;
   border-top: 1px solid var(--sl-border);
+  padding: 0.2rem 0.5rem 0.2rem 0;
   vertical-align: top;
 }
 
@@ -194,13 +192,13 @@ table.sl-events td.detail {
 
 .sl-filter input,
 .sl-filter select {
+  background: var(--sl-bg);
+  border: 1px solid var(--sl-border);
+  border-radius: 0.35rem;
+  color: var(--sl-fg);
   font: inherit;
   font-size: 0.8rem;
   padding: 0.3rem 0.5rem;
-  border-radius: 0.35rem;
-  border: 1px solid var(--sl-border);
-  background: var(--sl-bg);
-  color: var(--sl-fg);
 }
 
 .sl-empty {

--- a/extensions/suspender-ledger/src/worker/core/observability.test.ts
+++ b/extensions/suspender-ledger/src/worker/core/observability.test.ts
@@ -124,6 +124,61 @@ describe("Recorder", () => {
     expect(second.events().map((e) => e.kind)).toEqual(["a"])
   })
 
+  it("keeps events recorded before hydrate resolves", async () => {
+    const persistence = memoryPersistence()
+    const first = makeRecorder(persistence)
+    first.record({ kind: "a", subject: "old" })
+    await first.flush()
+
+    // The startup window: an MV3 worker registers its listeners at module
+    // evaluation and they fire immediately — an alarm that fired *and is what
+    // woke the page* records here, while hydrate's storage read is still in
+    // flight. Clearing the buffer on load deleted exactly that, which is how a
+    // sweep's `tab.skipped` events came to appear with no `check.start` before
+    // them, and how a real alarm fire came to look like a missed one.
+    const second = makeRecorder(persistence)
+    const loading = second.hydrate()
+    second.record({ kind: "b", subject: "during-hydrate" })
+    await loading
+
+    expect(second.events().map((e) => e.subject)).toEqual([
+      "old",
+      "during-hydrate",
+    ])
+    // Re-sequenced to follow the restored history, not left colliding with it.
+    expect(second.events().map((e) => e.seq)).toEqual([1, 2])
+  })
+
+  it("adds counters taken during the hydrate window to the stored ones", async () => {
+    const persistence = memoryPersistence()
+    const first = makeRecorder(persistence)
+    first.count("hits", 4)
+    await first.flush()
+
+    const second = makeRecorder(persistence)
+    const loading = second.hydrate()
+    second.count("hits", 2)
+    await loading
+
+    // 6, not 4 — overwriting would silently discard the live count, which is
+    // what made `alarm_fires` under-report every fire that woke the worker.
+    expect(second.metrics.counter("hits")).toBe(6)
+  })
+
+  it("does not let a stored snapshot overwrite a fresher live one", async () => {
+    const persistence = memoryPersistence()
+    const first = makeRecorder(persistence)
+    first.setSnapshot("alarm:lastFire", 1000)
+    await first.flush()
+
+    const second = makeRecorder(persistence)
+    const loading = second.hydrate()
+    second.setSnapshot("alarm:lastFire", 2000)
+    await loading
+
+    expect(second.snapshotEntries()["alarm:lastFire"]).toBe(2000)
+  })
+
   it("continues the sequence after hydrating rather than restarting at 1", async () => {
     const persistence = memoryPersistence()
     const first = makeRecorder(persistence)
@@ -256,6 +311,8 @@ const context = (over: Partial<InvariantContext> = {}): InvariantContext => ({
   expectedIntervalMs: INTERVAL,
   alarmScheduledTime: NOW + INTERVAL,
   lastCheckAt: NOW - 1000,
+  sweepsStarted: 10,
+  sweepsSettled: 10,
   marker: "💤",
   tabs: [],
   inFlight: [],
@@ -316,6 +373,35 @@ describe("suspender invariants", () => {
     const result = await check(
       "CheckRanRecently",
       context({ lastCheckAt: undefined })
+    )
+    expect(result.status).toBe("unknown")
+  })
+
+  it("SweepsTerminate catches sweeps that start and never finish", async () => {
+    // The exact shape of the reported regression: the scheduler is healthy and
+    // firing, every sweep is entered, and not one of them ever reaches a
+    // terminal outcome because a tab probe hangs mid-loop. Every other
+    // invariant reads green through this — which is how a profile that had not
+    // suspended a single tab in hours still scored 100.
+    const result = await check(
+      "SweepsTerminate",
+      context({ sweepsStarted: 13, sweepsSettled: 0 })
+    )
+    expect(result.status).toBe("violated")
+  })
+
+  it("SweepsTerminate tolerates exactly one sweep in flight", async () => {
+    const result = await check(
+      "SweepsTerminate",
+      context({ sweepsStarted: 13, sweepsSettled: 12 })
+    )
+    expect(result.status).toBe("ok")
+  })
+
+  it("SweepsTerminate reports unknown before any sweep has run", async () => {
+    const result = await check(
+      "SweepsTerminate",
+      context({ sweepsStarted: 0, sweepsSettled: 0 })
     )
     expect(result.status).toBe("unknown")
   })

--- a/extensions/suspender-ledger/src/worker/core/observability.ts
+++ b/extensions/suspender-ledger/src/worker/core/observability.ts
@@ -66,8 +66,11 @@ export type SuspenderEventKind =
   | "check.skipped"
   | "check.done"
   | "check.error"
+  | "check.failed"
+  | "check.census"
   | "tab.skipped"
   | "tab.meta_error"
+  | "tab.meta_timeout"
   // one tab's suspend lifecycle
   | "suspend.requested"
   | "suspend.queued"
@@ -95,12 +98,14 @@ export type SuspenderCounter =
   | "alarm_missed"
   | "alarm_repairs"
   | "checks_run"
+  | "checks_done"
   | "checks_skipped"
   | "check_errors"
   | "tabs_scanned"
   | "tabs_selected"
   | "tabs_skipped"
   | "meta_errors"
+  | "meta_timeouts"
   | "suspend_attempts"
   | "suspend_succeeded"
   | "suspend_noop"
@@ -132,6 +137,10 @@ export type InvariantContext = {
   alarmScheduledTime: number | undefined
   /** Epoch ms of the last completed sweep, if one has run since install. */
   lastCheckAt: number | undefined
+  /** Lifetime count of sweeps entered. */
+  sweepsStarted: number
+  /** Lifetime count of sweeps that reached a terminal outcome. */
+  sweepsSettled: number
   /** The configured title marker; "" disables marking entirely. */
   marker: string
   tabs: ReadonlyArray<{
@@ -197,6 +206,26 @@ export const suspenderInvariants: ReadonlyArray<Invariant<InvariantContext>> = [
         ? violated({
             msSinceLastCheck: since,
             expectedIntervalMs: ctx.expectedIntervalMs,
+          })
+        : { ok: true }
+    },
+  },
+  {
+    name: "SweepsTerminate",
+    description:
+      "Sweeps entered and sweeps finished must stay in step — a growing gap means each sweep is starting and then dying mid-flight.",
+    check: (ctx): InvariantOutcome => {
+      if (ctx.sweepsStarted === 0) {
+        return { ok: "unknown" }
+      }
+      // One sweep may legitimately be in flight at the moment of the reading;
+      // a second is already a pattern, not a race.
+      const stranded = ctx.sweepsStarted - ctx.sweepsSettled
+      return stranded > 1
+        ? violated({
+            stranded,
+            started: ctx.sweepsStarted,
+            settled: ctx.sweepsSettled,
           })
         : { ok: true }
     },
@@ -406,6 +435,11 @@ export async function collectInvariantContext(): Promise<InvariantContext> {
     expectedIntervalMs: schedulingEnabled ? checkIntervalMs(stored.period) : 0,
     alarmScheduledTime,
     lastCheckAt,
+    sweepsStarted: obs.metrics.counter("checks_run"),
+    sweepsSettled:
+      obs.metrics.counter("checks_done") +
+      obs.metrics.counter("checks_skipped") +
+      obs.metrics.counter("check_errors"),
     marker: prefs.prepends,
     tabs,
     inFlight: stateProbe().inFlight,

--- a/extensions/suspender-ledger/src/worker/modes/number.test.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.test.ts
@@ -49,6 +49,9 @@ const readyResult = (
 ]
 
 beforeEach(() => {
+  // Any test that installs fake timers must not be able to leak them into the
+  // next one, even if it fails before its own cleanup runs.
+  vi.useRealTimers()
   vi.clearAllMocks()
   discard.count = 0
   discard.time = 0
@@ -125,6 +128,46 @@ describe("number.check — auto-discard", () => {
 
     expect(chrome.tabs.discard).toHaveBeenCalledWith(10)
     expect(chrome.tabs.remove).not.toHaveBeenCalled()
+  })
+
+  it("does not let a tab that never answers stall the rest of the sweep", async () => {
+    // A wedged content process is what this looks like from the worker:
+    // executeScript neither resolves nor rejects, because the injected function
+    // is queued behind a page main thread that is never going to run it.
+    // Awaited unguarded, it does not slow the sweep down — it ends it, and
+    // every tab after it in the list is never evaluated again.
+    vi.useFakeTimers()
+    try {
+      const tabs = Array.from({ length: 8 }, (_, i) => makeTab({ id: 10 + i }))
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      vi.mocked(chrome.tabs.query).mockImplementation(((
+        _opts: unknown,
+        cb: QueryCb
+      ) => cb(tabs)) as never)
+
+      vi.mocked(chrome.scripting.executeScript).mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        (injection: { target?: { tabId?: number } }) =>
+          injection.target?.tabId === 10
+            ? new Promise(() => undefined)
+            : Promise.resolve(readyResult())
+      )
+
+      const sweep = number.check(undefined, { number: 0 })
+      await vi.advanceTimersByTimeAsync(10_000)
+      await sweep
+
+      // The sweep resolved at all — before the probe deadline it hung here
+      // forever — and every tab behind the wedged one was still judged.
+      for (const id of [11, 12, 13, 14, 15, 16, 17]) {
+        expect(chrome.tabs.discard).toHaveBeenCalledWith(id)
+      }
+      // The unanswerable tab is passed over, not suspended blind: we cannot see
+      // unsaved form input in a page that will not talk to us.
+      expect(chrome.tabs.discard).not.toHaveBeenCalledWith(10)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("skips a tab whose meta.ready is false (collector not yet injected)", async () => {

--- a/extensions/suspender-ledger/src/worker/modes/number.ts
+++ b/extensions/suspender-ledger/src/worker/modes/number.ts
@@ -40,6 +40,16 @@ import { log, match, query } from "../core/utils"
  *     affected tabs are skipped.
  */
 
+/**
+ * One frame's result from the meta-collector injection. Structural rather than
+ * `chrome.scripting.InjectionResult<CollectedMeta>`: `readMeta` already treats
+ * `result` as untrusted, and the collector runs in a page we do not control.
+ */
+type MetaInjection = {
+  frameId?: number
+  result?: unknown
+}
+
 /** Per-tab metadata returned by the injected meta collector. */
 type TabMeta = {
   ready?: boolean
@@ -100,6 +110,81 @@ function closeEnough(a: number | undefined, b: number): boolean {
 }
 
 /**
+ * How long to wait for one tab's metadata probe before giving up on it.
+ *
+ * `chrome.scripting.executeScript` resolves when the injected function has run
+ * *in the page's own main thread*. It therefore inherits that thread's health:
+ * a page pegged by a busy script, a wedged content process, or a cross-origin
+ * frame that never becomes scriptable simply never answers. It does not reject,
+ * and it has no built-in deadline — a rejection handler is no defence, because
+ * nothing is ever rejected.
+ *
+ * Awaited unguarded in a sequential loop, one such tab is not a slow tab: it is
+ * a permanently stopped sweep, and every tab behind it in the list is never
+ * evaluated again for the life of the profile.
+ */
+const META_TIMEOUT_MS = 5_000
+
+/**
+ * How many tabs to probe at once.
+ *
+ * Strictly sequential probing costs a full round-trip per tab; across a
+ * few-hundred-tab profile that is minutes of wall-clock during which the event
+ * page can be recycled out from under the sweep — losing it just as surely as
+ * a hang, only less obviously. Modest parallelism keeps a sweep to seconds.
+ * Kept low deliberately: each probe runs script in a real page, and a good
+ * citizen does not stampede the browser to save a few hundred milliseconds.
+ */
+const META_CONCURRENCY = 6
+
+/**
+ * Resolve with `undefined` if `promise` has not settled within `ms`.
+ *
+ * The pending promise is abandoned, not cancelled — there is no way to cancel
+ * an in-flight `executeScript`. That is acceptable: it holds one closure, and
+ * the sweep no longer waits on it.
+ */
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number
+): Promise<T | undefined> {
+  return new Promise<T | undefined>((resolve) => {
+    const timer = setTimeout(() => resolve(undefined), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      () => {
+        clearTimeout(timer)
+        resolve(undefined)
+      }
+    )
+  })
+}
+
+/** Run `worker` over every item, at most `limit` in flight. Never rejects. */
+async function forEachConcurrent<T>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  worker: (item: T) => Promise<void>
+): Promise<void> {
+  let cursor = 0
+  const lanes = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      while (cursor < items.length) {
+        const item = items[cursor++]
+        if (item !== undefined) {
+          await worker(item)
+        }
+      }
+    }
+  )
+  await Promise.all(lanes)
+}
+
+/**
  * Record the end of one sweep: duration into the aggregate, tallies into the
  * timeline. Every exit path from `check()` goes through here or through the
  * `check.skipped` branches, so a sweep that vanishes mid-flight is visible as
@@ -116,7 +201,81 @@ function finish(
 ): void {
   const duration = Date.now() - startedAt
   observe("check_duration_ms", duration)
+  count("checks_done")
+  noteCheckCompleted(Date.now())
   record("check.done", undefined, { ...tally, durationMs: duration })
+}
+
+/**
+ * Terminate a sweep early — a legitimate outcome, not a failure. A sweep that
+ * decides there is nothing to do has run just as surely as one that suspends
+ * something, so it counts as completion for {@link noteCheckCompleted}.
+ */
+function abandon(
+  reason: string,
+  why: string,
+  detail: Record<string, JsonValue> = {}
+): void {
+  count("checks_skipped")
+  noteCheckCompleted(Date.now())
+  record("check.skipped", reason, { why, ...detail })
+}
+
+/**
+ * The whole tab population, independent of the sweep's candidate filters.
+ *
+ * Answers "does the suspender even see my tabs?" — a question the candidate
+ * count alone cannot, since it is the count *after* every filter has run.
+ */
+async function readTabCensus(): Promise<{
+  total: number
+  windows: number
+  discarded: number
+  active: number
+  pinned: number
+  audible: number
+}> {
+  try {
+    const all = await chrome.tabs.query({})
+    return {
+      total: all.length,
+      windows: new Set(all.map((t) => t.windowId)).size,
+      discarded: all.filter((t) => t.discarded === true).length,
+      active: all.filter((t) => t.active).length,
+      pinned: all.filter((t) => t.pinned).length,
+      audible: all.filter((t) => t.audible === true).length,
+    }
+  } catch {
+    return {
+      total: -1,
+      windows: -1,
+      discarded: -1,
+      active: -1,
+      pinned: -1,
+      audible: -1,
+    }
+  }
+}
+
+/**
+ * Run a sweep, recording a rejection rather than dropping it.
+ *
+ * Every scheduled sweep is launched fire-and-forget, so before this an
+ * exception thrown after `check.start` — anywhere outside the per-tab
+ * `try`/`catch` — became an unhandled rejection: no event, no counter, no
+ * console line. The sweep simply stopped existing, and the timeline showed a
+ * `check.start` with nothing after it.
+ */
+function runCheck(reason: string): void {
+  void number.check(undefined, undefined, reason).catch((e: unknown) => {
+    count("check_errors")
+    record(
+      "check.failed",
+      reason,
+      { error: e instanceof Error ? e.message : String(e) },
+      "error"
+    )
+  })
 }
 
 /**
@@ -244,11 +403,12 @@ const number: NumberMode = {
     const startedAt = Date.now()
     count("checks_run")
     record("check.start", reason ?? "manual")
-    // Noted at the *start*: what the CheckRanRecently invariant is really
-    // asking is "did the scheduler wake us", and a sweep that skips out early
-    // (machine not idle, tab count below threshold) answers that just as well
-    // as one that suspends something.
-    noteCheckCompleted(startedAt)
+    // Completion is noted at the *terminal* points (`finish` / `abandon`), not
+    // here. Noting it on entry made CheckRanRecently ask "did the scheduler
+    // wake us" — which a sweep that starts and then hangs forever answers
+    // perfectly well. The whole class of bug the invariant exists to catch
+    // lives after this line, so a mark taken before it can only ever read
+    // green.
 
     const base = await storage<Omit<CheckPrefs, "whitelist.session">>({
       mode: "time-based",
@@ -284,16 +444,14 @@ const number: NumberMode = {
       )
       if (state !== "idle") {
         log("discarding is skipped", "not in the idle state")
-        count("checks_skipped")
-        record("check.skipped", reason ?? "manual", { why: "machine-not-idle" })
+        abandon(reason ?? "manual", "machine-not-idle")
         return
       }
     }
     // only check if INTERNET is connected
     if (prefs.online && navigator.onLine === false) {
       log("discarding is skipped", "No INTERNET connection detected")
-      count("checks_skipped")
-      record("check.skipped", reason ?? "manual", { why: "offline" })
+      abandon(reason ?? "manual", "offline")
       return
     }
 
@@ -312,6 +470,25 @@ const number: NumberMode = {
     }
     let tbs = await query(options)
     count("tabs_scanned", tbs.length)
+
+    // The candidate query is heavily filtered — `discarded: false` alone hides
+    // every tab the browser already unloaded, which on a session-restored
+    // profile is most of them. Without the total alongside it, `tabs_scanned`
+    // is unreadable: there is no way to tell "your 200 tabs are already
+    // unloaded, nothing to do" apart from "the sweep can only see 20 of your
+    // 200 tabs", and those call for opposite responses. Record the census.
+    const census = await readTabCensus()
+    record("check.census", reason ?? "manual", {
+      ...census,
+      candidates: tbs.length,
+      query: {
+        discarded: false,
+        active: options.active ?? null,
+        pinned: options.pinned ?? null,
+        audible: options.audible ?? null,
+      },
+    })
+    obs.setSnapshot("tabs:census", { ...census, at: Date.now() })
 
     /** Record why one tab was passed over. The "why wasn't this tab suspended?"
      *  question is answered entirely from these events. */
@@ -398,9 +575,7 @@ const number: NumberMode = {
           tbs.length,
           prefs.number
         )
-        count("checks_skipped")
-        record("check.skipped", reason ?? "manual", {
-          why: "below-tab-threshold",
+        abandon(reason ?? "manual", "below-tab-threshold", {
           candidates: tbs.length,
           ignored: exceptionCount,
           threshold: prefs.number,
@@ -412,9 +587,15 @@ const number: NumberMode = {
     const now = Date.now()
     const map = new Map<chrome.tabs.Tab, TabMeta>()
     const arr: Array<chrome.tabs.Tab> = []
-    for (const tb of tbs) {
+
+    /**
+     * Judge one tab: either add it to the candidate set or record why not.
+     * Never throws and never waits indefinitely, so no single tab can decide
+     * the fate of the whole sweep.
+     */
+    const evaluate = async (tb: chrome.tabs.Tab): Promise<void> => {
       if (tb.id === undefined) {
-        continue
+        return
       }
       try {
         // An injection failure used to be swallowed whole (`() => []`), which
@@ -422,23 +603,46 @@ const number: NumberMode = {
         // "this tab is fine". Keep the same non-fatal behaviour, but keep the
         // reason.
         let injectionError: string | undefined
-        const results =
-          tb.status === "unloaded"
-            ? []
-            : await chrome.scripting
-                .executeScript({
-                  target: { tabId: tb.id, allFrames: true },
-                  // Inject the collector as a function, not a bundled file: a
-                  // bundler tree-shakes the file's completion-value payload.
-                  func: collectMeta,
-                })
-                .then(
-                  (r) => r,
-                  (e: unknown) => {
-                    injectionError = e instanceof Error ? e.message : String(e)
-                    return []
-                  }
-                )
+        let results: Array<MetaInjection> = []
+        if (tb.status !== "unloaded") {
+          const probed = await withTimeout(
+            chrome.scripting
+              .executeScript({
+                target: { tabId: tb.id, allFrames: true },
+                // Inject the collector as a function, not a bundled file: a
+                // bundler tree-shakes the file's completion-value payload.
+                func: collectMeta,
+              })
+              .then(
+                (r) => r,
+                (e: unknown) => {
+                  injectionError = e instanceof Error ? e.message : String(e)
+                  return []
+                }
+              ),
+            META_TIMEOUT_MS
+          )
+          if (probed === undefined) {
+            // The page never answered. Treat it as unjudgeable rather than as
+            // safe-to-suspend: we cannot see unsaved form input from here, and
+            // suspending through it would lose the user's work.
+            count("meta_timeouts")
+            record(
+              "tab.meta_timeout",
+              tb.id,
+              {
+                origin: safeOrigin(tb.url),
+                status: tb.status ?? null,
+                timeoutMs: META_TIMEOUT_MS,
+              },
+              "warn"
+            )
+            skipped(tb, "meta-timeout", { timeoutMs: META_TIMEOUT_MS })
+            exceptionCount += 1
+            return
+          }
+          results = probed
+        }
         if (injectionError !== undefined) {
           count("meta_errors")
           record("tab.meta_error", tb.id, {
@@ -459,7 +663,7 @@ const number: NumberMode = {
             icon(tb, "metadata fetch error")
             skipped(tb, "metadata-unavailable", { status: tb.status ?? null })
             exceptionCount += 1
-            continue
+            return
           }
         }
         const meta: TabMeta = Object.assign({}, ...ms)
@@ -491,48 +695,48 @@ const number: NumberMode = {
             origin: safeOrigin(tb.url),
           })
           void discard(tb)
-          continue
+          return
         }
         if (meta.ready !== true && ops["ignore.ready.state"] !== true) {
           log("discarding aborted", "tab is not ready", tb)
           skipped(tb, "not-ready", { status: tb.status ?? null })
           exceptionCount += 1
-          continue
+          return
         }
         if (prefs.audio && meta.audible) {
           log("discarding aborted", "audio is playing", tb)
           icon(tb, "tab plays an audio")
           skipped(tb, "audible")
           exceptionCount += 1
-          continue
+          return
         }
         if (prefs.paused && meta.paused) {
           log("discarding aborted", "player is paused", tb)
           icon(tb, "tab has a paused player")
           skipped(tb, "paused-media")
           exceptionCount += 1
-          continue
+          return
         }
         if (prefs.form && meta.forms) {
           log("discarding aborted", "active form", tb)
           icon(tb, "there is an active form on this tab")
           skipped(tb, "unsaved-form")
           exceptionCount += 1
-          continue
+          return
         }
         if (prefs["notification.permission"] && meta.permission) {
           log("discarding aborted", "tab has notification permission")
           icon(tb, "tab has notification permission")
           skipped(tb, "notification-permission")
           exceptionCount += 1
-          continue
+          return
         }
         if (tb.autoDiscardable === false) {
           log("discarding aborted", "tab is not discardable", tb)
           skipped(tb, "not-auto-discardable")
           exceptionCount += 1
           icon(tb, "tab is not discardable")
-          continue
+          return
         }
         if (now - (meta.time ?? tb.lastAccessed ?? now) < prefs.period * 1000) {
           log("discarding aborted", "tab is not old", tb)
@@ -544,21 +748,17 @@ const number: NumberMode = {
           })
           exceptionCount += 1
           icon.reset(tb)
-          continue
+          return
         }
         if (tb.active) {
           log("discarding aborted", "tab is active", tb)
           skipped(tb, "active")
           exceptionCount += 1
           icon.reset(tb)
-          continue
+          return
         }
         map.set(tb, meta)
         arr.push(tb)
-        if (arr.length > prefs["max.single.discard"]) {
-          log("number.check", "breaking", "max number of tabs reached")
-          break
-        }
       } catch (e) {
         log("number.check error", e)
         count("check_errors")
@@ -571,6 +771,14 @@ const number: NumberMode = {
       }
     }
 
+    // Note on the dropped early-exit: the sequential loop used to `break` once
+    // `arr` passed `max.single.discard`. That truncated the candidate set
+    // *before* it was sorted by age, so the cap was applied to whichever tabs
+    // the query happened to list first rather than to the oldest ones. The
+    // `slice` below still enforces the same cap, now against a fully-sorted
+    // set — the oldest tabs win, which is what the cap was always for.
+    await forEachConcurrent(tbs, META_CONCURRENCY, evaluate)
+
     if (prefs["icon-update"] === true) {
       if (tbs.length + exceptionCount <= prefs.number) {
         log(
@@ -579,9 +787,7 @@ const number: NumberMode = {
           tbs.length,
           prefs.number
         )
-        count("checks_skipped")
-        record("check.skipped", reason ?? "manual", {
-          why: "below-tab-threshold",
+        abandon(reason ?? "manual", "below-tab-threshold", {
           candidates: tbs.length,
           ignored: exceptionCount,
           threshold: prefs.number,
@@ -669,7 +875,7 @@ chrome.alarms.onAlarm.addListener((alarm) => {
         periodInMinutes: alarm.periodInMinutes,
       })
     }
-    void number.check(undefined, undefined, "number/1")
+    runCheck("number/1")
   }
 })
 
@@ -699,7 +905,7 @@ async function watchdog(periodSeconds: number): Promise<void> {
     // have performed is what we owe the user right now.
     count("alarm_repairs")
     record("alarm.repaired", CHECK_ALARM, { why: "absent" }, "warn")
-    void number.check(undefined, undefined, "watchdog/absent")
+    runCheck("watchdog/absent")
     return
   }
 
@@ -716,7 +922,7 @@ async function watchdog(periodSeconds: number): Promise<void> {
       when: now + intervalMs,
       periodInMinutes: intervalMs / 60_000,
     })
-    void number.check(undefined, undefined, "watchdog/overdue")
+    runCheck("watchdog/overdue")
   }
 }
 


### PR DESCRIPTION
## Description

This PR addresses a critical issue where tab metadata probes could hang indefinitely, stalling the entire sweep and preventing subsequent tabs from being evaluated. It also fixes observability gaps during worker startup that masked these hangs.

### Key Changes

**Sweep Reliability:**
- Add timeout handling for `chrome.scripting.executeScript` calls that never resolve (wedged content processes, unresponsive pages). Tabs that don't answer within 5 seconds are marked as unjudgeable rather than blocking the sweep.
- Implement concurrent tab evaluation (6 tabs in parallel) to prevent a single slow tab from stalling the entire sweep. Previously, sequential evaluation meant one hung tab stopped all subsequent tabs from being checked.
- Refactor tab evaluation into an `evaluate` function that never throws and never waits indefinitely, ensuring robustness.

**Observability & Startup:**
- Fix `Recorder.hydrate()` to merge live events/counters recorded during the async storage read, rather than clearing them. This was causing startup events (alarm fires, initial sweep) to vanish from the timeline.
- Add `SweepsTerminate` invariant to detect sweeps that start but never finish—the exact pattern this bug created.
- Add `check.census` event to record the full tab population alongside candidates, making it possible to distinguish "nothing to do" from "can't see tabs."
- Track `checks_done` and `checks_skipped` counters to measure sweep completion.
- Add `meta_timeouts` counter and `tab.meta_timeout` event to track probes that exceed the deadline.

**Code Quality:**
- Add `MetricsStore.merge()` to fold snapshots without overwriting fresher values.
- Improve debug page styling (dark mode unconditionally, consistent with the extension's purpose).
- Add comprehensive test coverage for startup window behavior and timeout handling.

### Type of Change

- [x] Bug fix (fixes sweeps hanging indefinitely on unresponsive tabs)
- [x] New feature (concurrent evaluation, timeout handling, improved observability)

## Test Plan

- Added unit tests for timeout behavior and concurrent evaluation
- Added tests for `Recorder.hydrate()` merge semantics during startup window
- Added tests for `SweepsTerminate` invariant
- Existing tests pass with the refactored tab evaluation logic

https://claude.ai/code/session_014fb5nkZqVpxHBWCE8Z6D5w