### PR TITLE
fix(honeycomb): fit the three hangul overlays to their box

### DIFF
--- a/packages/ui/honeycomb/src/components/hangul-hex-grid/game-over-modal/index.tsx
+++ b/packages/ui/honeycomb/src/components/hangul-hex-grid/game-over-modal/index.tsx
@@ -10,6 +10,21 @@ type GameOverModalProps = {
   onContinue: () => void
 }
 
+/**
+ * The end-of-run summary, sized to fit the board it covers.
+ *
+ * Everything here is fixed-cardinality - one verdict line, five figures, one
+ * button - so `docs/ui-fit`'s first question ("can this just fit?") has a
+ * plain yes, and the panel takes no height cap and no scrollbar. It used to
+ * take both, and at the 500px board the stories render it was genuinely
+ * overflowing them: a stacked emoji, a stacked headline, and five full-width
+ * label/value rows at `p-6` came to roughly 550px of content. The fix is the
+ * layout, not a scroll container - the verdict is one line, the figures are a
+ * 2-up hero over a 3-up footnote, and completion is a single row.
+ *
+ * The numbers are `tabular-nums` for the same reason: the grid's height must
+ * not depend on the run it is describing.
+ */
 export const GameOverModal = ({
   isOpen,
   status,
@@ -37,77 +52,90 @@ export const GameOverModal = ({
       aria-label="Close modal overlay"
     >
       <div
-        className="glass-effect rounded-3xl px-6 py-6 sm:px-12 sm:py-10 text-white text-center max-w-md max-h-[calc(100%-2rem)] overflow-y-auto"
+        className="glass-effect rounded-3xl mx-4 w-full max-w-md px-5 py-5 sm:px-8 sm:py-7 text-white text-center"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
         role="presentation"
       >
-        {/* Title */}
-        <div className="text-5xl mb-4">
-          {isComplete ? "🎉" : isTimeout ? "⏰" : "🎮"}
+        {/* Verdict. The emoji sits beside the headline rather than above it:
+            two stacked display lines were the single biggest block of height
+            here, and they say one thing between them. */}
+        <div className="flex items-center justify-center gap-3 mb-4 sm:mb-5">
+          <span className="text-4xl sm:text-5xl leading-none" aria-hidden>
+            {isComplete ? "🎉" : isTimeout ? "⏰" : "🎮"}
+          </span>
+          <span className="text-2xl sm:text-3xl font-bold">
+            {isComplete ? "Complete!" : isTimeout ? "Time's Up!" : "Game Over"}
+          </span>
         </div>
-        <div className="text-3xl font-bold mb-6">
-          {isComplete ? "Complete!" : isTimeout ? "Time's Up!" : "Game Over"}
-        </div>
 
-        {/* Stats Summary */}
-        <div className="space-y-3 mb-8 text-left bg-white/5 rounded-xl p-6">
-          <div className="flex justify-between items-baseline">
-            <span className="text-white/70">Final Score:</span>
-            <span className="text-2xl font-bold text-cyan-400">
-              {stats.score}
-            </span>
-          </div>
-
-          <div className="flex justify-between items-baseline">
-            <span className="text-white/70">Accuracy:</span>
-            <span
-              className={`font-bold ${
-                stats.accuracy >= 80
-                  ? "text-green-400"
-                  : stats.accuracy >= 60
-                    ? "text-yellow-400"
-                    : "text-red-400"
-              }`}
-            >
-              {stats.accuracy.toFixed(1)}%
-            </span>
-          </div>
-
-          <div className="flex justify-between items-baseline">
-            <span className="text-white/70">Best Streak:</span>
-            <span className="font-bold text-purple-400">
-              {stats.bestStreak}
-            </span>
-          </div>
-
-          <div className="pt-3 border-t border-white/10 flex justify-between text-sm">
+        {/* Stats summary, laid out by weight rather than as one column of
+            label/value rows. Score and accuracy are what the player came for,
+            so they get the display sizes; the rest reads as a footnote. Every
+            figure is a fixed-width number, so the grid's height is the same
+            for a 12-point run as for a 12,000-point one. */}
+        <div className="bg-white/5 rounded-xl p-4 sm:p-5 mb-4 sm:mb-5">
+          <div className="grid grid-cols-2 divide-x divide-white/10">
             <div>
-              <div className="text-white/50 text-xs">Correct</div>
-              <div className="text-green-400 font-bold">
-                {stats.totalCorrect}
+              <div className="text-2xl sm:text-3xl font-bold text-cyan-400 tabular-nums">
+                {stats.score}
+              </div>
+              <div className="text-white/50 text-[11px] uppercase tracking-wider">
+                Score
               </div>
             </div>
             <div>
-              <div className="text-white/50 text-xs">Missed</div>
-              <div className="text-red-400 font-bold">{stats.totalMissed}</div>
+              <div
+                className={`text-2xl sm:text-3xl font-bold tabular-nums ${
+                  stats.accuracy >= 80
+                    ? "text-green-400"
+                    : stats.accuracy >= 60
+                      ? "text-yellow-400"
+                      : "text-red-400"
+                }`}
+              >
+                {stats.accuracy.toFixed(1)}%
+              </div>
+              <div className="text-white/50 text-[11px] uppercase tracking-wider">
+                Accuracy
+              </div>
             </div>
           </div>
 
-          {/* Fixed unnecessary condition by removing optional chain if type guarantees it */}
-          <div className="pt-3 border-t border-white/10">
-            <div className="text-white/50 text-xs mb-1">Completion</div>
-            <div className="text-cyan-400 font-bold">
-              {status.progress.completedKeys} / {status.progress.totalKeys} (
-              {status.progress.completionPercentage.toFixed(0)}%)
+          <div className="mt-3 pt-3 border-t border-white/10 grid grid-cols-3 gap-2">
+            <div>
+              <div className="text-base font-bold text-purple-400 tabular-nums">
+                {stats.bestStreak}
+              </div>
+              <div className="text-white/50 text-[11px]">Best streak</div>
             </div>
+            <div>
+              <div className="text-base font-bold text-green-400 tabular-nums">
+                {stats.totalCorrect}
+              </div>
+              <div className="text-white/50 text-[11px]">Correct</div>
+            </div>
+            <div>
+              <div className="text-base font-bold text-red-400 tabular-nums">
+                {stats.totalMissed}
+              </div>
+              <div className="text-white/50 text-[11px]">Missed</div>
+            </div>
+          </div>
+
+          <div className="mt-3 pt-3 border-t border-white/10 flex items-baseline justify-between text-xs">
+            <span className="text-white/50">Completion</span>
+            <span className="text-cyan-400 font-bold tabular-nums">
+              {status.progress.completedKeys} / {status.progress.totalKeys} ·{" "}
+              {status.progress.completionPercentage.toFixed(0)}%
+            </span>
           </div>
         </div>
 
         {/* Action Button */}
         <button
           onClick={onContinue}
-          className="w-full glass-effect rounded-xl px-8 py-4 text-white font-semibold hover:bg-white/20 active:scale-95 transition-all shadow-lg text-lg"
+          className="w-full glass-effect rounded-xl px-8 py-3 text-white font-semibold hover:bg-white/20 active:scale-95 transition-all shadow-lg"
         >
           🔄 Play Again
         </button>

--- a/packages/ui/honeycomb/src/components/hangul-hex-grid/stats-panel/index.tsx
+++ b/packages/ui/honeycomb/src/components/hangul-hex-grid/stats-panel/index.tsx
@@ -49,7 +49,15 @@ export const StatsPanel = ({
   }
 
   return (
-    <div className="absolute top-2 start-2 sm:top-8 sm:start-6 glass-effect rounded-2xl px-3 py-2 sm:px-4 sm:py-3 lg:px-6 lg:py-4 text-white shadow-2xl w-fit max-w-[calc(100%-1rem)] sm:max-w-xs lg:max-w-sm max-h-[calc(100%-1rem)] overflow-y-auto">
+    // No height cap and no scroll: this panel's height is bounded by
+    // construction, not by a box it might overflow. Every row is a fixed
+    // label/value pair - there is no list here whose length belongs to the
+    // data - and the only optional block, the secondary stats, is already
+    // behind the `Details` disclosure below on anything narrower than `lg`.
+    // A HUD is also the one surface where a scrollbar is never the answer:
+    // a player mid-run has both hands on the keyboard and will not reach for
+    // one, so content parked below the fold would simply be content deleted.
+    <div className="absolute top-2 start-2 sm:top-8 sm:start-6 glass-effect rounded-2xl px-3 py-2 sm:px-4 sm:py-3 lg:px-6 lg:py-4 text-white shadow-2xl w-fit max-w-[calc(100%-1rem)] sm:max-w-xs lg:max-w-sm">
       {/* Header - always visible */}
       <div className="flex items-center justify-between mb-2 sm:mb-3 gap-2">
         <h2 className="text-base sm:text-lg lg:text-2xl font-bold bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent">

--- a/packages/ui/honeycomb/src/components/hangul-hex-grid/vocab-debrief-modal/index.tsx
+++ b/packages/ui/honeycomb/src/components/hangul-hex-grid/vocab-debrief-modal/index.tsx
@@ -112,7 +112,20 @@ export const VocabDebriefModal = ({
       role="presentation"
     >
       <div
-        className="hangul-debrief-panel relative mx-4 flex max-h-[calc(100%-2rem)] w-full max-w-lg flex-col gap-5 overflow-y-auto rounded-3xl border border-white/15 bg-slate-950/85 px-6 py-7 text-center text-white shadow-2xl sm:px-10"
+        className={
+          // scroll-intent: long-form — `pedagogy.note` and `pedagogy.example`
+          // are prose carried by the word entry, so their length belongs to
+          // whoever wrote the corpus, not to this layout. docs/ui-fit's
+          // earlier options all come off worse here: tabs and a paged list
+          // both put a click between the player and the sentence they missed
+          // the word for, on a panel that dismisses itself in nine seconds,
+          // and the surface cannot be enlarged - it is already the full
+          // height of the board it covers. Scrolling is safe on this one
+          // surface precisely because engagement pauses the countdown (see
+          // `useAutoDismiss`), so a player who scrolls is not racing a timer.
+          "hangul-debrief-panel relative mx-4 flex max-h-[calc(100%-2rem)] w-full max-w-lg flex-col gap-5 overflow-y-auto rounded-3xl border border-white/15 bg-slate-950/85 px-6 py-7 text-center text-white shadow-2xl sm:px-10"
+        }
+        data-scroll-intent="long-form"
         role="dialog"
         aria-modal="true"
         aria-label={`Missed word: ${word}`}


### PR DESCRIPTION
## Description

`pnpm --filter @some-ui/honeycomb lint` was warning on all three overlay surfaces in `hangul-hex-grid` under `fits-the-box/no-greedy-overflow`. Two of them were the pattern the rule exists to catch; the third is the case `docs/ui-fit` names as real. Each is resolved on its own merits rather than by deleting a class name.

**`GameOverModal` — was genuinely overflowing, not merely suspicious.** The ui-fit sweep measures **546px of content in the 468px box** at phone and **578px in 468px** at short-laptop, so on a short board the player was being handed a scrollbar to reach their own final score. A stacked emoji, a stacked headline, and five full-width label/value rows at `p-6` were the whole of it. The verdict is now one line (emoji beside the headline), the five figures are a 2-up hero (score, accuracy) over a 3-up footnote (best streak, correct, missed) with completion as a single row, and the height cap and scroll are gone. Figures are `tabular-nums` so the panel's height does not depend on the run it describes.

**`StatsPanel` — never needed the cap it carried.** Every row is a fixed label/value pair, and the only optional block already sits behind the `Details` disclosure below `lg`, so the box fits its content by construction. A HUD is also the one surface where a scrollbar is never the answer: a player mid-run has both hands on the keyboard and will not reach for one, so content parked below the fold is content deleted.

**`VocabDebriefModal` — keeps its scroll and declares it.** `pedagogy.note` and `pedagogy.example` are prose carried by the word entry, so their length belongs to the corpus author rather than the layout. The doctrine's earlier options all come off worse here: tabs and paging both put a click between the player and the sentence they missed the word for, on a panel that dismisses itself in nine seconds, and the surface cannot be enlarged — it is already the full height of the board. Scrolling is safe on this one surface precisely because engagement pauses the countdown (`useAutoDismiss`). Declared both ways the doctrine requires: an in-brace `scroll-intent:` comment for the lint rule, and `data-scroll-intent="long-form"` for the sweep.

### Not changed: the three `no-unsafe-return` errors

The same local run also reported three `@typescript-eslint/no-unsafe-return` errors in `src/lib/hangul/hangul-wasm-runtime.ts` (lines 68, 74, 133). Those are an environment artifact, not a code defect, and there is nothing to fix in the file.

Root cause, reproduced exactly: `@some-ui/wasm-loader` is unresolvable in that checkout's `node_modules`. Moving the symlink aside here reproduces all three errors at precisely those lines and nowhere else — which is also why line 65 is *not* reported (`getState()`'s declared return type comes from the same unresolved module, so error-to-error is not an unsafe return) while 68, 74 and 133 are. Restoring the link clears them. The fix is `pnpm install` at the repo root.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings — `pnpm --filter @some-ui/honeycomb lint` (eslint + prettier + tsc) is clean
- [x] New and existing unit tests pass locally with my changes — 272 passed / 19 files

## Verification

Checked with the gate that actually proves it, not just the lint rule:

```bash
STORYBOOK_WORKSPACE=honeycomb CI=1 pnpm build-storybook -o storybook-static
STORYBOOK_STATIC=storybook-static pnpm --filter www test:e2e tests/ui-fit/no-overflow.spec.ts
```

| | greedy scrollers |
|---|---|
| before | 3 (`GameOverModal` × Completed / Timed Out / Generic Game Over) |
| after | **0** |

The `scrolls sideways` failures on the `HexGrid` (4) and `StatsPanel` (9) stories are byte-identical before and after — they predate this change, come from the story decorators rather than the components, and are left alone per the scope of this PR.

## Screenshots

None attached — the sweep numbers above are the measurement that matters here, and they are reproducible from the commands given.

---
_Generated by [Claude Code](https://claude.ai/code/session_017n1AMr9VTARChnngxLJN3u)_