### PR TITLE
Add compile-time contract check for wasm bindings

### DIFF
--- a/packages/ui/leetype/package.json
+++ b/packages/ui/leetype/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
-    "@some-ui/leetype-wasm": "^0.0.9",
+    "@some-ui/leetype-wasm": "^0.0.10",
     "@some-ui/shared": "workspace:*",
     "@some-ui/styles": "workspace:*",
     "@some-ui/wasm-loader": "workspace:*",

--- a/packages/ui/leetype/src/components/typing-game/leetype/index.test.tsx
+++ b/packages/ui/leetype/src/components/typing-game/leetype/index.test.tsx
@@ -1,9 +1,19 @@
 import { resetWasm } from "@leetype/lib/leetype/leetype-wasm-loader"
 import type { Exercise } from "@leetype/types/exercise"
+import type { default as wasmInit } from "@some-ui/leetype-wasm"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Leetype } from "."
+
+/**
+ * What `__wbg_init` resolves to — the wasm exports table. Derived from the
+ * bindings rather than written as `void` so this mock keeps tracking the
+ * real signature; the loader awaits init purely for sequencing and never
+ * reads the table, so a stand-in value is enough.
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- a stand-in for the wasm exports table, which the loader awaits but never reads
+const INIT_OUTPUT = {} as Awaited<ReturnType<typeof wasmInit>>
 
 // ═══════════════════════════════════════════════════════════════════════════
 // What is pinned here is the one thing the composition can get wrong in a way
@@ -248,7 +258,7 @@ beforeEach(async () => {
   const wasmStub = await import("@some-ui/leetype-wasm")
   vi.mocked(wasmStub.default)
     .mockReset()
-    .mockImplementation(() => Promise.resolve())
+    .mockImplementation(() => Promise.resolve(INIT_OUTPUT))
 })
 
 describe("the step hand-off", () => {

--- a/packages/ui/leetype/src/hooks/leetype/use-typing-game-wasm/index.test.ts
+++ b/packages/ui/leetype/src/hooks/leetype/use-typing-game-wasm/index.test.ts
@@ -1,10 +1,25 @@
 import { resetWasm } from "@leetype/lib/leetype/leetype-wasm-loader"
 import type { GameState } from "@leetype/types/leetype"
+import type { default as wasmInit } from "@some-ui/leetype-wasm"
 import { act, renderHook, waitFor } from "@testing-library/react"
 import type { Mock } from "vitest"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useTypingGame } from "."
+
+/**
+ * What `__wbg_init` resolves to — the wasm exports table.
+ *
+ * Derived from the bindings rather than written as `void` so these mocks
+ * keep tracking the real signature: the stub now takes its types from the
+ * published `.d.ts`, so init's return type is the crate's to change. The
+ * loader awaits init purely for sequencing and never reads the table, so a
+ * stand-in value is enough.
+ */
+type InitOutput = Awaited<ReturnType<typeof wasmInit>>
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- a stand-in for the wasm exports table, which the loader awaits but never reads
+const INIT_OUTPUT = {} as InitOutput
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Two things are pinned here.
@@ -227,7 +242,7 @@ beforeEach(async () => {
   const wasmStub = await import("@some-ui/leetype-wasm")
   vi.mocked(wasmStub.default)
     .mockReset()
-    .mockImplementation(() => Promise.resolve())
+    .mockImplementation(() => Promise.resolve(INIT_OUTPUT))
 })
 
 describe("lazy init", () => {
@@ -424,7 +439,7 @@ describe("teardown", () => {
 describe("resolve-after-unmount safety (aliveRef guard)", () => {
   it("does not construct a game instance if loadWasm resolves after unmount", async () => {
     const wasmStub = await import("@some-ui/leetype-wasm")
-    const gate = deferred<void>()
+    const gate = deferred<InitOutput>()
     vi.mocked(wasmStub.default).mockImplementation(() => gate.promise)
 
     const { unmount } = renderHook(() => useTypingGame(baseProps()))
@@ -436,7 +451,7 @@ describe("resolve-after-unmount safety (aliveRef guard)", () => {
     expect(instances).toHaveLength(0)
 
     await act(async () => {
-      gate.resolve()
+      gate.resolve(INIT_OUTPUT)
       await gate.promise
     })
 
@@ -447,7 +462,7 @@ describe("resolve-after-unmount safety (aliveRef guard)", () => {
 
   it("does not surface an error state if loadWasm rejects after unmount", async () => {
     const wasmStub = await import("@some-ui/leetype-wasm")
-    const gate = deferred<void>()
+    const gate = deferred<InitOutput>()
     vi.mocked(wasmStub.default).mockImplementation(() => gate.promise)
 
     const { result, unmount } = renderHook(() => useTypingGame(baseProps()))

--- a/packages/ui/leetype/src/types/wasm/bindings-contract.ts
+++ b/packages/ui/leetype/src/types/wasm/bindings-contract.ts
@@ -1,0 +1,163 @@
+/**
+ * Compile-time contract between the hand-written wasm surface in
+ * `types/leetype.ts` and the declarations `wasm-pack` actually published.
+ *
+ * This file exports nothing a caller uses. It exists so that `tsc` fails —
+ * loudly, at the seam, with no test run and no browser — when the installed
+ * `@some-ui/leetype-wasm` stops agreeing with what this workspace believes
+ * the engine exposes.
+ *
+ * ## Why it was needed
+ *
+ * The Zod schemas next door guard the *payloads* crossing the boundary, and
+ * that is the right place for them: `serde-wasm-bindgen` hands JS untyped
+ * values, so a field the engine renamed can only be caught by looking at a
+ * real value at runtime. But payloads were never the whole surface. Nothing
+ * guarded the *call surface* — which methods exist, their arities, the
+ * constructor — and there the drift was silent in both directions:
+ *
+ *   - `TypingGameWasm` named `tick`, `calibrate`, `progression`,
+ *     `retry_chunk` and `visibility`, and `WasmModule["TypingGame"]` took a
+ *     four-argument constructor, while the installed crate was 0.0.9, which
+ *     shipped none of them and took two arguments.
+ *   - `tsc` agreed anyway, because `@some-ui/leetype-wasm` resolves to
+ *     `./leetype-wasm.d.ts`, and that stub used to derive `TypingGame` from
+ *     `WasmModule`. The wrapper was being checked against itself.
+ *
+ * So the first honest signal was `this.instance.tick is not a function`, in
+ * a browser, from a caller several layers from the cause. The stub now
+ * derives from the published declarations instead, which closes the loop;
+ * the assertions below are what makes a break in that loop legible rather
+ * than showing up as a confusing error inside the loader.
+ *
+ * ## What it can and cannot check
+ *
+ * Every JsValue-returning method types as `any` in the generated `.d.ts`,
+ * because the crate projects through `serde_wasm_bindgen::to_value` and
+ * wasm-bindgen has no field-level type to emit. So the split is:
+ *
+ *   call surface  → checked here, at compile time, against the crate
+ *   payload shape → checked by Zod, at runtime, at the seam
+ *
+ * `SnapshotSchema` gaining a field the Rust struct does not have is still
+ * a runtime discovery. `PayloadsAreStillOpaque` at the bottom is the
+ * tripwire for the day that becomes fixable.
+ *
+ * Bump `@some-ui/leetype-wasm` and this file re-checks itself: the import
+ * below reaches into the installed package, not a vendored copy, so the
+ * check always describes the version `package.json` actually resolves to.
+ */
+import type { TypingGameWasm, WasmModule } from "@leetype/types/leetype"
+
+/**
+ * The declarations wasm-pack emits, exactly as published.
+ *
+ * Reached by subpath rather than by the bare specifier because the bare one
+ * is mapped in tsconfig.json to the stub next door — which is derived from
+ * this same file and so has nothing independent to say. The mapping has no
+ * wildcard, so this deeper path resolves through `node_modules` as usual.
+ *
+ * `typeof import(...)` rather than named imports because two of the
+ * assertions below reflect over the module's *export set* — "did a function
+ * appear that nothing here wraps?" — and a named import can only name
+ * exports we already know about, which is the question being asked.
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- reflecting over the module's export set requires the whole module type; a named import cannot express "everything the crate exports"
+type Generated = typeof import("@some-ui/leetype-wasm/dist/leetype_wasm")
+
+/** The generated `TypingGame` as an instance, which is what we wrap. */
+type GeneratedGame = InstanceType<Generated["TypingGame"]>
+
+type Assert<Check extends true> = Check
+
+type Extends<A, B> = [A] extends [B] ? true : false
+
+type IsNever<T> = [T] extends [never] ? true : false
+
+type IsAny<T> = 0 extends 1 & T ? true : false
+
+/**
+ * Module exports wasm-pack adds for its own loading protocol. They are not
+ * engine surface, so `WasmModule` deliberately omits them and the
+ * "nothing unwrapped" check below has to know to ignore them.
+ */
+type LoaderPlumbing = "default" | "initSync"
+
+/** Engine methods the published class has that `TypingGameWasm` does not. */
+type UnwrappedMethods = Exclude<
+  Extract<keyof GeneratedGame, string>,
+  keyof TypingGameWasm
+>
+
+/** Module exports the published bindings have that `WasmModule` does not. */
+type UnwrappedExports = Exclude<
+  Extract<keyof Generated, string>,
+  keyof WasmModule | LoaderPlumbing
+>
+
+/** Argument counts the constructor admits — a union, since some are optional. */
+type OurArity = ConstructorParameters<WasmModule["TypingGame"]>["length"]
+type GeneratedArity = ConstructorParameters<Generated["TypingGame"]>["length"]
+
+/**
+ * Each entry is `true` or the build stops. Read a `Type 'false' does not
+ * satisfy the constraint 'true'` here as "the crate moved and this
+ * workspace has not caught up" — the comment on the failing line says what
+ * moved.
+ */
+export type LeetypeWasmBindingContract = [
+  /**
+   * The published bindings still satisfy everything `WasmModule` claims.
+   *
+   * This is the load-bearing one, and it fails from either side: a method
+   * `TypingGameWasm` names that the crate dropped (or has not shipped yet
+   * — 0.0.9 fails here on five of them), a return type that changed kind
+   * (`slot_of_display` going `Int32Array` → `Uint32Array`), or an argument
+   * whose type no longer accepts what we pass.
+   */
+  Assert<Extends<Generated, WasmModule>>,
+
+  /**
+   * Nothing new arrived unwrapped.
+   *
+   * Assignability above is one-directional: a crate that *adds* a method
+   * satisfies `WasmModule` just fine. But an engine method with no
+   * `TypedTypingGame` wrapper is an unvalidated way across the boundary,
+   * so a new one should be a decision, not an oversight. Fix by adding it
+   * to `TypingGameWasm` and wrapping it in the loader — including the Zod
+   * parse on whatever it returns.
+   */
+  Assert<IsNever<UnwrappedMethods>>,
+
+  /** Same, for free functions rather than methods on the game. */
+  Assert<IsNever<UnwrappedExports>>,
+
+  /**
+   * The constructor takes the same number of arguments on both sides.
+   *
+   * Needed separately because TypeScript lets a constructor with *fewer*
+   * parameters satisfy one that declares more — which is exactly how
+   * `new TypingGame(code, maxErrors, baselineWpm, dispersionWpm)` type-
+   * checked against 0.0.9's two-argument constructor and silently dropped
+   * the calibration the whole reveal loop is a function of. Asserted in
+   * both directions because each arity is a union of the lengths an
+   * optional parameter admits, and either side may be the wider one.
+   */
+  Assert<Extends<OurArity, GeneratedArity>>,
+  Assert<Extends<GeneratedArity, OurArity>>,
+
+  /**
+   * The payload seam is still opaque, so Zod is still the only thing that
+   * can check it.
+   *
+   * A deliberate tripwire on an *improvement*: this fails the day the
+   * crate starts emitting real payload interfaces (`tsify`, or a
+   * `typescript_custom_section`), because on that day `Snapshot` and
+   * friends become checkable at compile time and these schemas should be
+   * asserted field-for-field against them — `Assert<IsEqual<Snapshot,
+   * Generated.Snapshot>>` and so on — instead of only at runtime. Without
+   * this line that day passes unnoticed and the schemas stay a trailing
+   * artifact forever.
+   */
+  Assert<IsAny<ReturnType<GeneratedGame["snapshot"]>>>,
+]

--- a/packages/ui/leetype/src/types/wasm/leetype-wasm.d.ts
+++ b/packages/ui/leetype/src/types/wasm/leetype-wasm.d.ts
@@ -1,14 +1,28 @@
-// Hand-written stand-in for the wasm-bindgen-generated declarations that
-// `wasm-pack build` (crates/leetype_wasm) would normally emit into its dist
-// output. Resolved via the "@some-ui/leetype-wasm" tsconfig path mapping so
-// the ESLint/TS resolver has a real file to point at without requiring a
-// WASM build. Only the members imported in this workspace are declared;
-// full binding-accurate typing is tracked separately.
-import type { WasmModule } from "@leetype/types/leetype"
+// Stand-in module for "@some-ui/leetype-wasm", resolved via the tsconfig
+// path mapping so the ESLint/TS resolver and Vitest have a real file to
+// point at without instantiating the binary. Only the members imported in
+// this workspace are declared.
+//
+// Every member is *derived* from the published declarations (reached by
+// subpath, since the bare specifier maps back to this file) rather than
+// spelled out again. That matters: this file used to type `TypingGame` as
+// `WasmModule["TypingGame"]`, i.e. from the hand-written surface in
+// types/leetype.ts, which made the check circular — the stub agreed with
+// the wrapper because it was built out of the wrapper, and the crate had
+// no say. See ./bindings-contract.ts.
+//
+// `import type` is erased entirely, so this file still emits nothing at
+// runtime and Vitest still sees an empty module to `vi.mock` over.
+import type {
+  classify_source as generatedClassifySource,
+  default as generatedInit,
+  slot_map_from_source as generatedSlotMapFromSource,
+  TypingGame as GeneratedTypingGame,
+} from "@some-ui/leetype-wasm/dist/leetype_wasm"
 
-declare const init: () => Promise<void>
+declare const init: typeof generatedInit
 export default init
 
-export declare const TypingGame: WasmModule["TypingGame"]
-export function classify_source(input: string): Uint8Array
-export function slot_map_from_source(input: string): Int32Array
+export declare const TypingGame: typeof GeneratedTypingGame
+export declare const classify_source: typeof generatedClassifySource
+export declare const slot_map_from_source: typeof generatedSlotMapFromSource

--- a/packages/ui/leetype/tsconfig.json
+++ b/packages/ui/leetype/tsconfig.json
@@ -10,6 +10,17 @@
       // exists after a wasm-pack build, so tsc resolves the hand-written
       // stub instead — the same mapping tsconfig.eslint.json uses, hoisted
       // here so `tsc --noEmit` doesn't depend on a built crate.
+      // Note this mapping has no wildcard, so it is an *exact* match:
+      // "@some-ui/leetype-wasm/dist/leetype_wasm" still resolves normally,
+      // through node_modules, to the declarations wasm-pack actually
+      // published. That is deliberate — it is how the stub below and
+      // src/types/wasm/bindings-contract.ts reach the real bindings to
+      // check this workspace's hand-written surface against. The trade is
+      // that the *bare* specifier still resolves without a wasm build, but
+      // the contract check does not: link the crate as a workspace package
+      // instead of installing it and `wasm-pack build` becomes a
+      // prerequisite for typechecking. That is the intended cost — a
+      // contract with nothing to check against is not worth having.
       "@some-ui/leetype-wasm": ["./src/types/wasm/leetype-wasm.d.ts"]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1429,8 +1429,8 @@ importers:
   packages/ui/leetype:
     dependencies:
       '@some-ui/leetype-wasm':
-        specifier: ^0.0.9
-        version: 0.0.9
+        specifier: ^0.0.10
+        version: 0.0.10
       '@some-ui/shared':
         specifier: workspace:*
         version: link:../shared
@@ -4713,8 +4713,8 @@ packages:
   '@some-ui/hangul-game-core@0.0.5':
     resolution: {integrity: sha512-TeC+861SSq3NYR+Hg+4Z3QF0XuadvNAcbGRosSuXaLLG2JKVczpy5/J9jVvh/pWVLdamsxGGDfEjX+LkqqvloA==}
 
-  '@some-ui/leetype-wasm@0.0.9':
-    resolution: {integrity: sha512-HEgOAtRHVE8Qvt3bgJL0FFs4t34x7Deq5nZPlXOaBbbd/ewXL3z9R5JX5HOkJx+r3aWeltOUL7cisrMCapZOYw==}
+  '@some-ui/leetype-wasm@0.0.10':
+    resolution: {integrity: sha512-7CYK01yggdOMKizceh1/KlXu8/tZWmQloHXScBZtMatSS067G3Bl0R1ETpoEc5aFxSVFuv0ueyOoaaHU8dibqQ==}
 
   '@some-ui/polyhedron@0.0.4':
     resolution: {integrity: sha512-6KgJ6rRUCoKiFjSbwTh1Mvj5f7DctDcBEIpM65aoujv9daLTU6zJhwnRqn8fz4jYHQf51fWtt68wbvWChEIr+g==}
@@ -13556,7 +13556,7 @@ snapshots:
 
   '@some-ui/hangul-game-core@0.0.5': {}
 
-  '@some-ui/leetype-wasm@0.0.9': {}
+  '@some-ui/leetype-wasm@0.0.10': {}
 
   '@some-ui/polyhedron@0.0.4': {}
 


### PR DESCRIPTION
## Description

This PR introduces a compile-time contract verification system for the WebAssembly bindings to catch drift between the hand-written TypeScript surface and the actual published wasm-pack declarations.

### Problem

Previously, the stub declarations in `leetype-wasm.d.ts` were derived from the hand-written `WasmModule` interface, creating a circular check where the stub agreed with the wrapper because it was built from the wrapper. The actual crate had no say in the validation. This allowed silent mismatches:

- Methods could be added/removed in the crate without detection
- Constructor arity changes went unnoticed (e.g., 0.0.9 shipped a 2-argument constructor while the wrapper expected 4)
- Return type changes were invisible
- The first signal of a problem was a runtime error deep in the call stack (`this.instance.tick is not a function`)

### Solution

**New file: `bindings-contract.ts`**
- Establishes a compile-time contract between hand-written types and published wasm-pack declarations
- Uses TypeScript's type system to assert:
  - All methods in `WasmModule` exist in the generated bindings
  - No unwrapped methods or exports exist (new crate methods must be explicitly wrapped)
  - Constructor arity matches exactly (catches optional parameter drift)
  - Payload types remain opaque (tripwire for future improvements)
- Reaches the *actual* published declarations via subpath import (`@some-ui/leetype-wasm/dist/leetype_wasm`), not the stub
- Build fails at `tsc` with clear error messages when the crate diverges

**Updated: `leetype-wasm.d.ts`**
- Now derives all exports from the published bindings instead of hand-writing them
- Closes the validation loop: stub types come from the real crate, not the wrapper
- Maintains zero runtime footprint (all imports are `type`-only)

**Updated: Test files**
- Mock return types now derive from actual bindings signature
- `wasmInit` return type properly tracked as `InitOutput` instead of `void`
- Tests remain compatible with the stub (no wasm build required)

**Updated: `tsconfig.json`**
- Clarified that the path mapping is an exact match (no wildcard)
- Documented that `@some-ui/leetype-wasm/dist/leetype_wasm` resolves normally through node_modules
- Added note that the contract check requires the crate to be linked/installed

**Updated: `package.json`**
- Bumped `@some-ui/leetype-wasm` to `^0.0.10` (the version this contract was designed for)

## Type of Change

- [x] New feature (compile-time validation system)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed for correctness
- [x] Hard-to-understand areas are commented (extensive docs in `bindings-contract.ts`)
- [x] No new warnings generated
- [x] Existing tests pass with changes
- [x] Changes are backward compatible (stub still works without wasm build)

## Test Plan

Existing unit tests pass with the updated mock signatures. The contract check itself is validated by `tsc --noEmit`:
- Passes with `@some-ui/leetype-wasm@^0.0.10`
- Would fail immediately if the crate's call surface diverges (methods added/removed, arity changes, return type changes)

https://claude.ai/code/session_01LSpnXjZk4pp3J6aiWFwU9E