### PR TITLE
fix(ci): restore wasm dist artifacts when a single crate is released

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -231,13 +231,36 @@ jobs:
           pattern: wasm-changeset-*
           path: .changeset
           merge-multiple: true
+      # actions/download-artifact nests each artifact under its own name
+      # only when more than one matches the pattern; a lone match is
+      # extracted straight into `path`. Globbing for `wasm-dist-*`
+      # directories therefore found nothing the first time this workflow
+      # had to release a single crate on its own (run 30422724972), and the
+      # unexpanded glob was handed to `mv`. The detect job already knows
+      # exactly which crates were built, so take the list from there and
+      # accept either layout rather than inferring it from the filesystem.
       - name: Restore dist artifacts into each crate directory
+        env:
+          BUILT_CRATES: ${{ needs.detect.outputs.matrix }}
         run: |
           set -euo pipefail
-          for artifact_dir in dist/wasm/wasm-dist-*; do
-            crate_name=$(basename "$artifact_dir" | sed 's/^wasm-dist-//')
+
+          mapfile -t crate_names < <(jq -r '.include[].crate_name' <<<"$BUILT_CRATES")
+
+          for crate_name in "${crate_names[@]}"; do
+            nested="dist/wasm/wasm-dist-${crate_name}"
+
+            if [ -d "$nested" ]; then
+              source_dir="$nested"
+            elif [ "${#crate_names[@]}" -eq 1 ] && [ -d "dist/wasm" ]; then
+              source_dir="dist/wasm"
+            else
+              echo "::error::no dist artifact found for ${crate_name} (looked for ${nested})"
+              exit 1
+            fi
+
             rm -rf "crates/${crate_name}/dist"
-            mv "$artifact_dir" "crates/${crate_name}/dist"
+            mv "$source_dir" "crates/${crate_name}/dist"
           done
       # This only needs the root project's own devDependencies (changesets
       # and friends) to run `npx changeset publish` below - nothing here

--- a/crates/leetype_wasm/Cargo.toml
+++ b/crates/leetype_wasm/Cargo.toml
@@ -6,6 +6,9 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 edition.workspace = true
+description = "Typing-game engine for LeetType: compiles source code into a typeable stream that skips layout whitespace, so the caret tracks the rendered code exactly."
+keywords = ["typing", "wasm", "game", "leetype"]
+categories = ["game-development", "wasm"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Description

The WASM release triggered by #835 failed — twice, deterministically — at *"Restore dist artifacts into each crate directory"*, so it never reached `changeset version`. No release PR was opened and nothing was published. [Run 30422724972.](https://github.com/paulgsc/some-ui/actions/runs/30422724972)

The build itself was fine: `wasm-pack` succeeded and both artifacts uploaded intact (`wasm-dist-leetype_wasm`, 30 KB; `wasm-changeset-leetype_wasm`). Only the restore shell step failed.

**Root cause.** `actions/download-artifact` nests each artifact under its own name only when *more than one* matches the pattern; a lone match is extracted straight into `path`. Every previous run of this workflow built six crates at once — a `Cargo.lock` bump, or a release commit — so the nested layout was the only one it had ever seen:

| run | dist artifacts | result |
|---|---|---|
| 30238070427 | 6 | ✅ |
| 30242865392 | 6 | ✅ |
| 30321656252 | 6 | ✅ |
| **30422724972** | **1** | ❌ |

With one artifact, `dist/wasm/wasm-dist-*` matches nothing, the unexpanded glob is passed to `mv`, and under `set -euo pipefail` the step dies:

```
mv: cannot stat 'dist/wasm/wasm-dist-*': No such file or directory
```

#835 is simply the first change this workflow has ever had to release as a single crate on its own. Nothing about that crate's contents is involved.

**Fix.** Stop inferring the crate list from the filesystem. The `detect` job already computes exactly which crates were built and publishes it as `outputs.matrix`, so the restore step reads the list from there and accepts either layout. The single-crate flat fallback is guarded on there actually being one crate, so a genuinely missing artifact still fails loudly rather than being silently absorbed.

### Second commit: the crate metadata

`crates/leetype_wasm/Cargo.toml` gains the `description` / `keywords` / `categories` that `cargo_common_metadata` asks for. It was one of six crates missing them, and it is the one this branch already owns — this clears all three findings for it (`cargo clippy -p leetype_wasm` now reports zero `package … is missing` errors).

It is also deliberately the release trigger. The fix above repairs the single-crate path, and a real change under `crates/leetype_wasm/` is what makes `detect` pick up exactly one crate — so merging this PR exercises the repaired path in production rather than leaving it unproven until the next single-crate release happens by chance.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Verification

A workflow step can't be unit-tested in place, so I extracted the old and new scripts and ran both against every artifact layout:

| layout | old script | new script |
|---|---|---|
| single crate, flat (what CI hit) | ❌ `mv: cannot stat …` | ✅ restores |
| several crates, nested (every past run) | ✅ | ✅ restores both |
| single crate, nested | ✅ | ✅ restores |
| artifact genuinely missing | ✅ *silently skips* | ❌ **fails loudly** (intended) |

The old script reproduces the CI error verbatim on the flat layout, which is what confirms the diagnosis — the CI log for that step was not retrievable (the API kept returning a concurrent post-job step's output at every tail size).

Note the last row: the old glob-based loop would have *silently* skipped a crate whose artifact went missing, publishing a stale `dist`. The new version treats that as an error.

For the manifest change: `cargo test -p leetype_wasm` still 83 green, `cargo fmt --check` clean on the crate, and both boundary guardrail scripts pass.

Still red and out of scope, unchanged from `main`: Rust CI on `pkg_cloner`'s clippy debt, and Deny Checks on the Node license audit.

## Screenshots

N/A — CI and manifest only.