### PR TITLE
ci: stop building wasm crates outside the wasm release flow

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -1,23 +1,36 @@
 name: "pnpm Cache"
-description: "Resolve pnpm store path inside Nix shell and restore/save the cache."
-inputs:
-  shell:
-    description: "Nix devShell to run pnpm store path in"
-    required: false
-    default: "ci"
+description: "Restore/save the pnpm content-addressable store."
+# The store path used to be discovered at runtime with
+# `nix develop .#ci --command pnpm store path`, purely to learn a directory
+# name before actions/cache could restore into it. That put a full cold
+# devShell entry inside a step whose name says "cache", and the two costs
+# were then indistinguishable in every per-step measurement: on Trunk run
+# 30762782458 this action took 44s while the `pnpm install` it exists to
+# accelerate took 8s, and cargo-cache - the same actions/cache calls with no
+# `nix develop` in front of them - took 2-4s in five sibling jobs on the same
+# run. The ~40s gap was the devShell, not tar extraction.
+#
+# So don't discover the path, declare it. pnpm reads `store-dir` from any
+# `npm_config_*` environment variable, so exporting it here fixes the store
+# location for every later `pnpm` call in the job - inside or outside the nix
+# shell - with no shell entry at all. The devShell still gets realized, but
+# now it is billed to the step that actually needs it (`pnpm install`), which
+# is what makes the next round of measurements honest.
+#
+# `runner.temp` rather than a path under the workspace: it survives
+# actions/checkout, stays out of lint/knip globs, and is on the same
+# filesystem as `node_modules`, so pnpm can still hardlink out of the store
+# instead of copying.
 runs:
   using: composite
   steps:
-    - name: Get pnpm store path
-      id: store
+    - name: Point pnpm at a fixed store path
       shell: bash
-      run: |
-        PATH_VAL=$(nix develop ".#${{ inputs.shell }}" --command pnpm store path 2>/dev/null)
-        echo "path=${PATH_VAL}" >> "$GITHUB_OUTPUT"
+      run: echo "npm_config_store_dir=${{ runner.temp }}/pnpm-store" >> "$GITHUB_ENV"
     - name: Restore pnpm store cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
-        path: ${{ steps.store.outputs.path }}
+        path: ${{ runner.temp }}/pnpm-store
         key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
           pnpm-${{ runner.os }}-

--- a/.github/workflows/_deny-checks.yml
+++ b/.github/workflows/_deny-checks.yml
@@ -71,8 +71,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Install dependencies
         run: |
           nix develop .#ci --command pnpm install \

--- a/.github/workflows/_extension-sign.yml
+++ b/.github/workflows/_extension-sign.yml
@@ -27,8 +27,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
         env:

--- a/.github/workflows/_extension-verify.yml
+++ b/.github/workflows/_extension-verify.yml
@@ -1,9 +1,13 @@
 name: Extension Verification
 # Verifies each changed extension: typecheck, lint, test, build, web-ext lint.
 #
-# Workspace packages (packages/*/dist) and wasm crates (crates/*/dist) are
-# consumed from artifacts produced by the build-workspace job in extension.yml.
-# This job does NOT rebuild shared packages — only the extension itself.
+# Workspace packages (packages/*/dist) are consumed from the artifact produced
+# by the build-workspace job in extension.yml. This job does NOT rebuild shared
+# packages — only the extension itself.
+#
+# Wasm is not among them: extensions depend on the published npm packages
+# (e.g. "@some-ui/polyhedron": "0.0.4"), so it arrives via pnpm install like
+# any other registry dependency. Nothing in extension CI runs wasm-pack.
 #
 # Forbidden-dep check: extensions must not list React/preact/lucide-react or
 # any packages/ui/* package as a runtime dependency. All deps bundled by Vite
@@ -26,8 +30,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
         env:
@@ -84,14 +86,6 @@ jobs:
         with:
           name: workspace-packages-dist
           path: packages
-      # Restore pre-built wasm crate outputs (e.g. crates/polyhedron/dist).
-      # Some extensions have no crate deps — the artifact may be empty; that's fine.
-      - name: Download workspace crate dist
-        uses: actions/download-artifact@v8
-        with:
-          name: workspace-crates-dist
-          path: crates
-        continue-on-error: true
       - name: Typecheck
         run: nix develop .#ci --command pnpm --filter "${{ matrix.package_name }}" typecheck
       - name: Lint

--- a/.github/workflows/extension-sign-manual.yml
+++ b/.github/workflows/extension-sign-manual.yml
@@ -90,14 +90,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
 
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
         env:
           HUSKY: 0
 
+      # `pnpm build` carries `--filter='!./crates/*'` (root package.json), so
+      # this excludes both extensions and the wasm crates. Only packages/*/dist
+      # is uploaded below, so the six wasm-pack builds this used to run
+      # produced nothing any later step read.
       - name: Build workspace packages
         run: |
           nix develop .#ci --command pnpm build \

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -3,7 +3,7 @@ name: Extension CI
 #
 # Job graph:
 #   detect
-#     └── build-workspace      (shared packages + wasm crates, paid once)
+#     └── build-workspace      (shared packages, paid once)
 #           └── verify[matrix] (per-extension: typecheck/lint/test/build)
 #
 # Signing is intentionally NOT wired here. AMO compliance footguns are being
@@ -11,21 +11,30 @@ name: Extension CI
 # auto-signing on main is suspended until all A+B issues are closed.
 # Use extension-sign-manual.yml (workflow_dispatch) to sign when ready.
 #
-# Workspace packages and wasm crates are built once and shared via the
-# workspace-packages-dist / workspace-crates-dist artifacts.
+# Workspace packages are built once and shared via the
+# workspace-packages-dist artifact.
 # verify does not rebuild shared packages — it only bundles the extension itself.
 #
 # Smart filter: build-workspace uses Turbo's dep-graph filter
 # '...{./extensions/*}' (transitive deps of all extensions) minus the
-# extensions themselves. This means only the packages and wasm crates that
-# extensions actually import are built — packages/ui/** and other unrelated
-# workspaces are skipped automatically by the dep graph.
+# extensions themselves. This means only the packages that extensions
+# actually import are built — packages/ui/** and other unrelated workspaces
+# are skipped automatically by the dep graph.
+#
+# Wasm crates are not part of that closure, are not built here, and no longer
+# trigger this workflow. Extensions pin the published npm package
+# (extensions/some-conveyor: "@some-ui/polyhedron": "0.0.4"), so wasm arrives
+# from the registry via pnpm install. Editing a .rs file cannot change an
+# extension bundle until wasm-release.yml publishes a new version and the pin
+# is bumped — and that bump touches package.json + pnpm-lock.yaml, which is
+# already in the trigger list below. crates/** here only bought a full
+# detect + build-workspace + per-extension verify matrix on crate-only pushes,
+# for a diff no extension could observe.
 on:
   pull_request:
     paths:
       - "extensions/**"
       - "packages/**"
-      - "crates/**"
       - "pnpm-lock.yaml"
       - ".github/workflows/extension.yml"
       - ".github/workflows/_extension-*.yml"
@@ -36,7 +45,6 @@ on:
     paths:
       - "extensions/**"
       - "packages/**"
-      - "crates/**"
       - "pnpm-lock.yaml"
       - ".github/workflows/extension.yml"
       - ".github/workflows/_extension-*.yml"
@@ -49,24 +57,25 @@ jobs:
     name: Detect Changed Extensions
     uses: ./.github/workflows/_extension-detect.yml
 
-  # Build shared workspace packages and wasm crates once.
-  # Uses a dep-graph-aware filter so only packages/crates that extensions
-  # actually depend on are built — packages/ui/** and other unrelated
-  # packages are skipped automatically.
+  # Build shared workspace packages once.
+  # Uses a dep-graph-aware filter so only packages that extensions actually
+  # depend on are built — packages/ui/** and other unrelated packages are
+  # skipped automatically.
   build-workspace:
     name: Build Workspace Packages
     needs: detect
     if: needs.detect.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
+      # No cargo-cache: nothing in this job invokes cargo. The extension
+      # dependency closure resolves the wasm packages from the npm registry
+      # (extensions/some-conveyor pins "@some-ui/polyhedron": "0.0.4"), not
+      # from crates/* as workspace source, so `...{./extensions/*}` below
+      # selects zero crates and the cache was restored and saved for a
+      # toolchain the job never ran.
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
-      - uses: ./.github/actions/cargo-cache
-        with:
-          key-suffix: wasm-ext-deps
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
 
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
@@ -74,23 +83,25 @@ jobs:
           HUSKY: 0
 
       # Restore cached dist to skip rebuilding when nothing relevant changed.
-      # Key covers pnpm-lock + all package/crate source trees.
+      # Key covers pnpm-lock + the package source trees this job actually
+      # builds. Cargo.toml/Cargo.lock are deliberately not hashed in: a Rust
+      # dependency bump cannot change any output of this job, so hashing it
+      # only threw away a valid packages/*/dist cache and forced a full JS
+      # rebuild.
       - name: Restore workspace dist cache
         id: ws-cache
         uses: actions/cache@v6
         with:
-          path: |
-            packages/*/dist
-            crates/*/dist
-          key: workspace-dist-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/**/package.json', 'crates/**/Cargo.toml', 'Cargo.lock') }}
+          path: packages/*/dist
+          key: workspace-dist-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/**/package.json') }}
           restore-keys: |
             workspace-dist-${{ runner.os }}-
 
-      # Build only the packages/crates that extensions depend on.
-      # pnpm build at the root invokes `turbo run build` (see package.json).
-      # Turbo's '...{./extensions/*}' dependency selector walks the graph
-      # upstream from every extension, building their transitive workspace deps
-      # (packages, wasm crates like polyhedron) without the extensions themselves.
+      # Build only the packages that extensions depend on.
+      # pnpm build at the root invokes `turbo run build --filter='!./crates/*'`
+      # (see package.json). Turbo's '...{./extensions/*}' dependency selector
+      # walks the graph upstream from every extension, building their
+      # transitive workspace deps without the extensions themselves.
       - name: Build workspace deps
         if: steps.ws-cache.outputs.cache-hit != 'true'
         run: |
@@ -100,24 +111,21 @@ jobs:
         env:
           NODE_ENV: production
 
-      # Upload packages/*/dist and crates/*/dist as separate artifacts so
-      # verify jobs can download each to its correct location.
+      # Upload packages/*/dist so verify jobs can download it.
       # Use 'error' so a broken build fails loudly here rather than silently
       # producing a missing artifact that breaks all downstream verify jobs.
+      #
+      # There is no companion crates/*/dist artifact: this job builds no
+      # crates (see above), so it only ever uploaded an empty one - which is
+      # why it carried `if-no-files-found: warn` while its sibling used
+      # `error`. Extensions get their wasm from node_modules like any other
+      # published dependency.
       - name: Upload package dist
         uses: actions/upload-artifact@v7
         with:
           name: workspace-packages-dist
           path: packages/*/dist
           if-no-files-found: error
-          retention-days: 1
-
-      - name: Upload crate dist
-        uses: actions/upload-artifact@v7
-        with:
-          name: workspace-crates-dist
-          path: crates/*/dist
-          if-no-files-found: warn
           retention-days: 1
 
   verify:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -155,15 +155,18 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
+      # No crates/*/dist here, and no crates/**/src/** in the key. www consumes
+      # the wasm packages from the npm registry at a pinned version (see
+      # packages/ui/*/package.json), not from crates/* as workspace source, so
+      # `--filter=www...` below never reaches a crate and nothing would ever
+      # populate crates/*/dist in this job. Hashing crate sources into the key
+      # was actively harmful: editing any .rs file invalidated the *packages*
+      # dist cache and forced a full JS rebuild for a change www cannot see.
       - name: Cache workspace build outputs
         uses: actions/cache@v6
         with:
-          path: |
-            packages/*/dist
-            crates/*/dist
-          key: workspace-dist-${{ runner.os }}-${{ hashFiles('packages/**/src/**', 'crates/**/src/**') }}
+          path: packages/*/dist
+          key: workspace-dist-${{ runner.os }}-${{ hashFiles('packages/**/src/**') }}
           restore-keys: workspace-dist-${{ runner.os }}-
       - name: Install dependencies
         run: |
@@ -230,8 +233,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Cache workspace build outputs
         uses: actions/cache@v6
         with:
@@ -253,6 +254,14 @@ jobs:
             --prefer-offline
         env:
           HUSKY: 0
+      # `pnpm build` is `turbo run build --filter='!./crates/*'` (see the root
+      # package.json). The filter is what keeps wasm-pack out of this job:
+      # crates/* are pnpm workspaces with a `build` script that shells out to
+      # `wasm-pack build --release`, so an unfiltered `turbo run build`
+      # discovered and compiled all six of them here - despite Storybook, like
+      # www, importing those packages from the registry rather than from
+      # source. Note there is no cargo-cache in this job either, so each of
+      # those six builds compiled its full Rust dependency tree from cold.
       - name: Build workspace packages
         run: nix develop .#ci --command pnpm build --concurrency=100%
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,8 +62,6 @@ jobs:
 
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
 
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
@@ -73,11 +71,23 @@ jobs:
       # Build only the packages that changed or whose dependents changed.
       # The ...[HEAD^1] syntax means: this package and everything that
       # depends on it, filtered to what changed since the last commit.
+      #
+      # crates/* are excluded explicitly (this step calls turbo directly, so
+      # it does not pick up the root `pnpm build` script's filter). A PR that
+      # touches a .rs file makes ...[HEAD^1] select that crate, whose `build`
+      # script is `wasm-pack build --release` - a ~45s compile per crate, and
+      # this job has no cargo-cache to make it cheaper. Nothing in the PR
+      # needs the output: packages consume the wasm packages from the npm
+      # registry at a pinned version, so no dependent is waiting on that dist.
+      # The `rust` job in this same workflow already compiles, clippies and
+      # tests the crate, and wasm-release.yml is the only flow that has to
+      # turn a crate diff into an actual artifact.
       - name: Build (affected packages)
         run: |
           nix develop .#ci --command pnpm turbo run build \
             --filter=...[HEAD^1] \
             --filter='!./extensions/**' \
+            --filter='!./crates/*' \
             --concurrency=100%
 
       - name: Typecheck (affected packages)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Install dependencies
         run: |
           nix develop .#ci --command pnpm install \
@@ -26,6 +24,14 @@ jobs:
             --prefer-offline
         env:
           HUSKY: 0
+      # `pnpm build` excludes crates/* (root package.json). This is the
+      # changesets release for the Node packages; the wasm packages have their
+      # own publish track in wasm-release.yml, which builds each changed crate
+      # with wasm-pack and restores the dist into the crate directory before
+      # running `changeset publish`. In steady state `.changeset/` on main
+      # therefore never holds a wasm entry for this workflow to publish - if
+      # one is ever added by hand, dispatch wasm-release.yml instead, so the
+      # tarball ships with a dist built for that exact version.
       - name: Build packages
         run: nix develop .#ci --command pnpm build --concurrency=100%
       - name: Create Release PR or Publish

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -31,12 +31,19 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
         env:
           HUSKY: 0
+      # "All packages" means all *Node* packages. `pnpm build` is
+      # `turbo run build --filter='!./crates/*'` (root package.json) - the
+      # crates/* wasm workspaces are excluded on purpose. Their `build` script
+      # is `wasm-pack build --release`, and this job has no cargo-cache, so
+      # every push to main was compiling six Rust dependency trees from cold
+      # here. That is not lost coverage: the `rust` job above already runs
+      # `cargo build --workspace --locked` plus clippy and the full test suite
+      # over the same crates, and wasm-release.yml is what turns them into
+      # published npm packages.
       - name: Build all packages
         run: nix develop .#ci --command pnpm build --concurrency=100%
       - name: Typecheck all packages

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -217,8 +217,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Download all WASM dist artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/www-docker-release.yml
+++ b/.github/workflows/www-docker-release.yml
@@ -73,8 +73,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
         env:
@@ -108,8 +106,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/nix-setup
       - uses: ./.github/actions/pnpm-cache
-        with:
-          shell: ci
       - name: Install dependencies
         run: nix develop .#ci --command pnpm install --frozen-lockfile --prefer-offline
         env:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "clean": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo && rimraf .rollup.cache && rimraf node_modules",
     "clean:build": "turbo clean:build && turbo daemon stop && rimraf dist",
-    "build": "scripts/with-limits.sh turbo run build",
+    "build": "scripts/with-limits.sh turbo run build --filter='!./crates/*'",
+    "build:crates": "scripts/with-limits.sh turbo run build --filter='./crates/*'",
     "build:unsafe": "turbo run build",
     "build-storybook": "scripts/with-limits.sh storybook build",
     "build:template": "cargo run --manifest-path crates/pkg_cloner/Cargo.toml",


### PR DESCRIPTION
## Description

Scoped to CI compute waste. The headline: **`wasm-pack` was running in almost every CI workflow, and nothing consumed the output.**

### Why it happened

`crates/*` are pnpm workspaces, and each one's `build` script is `wasm-pack build --release`. Any *unfiltered* `turbo run build` therefore discovers and compiles all six. But consumers pin the **published** npm versions rather than linking the workspace:

```
packages/ui/input/package.json:        "@some-ui/some-crossword": "0.0.4"
packages/ui/honeycomb/package.json:    "@some-ui/hangul-game-core": "0.0.5"
extensions/some-conveyor/package.json: "@some-ui/polyhedron": "0.0.4"
```

`pnpm-lock.yaml` resolves those from the registry (`'@some-ui/polyhedron@0.0.4': {}`), not as `link:`. So the crates are **orphan roots** in the turbo graph — built only because they exist, never because anyone depends on them. That matches the intended architecture: `crates/ → publish npm package → packages/ → apps`.

### Verified against the graph, not assumed

```
turbo run build --dry                          →  60 tasks,  6 crates
turbo run build --filter='!./crates/*'         →  54 tasks,  0 crates
turbo run build --filter='www...'              →  33 tasks,  0 crates
turbo run build --filter='...{./extensions/*}' →  22 tasks,  0 crates
```

Neither `www`'s nor the extensions' dependency closure contains a single crate. Filtering the six out leaves the other 54 tasks byte-identical.

### Measured cost

From wasm-release run `30758426395`, the `Build WASM package` step — one crate, **with** a warm cargo cache — took **45s**. The jobs that were doing this incidentally (trunk `node`, pages `build-storybook`, pr `node`, extension-sign-manual) have **no cargo-cache at all**, so each was compiling six Rust dependency trees from cold on every run.

### Changes

- **Root `build` script** now carries `--filter='!./crates/*'`. One line covers trunk, pages (Storybook), release, and extension-sign-manual. Added `build:crates` so the crates stay reachable on purpose. Verified all four workflow call shapes still compose correctly with the added filter.
- **`pr.yml`** calls turbo directly, so it gets the filter explicitly. A PR touching a `.rs` file made `...[HEAD^1]` select the crate and build it — while the `rust` job in the same workflow already compiles, clippies and tests it. The workflow header already claimed *"What does NOT run on PR: … WASM publish"*; that is now true.
- **`extension.yml` no longer triggers on `crates/**`.** A crate diff cannot change an extension bundle until it is published and the pin bumped — and that bump touches `pnpm-lock.yaml`, which already triggers the workflow. `crates/**` was buying a full detect + build-workspace + per-extension verify matrix for a diff no extension could observe.
- **Dropped provably-dead plumbing from extension CI**: the `cargo-cache` step (that job invokes no cargo), the `crates/*/dist` cache paths, and the `workspace-crates-dist` artifact. It only ever uploaded an empty one — which is why it carried `if-no-files-found: warn` while its sibling used `error`.
- **Stopped hashing crate sources into `workspace-dist` cache keys** in pages and extension CI. This was worse than dead weight: editing any `.rs` file invalidated the *packages* dist cache and forced a full JS rebuild for a change those jobs cannot see.

`wasm-release.yml` is **untouched** — it remains the only flow that reads a crate diff and turns it into an artifact.

### The pnpm-cache finding

The action measured as the most expensive "cache" in the repo. It ran `nix develop .#ci --command pnpm store path` purely to learn a directory name before `actions/cache` could restore into it — putting a cold devShell entry inside a step whose name says "cache". The evidence, from trunk run `30762782458`:

| step | duration |
|---|---|
| `pnpm-cache` (actions/cache + one `nix develop`) | **44s** |
| `pnpm install` — the step it exists to accelerate | 8s |
| `cargo-cache` (same actions/cache calls, no `nix develop`) | **2–4s** ×5 sibling jobs |

The ~40s gap is the devShell, not tar extraction. The hypothesis in the original report was right.

The path is now **declared rather than discovered** — `npm_config_store_dir` under `runner.temp`, which pnpm honors (verified locally against pnpm 10.11.1) — so no shell entry is needed to compute it. `runner.temp` keeps the store out of the working tree and lint globs while staying on the same filesystem as `node_modules`, so pnpm can still hardlink instead of copying. The `shell` input is gone from the action and all 13 call sites.

**Being straight about what this does and does not save:** the devShell still gets realized once per job — it just moves to `pnpm install`, which genuinely needs it. This is primarily an **attribution** fix, plus one removed flake evaluation. Without it, every future snapshot keeps reporting a 6× cache-to-install ratio that is really the Nix shell wearing the cache's name.

### Not done

- **Storybook rebuilding the world.** `build-storybook` still runs the full workspace build where `build-www` runs `--filter=www...`, so shared packages compile twice across the two jobs. Restructuring around one shared workspace build is the larger remaining win, but Storybook's story globs span `packages/**` *and* `extensions/**`, so the correct filter needs its own investigation. Out of scope here.
- **The Nix cache itself.** `magic-nix-cache-action@v8` shows no deprecation notice upstream, and I have no run-log evidence that it is misbehaving, so I left it alone rather than gamble a ~40s/job regression on a hunch.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

All workflow and action YAML parses. Turbo task selection verified for every call shape in CI (`pnpm build`, `pnpm build:crates`, `pnpm build --filter='!./extensions/**'`, `pnpm build --filter '...{./extensions/*}'`). No test suite covers workflow files; the real proof is this PR's own CI run.

## Screenshots

n/a — no UI changes.