### PR TITLE
Add contract-harness package for client/server boundary testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "check:catalog": "node scripts/check-catalog-drift.mjs",
     "prepare": "husky",
     "test": "turbo test",
+    "contract": "pnpm --filter @some-ui/contract-harness contract",
+    "contract:drift": "pnpm --filter @some-ui/contract-harness contract:drift",
     "storybook": "storybook dev -p 6006 --no-open",
     "test:ui-fit": "CI=1 pnpm build-storybook -o storybook-static && STORYBOOK_STATIC=storybook-static pnpm --filter www test:ui-fit"
   },

--- a/packages/contract-harness/README.md
+++ b/packages/contract-harness/README.md
@@ -1,0 +1,208 @@
+# `@some-ui/contract-harness`
+
+An oracle for the client/server boundary. You write down the I/O you expect;
+it tells you whether the running server agrees.
+
+This exists for one workflow: you moved the Rust server, you moved the React
+client to match, and you want to know whether they actually still fit — without
+clicking through the app.
+
+```sh
+pnpm --filter @some-ui/contract-harness contract
+```
+
+## What it checks
+
+Two layers, cheapest first.
+
+**1. Route drift** — no server needed.
+
+The server repo emits its own route table (`make routes` →
+`routes.server.json`, checked in here). Every contract is compared against it.
+A contract targeting a path the server no longer serves fails here, by name,
+instead of surfacing later as an anonymous 404.
+
+**2. Conformance** — needs a running server.
+
+Each contract's request is sent for real and the response is compared to what
+the contract says it should be. Beyond ordinary validation, this reports two
+things `schema.parse()` structurally cannot:
+
+| Finding         | What happened                                              | Why validation misses it           |
+| --------------- | ---------------------------------------------------------- | ---------------------------------- |
+| `unknown-field` | Server sent a field the contract doesn't declare           | zod silently strips unknown keys   |
+| `phantom-field` | Contract declares an optional field the server never sends | An absent optional is always valid |
+
+Both are warnings, not failures — they mean "the other side moved and you
+haven't caught up", which is information, not breakage. Set
+`unknownFields: "reject"` on a contract where the payload shape _is_ the
+contract.
+
+There is a live example of the second kind right now. `MoodEventSchema` in
+`packages/ui/nfl/src/hooks/hopium/use-hopium-queries.ts` declares
+`time: z.string().optional()`; the server's `MoodEvent`
+(`crates/db/mood_event/src/core/model.rs`) has no `time` field at all. Because
+it's optional, every response validates and the drift has been invisible.
+
+## The loop
+
+```
+  server repo                             client repo
+  ───────────                             ───────────
+  change a route
+        │
+        ├── cargo test -p file_host --lib routes::inventory
+        │     ↑ fails if you renamed a route and didn't
+        │       update src/routes/inventory.rs
+        │
+        └── make routes ──► routes.server.json ──┐
+                                                 ▼
+                                        packages/contract-harness/
+                                                 │
+                                                 ├── pnpm contract:drift
+                                                 │     ↑ which contracts does
+                                                 │       the rename break?
+                                                 │
+                                                 └── pnpm contract
+                                                       ↑ does the live server
+                                                         still answer the way
+                                                         the client expects?
+```
+
+The diff on `routes.server.json` is the reviewable record of what moved.
+
+## Usage
+
+```sh
+# both layers, against the default server
+pnpm --filter @some-ui/contract-harness contract
+
+# structural check only — no server required, fast
+pnpm --filter @some-ui/contract-harness contract:drift
+
+# what isn't covered yet
+pnpm --filter @some-ui/contract-harness contract:coverage
+
+# point somewhere else
+pnpm --filter @some-ui/contract-harness contract --base-url http://localhost:3000
+
+# one module or one contract
+pnpm --filter @some-ui/contract-harness contract --only tabs
+pnpm --filter @some-ui/contract-harness contract --only mood_events.list
+```
+
+Flags: `--base-url`, `--routes`, `--only`, `--drift-only`,
+`--include-mutations`, `--show-uncovered`, `--timeout`, `--json`, `--help`.
+`CONTRACT_BASE_URL` works instead of `--base-url`.
+
+Exit code is non-zero for drift failures, failed probes and transport errors.
+Warnings do not fail the run.
+
+### Read-only by default
+
+Contracts marked `mutates: true` are skipped unless you pass
+`--include-mutations`, so pointing this at a server holding data you care about
+is safe by default rather than safe by remembering.
+
+## Refreshing the route snapshot
+
+In the **server** repo:
+
+```sh
+# the build needs a migrated SQLite file because sqlx checks queries at compile time
+DATABASE_URL="sqlite://$PWD/dev.db" make routes
+```
+
+then copy `routes.server.json` into this package. The server's own test
+(`routes::inventory::inventory_matches_route_sources`) guarantees the snapshot
+describes the routers that actually exist — it parses the `routes/*.rs` sources
+and fails if the declaration and the `.route(...)` calls disagree in either
+direction.
+
+## Writing a contract
+
+```ts
+import { z } from "zod"
+
+import { defineContract } from "../src/contract"
+
+export const contracts = [
+  defineContract({
+    id: "tabs.summaries",
+    module: "tabs",
+    method: "GET",
+    path: "/tabs/summaries", // as the server registers it; no /api/v1
+    summary: "lightweight tab list — no content blobs",
+    expect: { status: 200, schema: z.array(TabSummarySchema) },
+  }),
+]
+```
+
+Then add the file to `src/registry.ts`. Contracts are listed explicitly rather
+than globbed: a contract file that fails to load would otherwise vanish from the
+run and leave a smaller, entirely green report — the worst possible failure mode
+for a tool whose job is to tell you something is missing.
+
+Parameterised routes keep the template and bind separately:
+
+```ts
+path: "/mood_events/:id",
+request: { path: { id: 1 } },
+```
+
+An unbound `:id` is reported rather than requested, because a request for the
+literal path `/mood_events/:id` comes back as a 404 that reads like a missing
+route and sends you to the wrong side of the boundary.
+
+When a contract accepts both a success and a miss, say which one the schema
+describes:
+
+```ts
+expect: { status: [200, 404], schemaFor: 200, schema: MoodEventSchema },
+```
+
+## Deliberate limits
+
+Worth knowing before trusting a green run.
+
+- **Contracts are written by hand, not generated.** Generating them from the
+  Rust types or from the client's call sites would make the check circular: a
+  generated expectation agrees with its source by construction. A contract
+  states what the _client believes_; the runner finds out if the server agrees.
+
+- **Contract schemas are copies of the client's schemas.** The client's live
+  schemas sit inside React packages, and a Node CLI shouldn't boot a UI stack to
+  ask the server a question. The next step is hoisting shared response schemas
+  into `@some-ui/types` (no React dependency) so the hook and the contract share
+  one declaration — that removes the copy without making the check circular,
+  since the server side still comes from the wire.
+
+- **Coverage is 8 of 39 routes.** Not a gap to close for its own sake; the
+  valuable contracts are the ones on boundaries that actually move. Run
+  `contract:coverage` to see what's unwritten.
+
+- **This is not a browser test.** Requests go server-to-server, deliberately.
+  The tabs and mood-event routes pin CORS to a single origin, so a
+  browser-origin runner would be blocked from most of the surface and would be
+  reporting on CORS policy as much as on the handshake. A Playwright layer that
+  drives the real UI is a reasonable thing to add _above_ this — it answers
+  "does the product work", where this answers "do the two sides still fit".
+
+- **Findings are only as good as the data.** A contract whose response is an
+  empty collection reports `no-samples` rather than passing quietly, but it
+  still proved nothing about field shapes.
+
+- **Unions, records and tuples are not audited for unknown fields.** There's no
+  single declared shape to diff against. Those paths are listed as
+  `opaque-subtree` so a report says what it didn't look at.
+
+## Tests
+
+```sh
+pnpm --filter @some-ui/contract-harness test
+```
+
+48 tests. The integration suite stands up a real HTTP server and drives each
+detector against a concrete divergence — a renamed field, a widened type, a
+moved route, a phantom optional — because a drift detector nobody has watched
+fail is just a green light with extra steps.

--- a/packages/contract-harness/contracts/health.contract.ts
+++ b/packages/contract-harness/contracts/health.contract.ts
@@ -1,0 +1,35 @@
+/**
+ * `/health` is the one route deliberately left outside `/api/v1`, so that load
+ * balancers and orchestrators do not have to track API version bumps. That
+ * exemption is itself a handshake worth pinning: if it ever drifts under the
+ * prefix, every health probe in the deployment breaks at once.
+ *
+ * Mirrors `HealthResponse` in `apps/servers/file_host/src/handlers/health.rs`.
+ */
+
+import { z } from "zod"
+
+import { defineContract } from "../src/contract"
+
+const HealthResponseSchema = z.object({
+  status: z.string(),
+  version: z.string(),
+})
+
+export const contracts = [
+  defineContract({
+    id: "health.get",
+    module: "health",
+    method: "GET",
+    path: "/health",
+    versioned: false,
+    summary: "liveness probe, served unversioned",
+    expect: {
+      status: 200,
+      schema: HealthResponseSchema,
+      // The payload is consumed by infrastructure, not by application code —
+      // a field appearing here silently is more likely a mistake than growth.
+      unknownFields: "reject",
+    },
+  }),
+]

--- a/packages/contract-harness/contracts/mood-events.contract.ts
+++ b/packages/contract-harness/contracts/mood-events.contract.ts
@@ -1,0 +1,89 @@
+/**
+ * Mood event handshakes.
+ *
+ * `MoodEventSchema` below is a deliberate copy of the schema the client
+ * actually validates against, in
+ * `packages/ui/nfl/src/hooks/hopium/use-hopium-queries.ts`. It is copied rather
+ * than imported because that module pulls in `@tanstack/react-query` and React
+ * at import time, and a Node CLI should not have to boot a UI stack to ask the
+ * server a question.
+ *
+ * The copy is the point, not a compromise: a contract states what the client
+ * *believes*, and the runner's job is to find out whether the server agrees.
+ * Deriving the expectation from either side would make the check circular.
+ *
+ * The natural next step is to hoist these schemas into `@some-ui/types` — a
+ * plain package with no React dependency — so the hook and the contract can
+ * share one declaration. That removes the copy without making the check
+ * circular, since the server side of the comparison still comes from the wire.
+ *
+ * Note `time` below. The client declares it optional; the server's `MoodEvent`
+ * (`crates/db/mood_event/src/core/model.rs`) has no such field. Because it is
+ * optional, zod accepts every response and the mismatch never surfaces. The
+ * harness reports it as a phantom field — that is the case this whole layer
+ * exists to catch, so the contract keeps the field rather than quietly
+ * correcting it.
+ */
+
+import { z } from "zod"
+
+import { defineContract } from "../src/contract"
+
+const MoodEventSchema = z.object({
+  id: z.number(),
+  index: z.number(),
+  week: z.number(),
+  label: z.string(),
+  description: z.string(),
+  team: z.string(),
+  category: z.string(),
+  delta: z.number(),
+  mood: z.number(),
+  time: z.string().optional(),
+})
+
+const MoodEventsSchema = z.array(MoodEventSchema)
+
+/** Mirrors `MoodStats` in `crates/db/mood_event/src/core/model.rs`. */
+const MoodStatsSchema = z.object({
+  total_events: z.number(),
+  min_mood: z.number().nullable(),
+  max_mood: z.number().nullable(),
+  avg_mood: z.number().nullable(),
+  positive_events: z.number(),
+  negative_events: z.number(),
+  neutral_events: z.number(),
+})
+
+export const contracts = [
+  defineContract({
+    id: "mood_events.list",
+    module: "mood_events",
+    method: "GET",
+    path: "/mood_events",
+    summary: "every mood event, as the hopium dashboard loads them",
+    expect: { status: 200, schema: MoodEventsSchema },
+  }),
+
+  defineContract({
+    id: "mood_events.stats",
+    module: "mood_events",
+    method: "GET",
+    path: "/mood_events/stats",
+    summary: "aggregate mood statistics",
+    expect: { status: 200, schema: MoodStatsSchema },
+  }),
+
+  defineContract({
+    id: "mood_events.get_by_id",
+    module: "mood_events",
+    method: "GET",
+    path: "/mood_events/:id",
+    summary: "single mood event by id — exercises path parameter binding",
+    request: { path: { id: 1 } },
+    // 404 is accepted because this runs against whatever data the target server
+    // happens to hold. The handshake being pinned is "this route exists, and
+    // when it answers 200 the body is a MoodEvent" — not "row 1 exists".
+    expect: { status: [200, 404], schemaFor: 200, schema: MoodEventSchema },
+  }),
+]

--- a/packages/contract-harness/contracts/tabs.contract.ts
+++ b/packages/contract-harness/contracts/tabs.contract.ts
@@ -1,0 +1,102 @@
+/**
+ * Tab capture handshakes.
+ *
+ * This surface is written by the browser extension and read by the dashboard,
+ * so it is the one most likely to move on both sides at once — exactly the case
+ * where "did I remember to update the other repo?" is not a question anyone can
+ * answer by reading code.
+ *
+ * Shapes mirror `TabCapture` and `TabSummary` in
+ * `crates/ws-events/src/tabsched/capture.rs`, and the request/response structs
+ * declared at the top of `apps/servers/file_host/src/handlers/db/tab.rs`.
+ *
+ * `Domain` and `ContentKind` are newtypes over `String` on the server; serde
+ * serialises a newtype struct as its inner value, so both arrive as plain
+ * strings.
+ */
+
+import { z } from "zod"
+
+import { defineContract } from "../src/contract"
+
+const ExtractedContentSchema = z.object({
+  kind: z.string(),
+  title: z.string(),
+  summary: z.string(),
+  headings: z.array(z.string()),
+  keywords: z.array(z.string()),
+  raw_length: z.number(),
+  // `HashMap<String, serde_json::Value>` — keys are data, so there is nothing
+  // to declare and nothing to call undeclared.
+  meta: z.record(z.string(), z.unknown()),
+})
+
+const TabCaptureSchema = z.object({
+  tab_id: z.number(),
+  url: z.string(),
+  tab_title: z.string(),
+  captured_at: z.string(),
+  extractor: z.string(),
+  domain: z.string(),
+  content: ExtractedContentSchema,
+  extraction_ok: z.boolean(),
+  extraction_error: z.string().nullable(),
+})
+
+const TabSummarySchema = z.object({
+  tab_id: z.number(),
+  url: z.string(),
+  tab_title: z.string(),
+  domain: z.string(),
+  last_seen_at: z.string(),
+  extraction_ok: z.boolean(),
+})
+
+const ReconcileResponseSchema = z.object({
+  absent_tab_ids: z.array(z.number()),
+})
+
+export const contracts = [
+  defineContract({
+    id: "tabs.summaries",
+    module: "tabs",
+    method: "GET",
+    path: "/tabs/summaries",
+    summary: "lightweight tab list — no content blobs",
+    expect: { status: 200, schema: z.array(TabSummarySchema) },
+  }),
+
+  defineContract({
+    id: "tabs.list",
+    module: "tabs",
+    method: "GET",
+    path: "/tabs",
+    summary: "full tab payloads, including extracted content",
+    expect: { status: 200, schema: z.array(TabCaptureSchema) },
+  }),
+
+  defineContract({
+    id: "tabs.get_by_id",
+    module: "tabs",
+    method: "GET",
+    path: "/tabs/:tab_id",
+    summary: "single tab by browser tab id",
+    request: { path: { tab_id: 1 } },
+    expect: { status: [200, 404], schemaFor: 200, schema: TabCaptureSchema },
+  }),
+
+  defineContract({
+    id: "tabs.reconcile",
+    module: "tabs",
+    method: "POST",
+    path: "/tabs/reconcile",
+    summary:
+      "extension reports active tab ids, server returns the ones it holds that were not reported",
+    // Reports rather than writes, but it is a POST against a real server, so it
+    // stays behind --include-mutations along with everything else that is not a
+    // plain read.
+    mutates: true,
+    request: { body: { active_tab_ids: [] } },
+    expect: { status: 200, schema: ReconcileResponseSchema },
+  }),
+]

--- a/packages/contract-harness/eslint.config.js
+++ b/packages/contract-harness/eslint.config.js
@@ -1,0 +1,3 @@
+import someUIEslint from "@some-ui/eslint-kit"
+
+export default someUIEslint

--- a/packages/contract-harness/package.json
+++ b/packages/contract-harness/package.json
@@ -35,9 +35,10 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@some-ui/eslint-kit": "workspace:*",
     "@some-ui/tsconfig": "workspace:*",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.5"
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/contract-harness/package.json
+++ b/packages/contract-harness/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@some-ui/contract-harness",
+  "version": "0.1.0",
+  "description": "Runs the declared client/server boundary contracts against a real file_host and reports where actual I/O diverges from what the client expects",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "author": "pgdev",
+  "homepage": "https://pgdev.maishatu.com/?tab=github",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paulgsc/some-ui"
+  },
+  "bugs": {
+    "url": "https://github.com/paulgsc/some-ui/issues"
+  },
+  "keywords": [],
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "contract": "tsx src/cli.ts",
+    "contract:drift": "tsx src/cli.ts --drift-only",
+    "contract:coverage": "tsx src/cli.ts --drift-only --show-uncovered",
+    "clean": "rimraf .turbo && rimraf node_modules && rimraf .eslintcache",
+    "lint": "pnpm lint:js && pnpm prettier && pnpm typecheck",
+    "lint:js": "eslint \"**/*.ts\" --cache",
+    "prettier": "prettier . --ignore-path $(git rev-parse --show-toplevel)/.prettierignore --check --cache",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@some-ui/tsconfig": "workspace:*",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/contract-harness/routes.server.json
+++ b/packages/contract-harness/routes.server.json
@@ -1,0 +1,280 @@
+{
+  "schema_version": 1,
+  "api_base_path": "/api/v1",
+  "server_version": "0.0.0",
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/get_audio/:id",
+      "full_path": "/api/v1/get_audio/:id",
+      "versioned": true,
+      "module": "audio_files"
+    },
+    {
+      "method": "GET",
+      "path": "/search_audio",
+      "full_path": "/api/v1/search_audio",
+      "versioned": true,
+      "module": "audio_files"
+    },
+    {
+      "method": "POST",
+      "path": "/search_audio",
+      "full_path": "/api/v1/search_audio",
+      "versioned": true,
+      "module": "audio_files"
+    },
+    {
+      "method": "GET",
+      "path": "/gdrive/image/:image_id",
+      "full_path": "/api/v1/gdrive/image/:image_id",
+      "versioned": true,
+      "module": "gdrive"
+    },
+    {
+      "method": "GET",
+      "path": "/gdrive/json/:file_id",
+      "full_path": "/api/v1/gdrive/json/:file_id",
+      "versioned": true,
+      "module": "gdrive"
+    },
+    {
+      "method": "GET",
+      "path": "/gdrive/list",
+      "full_path": "/api/v1/gdrive/list",
+      "versioned": true,
+      "module": "gdrive"
+    },
+    {
+      "method": "GET",
+      "path": "/gdrive/list/:folder_id",
+      "full_path": "/api/v1/gdrive/list/:folder_id",
+      "versioned": true,
+      "module": "gdrive"
+    },
+    {
+      "method": "PUT",
+      "path": "/gdrive/write/:folder_id/:name",
+      "full_path": "/api/v1/gdrive/write/:folder_id/:name",
+      "versioned": true,
+      "module": "gdrive"
+    },
+    {
+      "method": "GET",
+      "path": "/get_github_repos",
+      "full_path": "/api/v1/get_github_repos",
+      "versioned": true,
+      "module": "github"
+    },
+    {
+      "method": "GET",
+      "path": "/health",
+      "full_path": "/health",
+      "versioned": false,
+      "module": "health"
+    },
+    {
+      "method": "GET",
+      "path": "/mood_events",
+      "full_path": "/api/v1/mood_events",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "POST",
+      "path": "/mood_events",
+      "full_path": "/api/v1/mood_events",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "DELETE",
+      "path": "/mood_events/:id",
+      "full_path": "/api/v1/mood_events/:id",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "GET",
+      "path": "/mood_events/:id",
+      "full_path": "/api/v1/mood_events/:id",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "PATCH",
+      "path": "/mood_events/:id",
+      "full_path": "/api/v1/mood_events/:id",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "DELETE",
+      "path": "/mood_events/batch",
+      "full_path": "/api/v1/mood_events/batch",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "PATCH",
+      "path": "/mood_events/batch",
+      "full_path": "/api/v1/mood_events/batch",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "POST",
+      "path": "/mood_events/batch",
+      "full_path": "/api/v1/mood_events/batch",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "GET",
+      "path": "/mood_events/stats",
+      "full_path": "/api/v1/mood_events/stats",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "GET",
+      "path": "/mood_events/team/:team",
+      "full_path": "/api/v1/mood_events/team/:team",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "GET",
+      "path": "/mood_events/week/:week",
+      "full_path": "/api/v1/mood_events/week/:week",
+      "versioned": true,
+      "module": "mood_events"
+    },
+    {
+      "method": "GET",
+      "path": "/get_attributions/:sheet_id",
+      "full_path": "/api/v1/get_attributions/:sheet_id",
+      "versioned": true,
+      "module": "sheets"
+    },
+    {
+      "method": "GET",
+      "path": "/get_gantt/:sheet_id",
+      "full_path": "/api/v1/get_gantt/:sheet_id",
+      "versioned": true,
+      "module": "sheets"
+    },
+    {
+      "method": "GET",
+      "path": "/get_nfl_roster/:sheet_id",
+      "full_path": "/api/v1/get_nfl_roster/:sheet_id",
+      "versioned": true,
+      "module": "sheets"
+    },
+    {
+      "method": "GET",
+      "path": "/get_nfl_tennis/:sheet_id",
+      "full_path": "/api/v1/get_nfl_tennis/:sheet_id",
+      "versioned": true,
+      "module": "sheets"
+    },
+    {
+      "method": "GET",
+      "path": "/get_video_chapters/:sheet_id",
+      "full_path": "/api/v1/get_video_chapters/:sheet_id",
+      "versioned": true,
+      "module": "sheets"
+    },
+    {
+      "method": "POST",
+      "path": "/now-playing",
+      "full_path": "/api/v1/now-playing",
+      "versioned": true,
+      "module": "tab_metadata"
+    },
+    {
+      "method": "GET",
+      "path": "/tabs",
+      "full_path": "/api/v1/tabs",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "POST",
+      "path": "/tabs",
+      "full_path": "/api/v1/tabs",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "DELETE",
+      "path": "/tabs/:tab_id",
+      "full_path": "/api/v1/tabs/:tab_id",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "GET",
+      "path": "/tabs/:tab_id",
+      "full_path": "/api/v1/tabs/:tab_id",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "DELETE",
+      "path": "/tabs/batch",
+      "full_path": "/api/v1/tabs/batch",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "POST",
+      "path": "/tabs/batch",
+      "full_path": "/api/v1/tabs/batch",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "POST",
+      "path": "/tabs/pipeline",
+      "full_path": "/api/v1/tabs/pipeline",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "POST",
+      "path": "/tabs/prune",
+      "full_path": "/api/v1/tabs/prune",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "POST",
+      "path": "/tabs/reconcile",
+      "full_path": "/api/v1/tabs/reconcile",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "GET",
+      "path": "/tabs/summaries",
+      "full_path": "/api/v1/tabs/summaries",
+      "versioned": true,
+      "module": "tabs"
+    },
+    {
+      "method": "POST",
+      "path": "/utter",
+      "full_path": "/api/v1/utter",
+      "versioned": true,
+      "module": "utterance"
+    },
+    {
+      "method": "GET",
+      "path": "/ws",
+      "full_path": "/ws",
+      "versioned": false,
+      "module": "websocket"
+    }
+  ]
+}

--- a/packages/contract-harness/src/cli.ts
+++ b/packages/contract-harness/src/cli.ts
@@ -1,0 +1,213 @@
+/**
+ * @module cli
+ *
+ * `pnpm contract` — the whole point of the package.
+ *
+ * Two checks run, in increasing order of cost and decreasing order of
+ * certainty:
+ *
+ * 1. **Drift** compares the contracts against the server's checked-in route
+ *    inventory. No network, no server, always runs.
+ * 2. **Conformance** sends each contract's request to a real server and
+ *    compares the response to what the contract says it should be. Needs a
+ *    server, so it is skipped when `--drift-only` is passed or nothing is
+ *    listening.
+ *
+ * Read-only by default. Contracts marked `mutates` sit out unless
+ * `--include-mutations` is passed, so pointing this at a server that holds data
+ * you care about is safe by default rather than safe by remembering.
+ */
+
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { fullPath } from "./contract"
+import type { RouteInventory } from "./drift"
+import {
+  checkDrift,
+  InventoryShapeError,
+  InventoryVersionError,
+  parseInventory,
+} from "./drift"
+import type { ContractOutcome } from "./probe"
+import { probeContract } from "./probe"
+import { allContracts, assertUniqueIds, selectContracts } from "./registry"
+import type { RunReport } from "./report"
+import {
+  exitCode,
+  renderDrift,
+  renderOutcomes,
+  renderSummary,
+  summarize,
+} from "./report"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const DEFAULT_INVENTORY = resolve(HERE, "..", "routes.server.json")
+const DEFAULT_BASE_URL = "http://nixos.local:3000"
+
+type Options = {
+  baseUrl: string
+  inventoryPath: string
+  only: string | undefined
+  driftOnly: boolean
+  includeMutations: boolean
+  showUncovered: boolean
+  json: boolean
+  timeoutMs: number
+}
+
+function parseArgs(argv: ReadonlyArray<string>): Options {
+  const value = (flag: string): string | undefined => {
+    const index = argv.indexOf(flag)
+    if (index === -1) return undefined
+    return argv[index + 1]
+  }
+  const has = (flag: string): boolean => argv.includes(flag)
+
+  const timeoutRaw = value("--timeout")
+  const parsedTimeout =
+    timeoutRaw === undefined ? Number.NaN : Number(timeoutRaw)
+
+  return {
+    baseUrl:
+      value("--base-url") ??
+      process.env["CONTRACT_BASE_URL"] ??
+      DEFAULT_BASE_URL,
+    inventoryPath: value("--routes") ?? DEFAULT_INVENTORY,
+    only: value("--only"),
+    driftOnly: has("--drift-only"),
+    includeMutations: has("--include-mutations"),
+    showUncovered: has("--show-uncovered"),
+    json: has("--json"),
+    timeoutMs: Number.isFinite(parsedTimeout) ? parsedTimeout : 10_000,
+  }
+}
+
+const HELP = `
+pnpm --filter @some-ui/contract-harness contract [options]
+
+  --base-url <url>        server to probe (default ${DEFAULT_BASE_URL}, or $CONTRACT_BASE_URL)
+  --routes <path>         route inventory snapshot (default routes.server.json)
+  --only <ids|modules>    comma-separated contract ids or module names
+  --drift-only            skip the live probes; compare contracts to the snapshot only
+  --include-mutations     also run contracts marked as mutating (they are skipped by default)
+  --show-uncovered        list server routes that no contract covers
+  --timeout <ms>          per-request timeout (default 10000)
+  --json                  emit the raw run report as JSON instead of text
+  --help                  this
+
+Regenerate the snapshot from the server repo with:
+  DATABASE_URL=sqlite://$PWD/dev.db make routes
+and copy routes.server.json into this package.
+`.trim()
+
+function loadInventory(path: string): RouteInventory {
+  let raw: string
+  try {
+    raw = readFileSync(path, "utf8")
+  } catch {
+    throw new Error(
+      `could not read route inventory at ${path}. Generate it in the server repo with \`make routes\` and copy it here.`
+    )
+  }
+  return parseInventory(JSON.parse(raw))
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(`${HELP}\n`)
+    return 0
+  }
+
+  const options = parseArgs(argv)
+  assertUniqueIds(allContracts)
+
+  const selected = selectContracts(allContracts, options.only)
+  if (selected.length === 0) {
+    process.stderr.write(`No contracts matched --only ${options.only ?? ""}\n`)
+    return 1
+  }
+
+  const inventory = loadInventory(options.inventoryPath)
+
+  // Drift is checked against every contract, not just the selected ones:
+  // coverage numbers for a filtered run would be misleading.
+  const drift = checkDrift(allContracts, inventory)
+
+  const outcomes: Array<ContractOutcome> = []
+
+  if (!options.driftOnly) {
+    for (const contract of selected) {
+      const runnable = contract.mutates !== true || options.includeMutations
+      if (!runnable) {
+        outcomes.push({
+          id: contract.id,
+          module: contract.module,
+          summary: contract.summary,
+          method: contract.method,
+          path: fullPath(contract),
+          status: "skipped",
+          findings: [
+            {
+              code: "mutation-skipped",
+              severity: "info",
+              message: "mutating contract; pass --include-mutations to run it",
+            },
+          ],
+        })
+        continue
+      }
+
+      // Sequential on purpose. The server has a concurrency limiter and a rate
+      // limiter in front of every versioned route, and a parallel run would be
+      // measuring those instead of the handshakes.
+      outcomes.push(
+        await probeContract(contract, {
+          baseUrl: options.baseUrl,
+          timeoutMs: options.timeoutMs,
+        })
+      )
+    }
+  }
+
+  const report: RunReport = {
+    drift,
+    outcomes,
+    baseUrl: options.driftOnly ? undefined : options.baseUrl,
+    probed: !options.driftOnly,
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+    return exitCode(summarize(report))
+  }
+
+  const summary = summarize(report)
+  const sections = [renderDrift(drift, options.showUncovered)]
+  if (report.probed) {
+    sections.push("", `Probing ${options.baseUrl}`, renderOutcomes(outcomes))
+  }
+  sections.push("", renderSummary(summary, report.probed))
+
+  process.stdout.write(`${sections.join("\n")}\n`)
+  return exitCode(summary)
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code
+  })
+  .catch((error: unknown) => {
+    if (error instanceof InventoryVersionError) {
+      process.stderr.write(`Inventory version mismatch: ${error.message}\n`)
+    } else if (error instanceof InventoryShapeError) {
+      process.stderr.write(`Unreadable route inventory: ${error.message}\n`)
+    } else {
+      process.stderr.write(
+        `contract harness failed: ${error instanceof Error ? error.message : String(error)}\n`
+      )
+    }
+    process.exitCode = 1
+  })

--- a/packages/contract-harness/src/conformance.test.ts
+++ b/packages/contract-harness/src/conformance.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { checkConformance } from "./conformance"
+
+describe("checkConformance", () => {
+  it("accepts a body that matches and reports nothing", () => {
+    const schema = z.object({ id: z.number(), label: z.string() })
+    const result = checkConformance(schema, { id: 1, label: "a" })
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([])
+    expect(result.unknownFields).toEqual([])
+    expect(result.phantomFields).toEqual([])
+    expect(result.sampleCount).toBe(1)
+  })
+
+  it("reports a field the server sent that the schema does not declare", () => {
+    const schema = z.object({ id: z.number() })
+    const result = checkConformance(schema, { id: 1, added_by_server: "new" })
+
+    // The load-bearing part: zod strips the key, so validation still passes.
+    expect(result.valid).toBe(true)
+    expect(result.unknownFields.map((field) => field.path)).toEqual([
+      "added_by_server",
+    ])
+  })
+
+  it("reports an optional field the server never sends", () => {
+    const schema = z.object({ id: z.number(), time: z.string().optional() })
+    const result = checkConformance(schema, { id: 1 })
+
+    expect(result.valid).toBe(true)
+    expect(result.phantomFields.map((field) => field.path)).toEqual(["time"])
+  })
+
+  it("does not call an optional field phantom when some values carry it", () => {
+    const schema = z.array(
+      z.object({ id: z.number(), time: z.string().optional() })
+    )
+    const result = checkConformance(schema, [{ id: 1 }, { id: 2, time: "now" }])
+
+    expect(result.phantomFields).toEqual([])
+  })
+
+  it("calls it phantom only when absent from every element", () => {
+    const schema = z.array(
+      z.object({ id: z.number(), time: z.string().optional() })
+    )
+    const result = checkConformance(schema, [{ id: 1 }, { id: 2 }, { id: 3 }])
+
+    expect(result.phantomFields).toHaveLength(1)
+    expect(result.phantomFields[0]?.path).toBe("[].time")
+    expect(result.phantomFields[0]?.samples).toBe(3)
+  })
+
+  it("reproduces the live MoodEvent drift", () => {
+    // Exactly the client schema from use-hopium-queries.ts …
+    const MoodEventSchema = z.object({
+      id: z.number(),
+      index: z.number(),
+      week: z.number(),
+      label: z.string(),
+      description: z.string(),
+      team: z.string(),
+      category: z.string(),
+      delta: z.number(),
+      mood: z.number(),
+      time: z.string().optional(),
+    })
+
+    // … against exactly what the server's MoodEvent serialises to.
+    const fromServer = [
+      {
+        id: 1,
+        index: 0,
+        week: 3,
+        label: "l",
+        description: "d",
+        team: "t",
+        category: "c",
+        delta: -2,
+        mood: 4,
+      },
+    ]
+
+    const result = checkConformance(z.array(MoodEventSchema), fromServer)
+
+    expect(result.valid).toBe(true)
+    expect(result.phantomFields.map((field) => field.path)).toEqual(["[].time"])
+  })
+
+  it("collapses array indices so a path is reported once, not per element", () => {
+    const schema = z.array(z.object({ id: z.number() }))
+    const result = checkConformance(schema, [
+      { id: 1, extra: true },
+      { id: 2, extra: true },
+    ])
+
+    expect(result.unknownFields).toHaveLength(1)
+    expect(result.unknownFields[0]?.path).toBe("[].extra")
+    expect(result.unknownFields[0]?.samples).toBe(2)
+  })
+
+  it("walks nested objects", () => {
+    const schema = z.object({
+      content: z.object({ title: z.string(), summary: z.string().optional() }),
+    })
+    const result = checkConformance(schema, {
+      content: { title: "t", kind: "article" },
+    })
+
+    expect(result.unknownFields.map((field) => field.path)).toEqual([
+      "content.kind",
+    ])
+    expect(result.phantomFields.map((field) => field.path)).toEqual([
+      "content.summary",
+    ])
+  })
+
+  it("sees through nullable and default wrappers", () => {
+    const schema = z.object({
+      a: z.string().nullable(),
+      b: z.string().default("x"),
+    })
+    const result = checkConformance(schema, { a: null })
+
+    expect(result.valid).toBe(true)
+    // `b` has a default, so its absence is expected of the wire, not phantom-free
+    expect(result.phantomFields.map((field) => field.path)).toEqual(["b"])
+  })
+
+  it("reports an empty collection as zero samples so it is not read as clean", () => {
+    const schema = z.array(
+      z.object({ id: z.number(), time: z.string().optional() })
+    )
+    const result = checkConformance(schema, [])
+
+    expect(result.valid).toBe(true)
+    expect(result.sampleCount).toBe(0)
+    expect(result.phantomFields).toEqual([])
+  })
+
+  it("still surfaces unknown fields when validation fails, so a rename is legible", () => {
+    const schema = z.object({ tab_id: z.number() })
+    const result = checkConformance(schema, { tabId: 7 })
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.join()).toContain("tab_id")
+    expect(result.unknownFields.map((field) => field.path)).toEqual(["tabId"])
+  })
+
+  it("flags a type change that unit tests on either side would miss", () => {
+    // The exact scenario from the design discussion: id goes number -> string.
+    const schema = z.object({ id: z.number(), prompt: z.string() })
+    const result = checkConformance(schema, { id: "123", prompt: "p" })
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.join()).toContain("id")
+  })
+
+  it("does not audit record subtrees for unknown keys, and says so", () => {
+    const schema = z.object({ meta: z.record(z.string(), z.unknown()) })
+    const result = checkConformance(schema, { meta: { anything: 1, else: 2 } })
+
+    expect(result.valid).toBe(true)
+    expect(result.unknownFields).toEqual([])
+    expect(result.opaqueSubtrees).toEqual(["meta"])
+  })
+})

--- a/packages/contract-harness/src/conformance.ts
+++ b/packages/contract-harness/src/conformance.ts
@@ -1,0 +1,279 @@
+/**
+ * @module conformance
+ *
+ * Compares a response body against the schema the client believes describes it,
+ * and reports the two kinds of divergence that ordinary validation cannot see.
+ *
+ * `schema.parse(body)` answers one question: is this body acceptable? That is
+ * not the question a boundary check is asking. Two failure modes pass
+ * validation while the two sides are meaningfully out of step:
+ *
+ * **Unknown fields.** zod strips keys it does not declare. A server that grows
+ * a field keeps validating cleanly forever, so the client never learns there is
+ * something new to consume.
+ *
+ * **Phantom fields.** A field declared `.optional()` that the server never
+ * sends also validates cleanly, forever. This is not hypothetical here:
+ * `MoodEventSchema` in `packages/ui/nfl/src/hooks/hopium/use-hopium-queries.ts`
+ * declares `time: z.string().optional()`, and the server's `MoodEvent` has no
+ * `time` field at all. A pure pass/fail check scores that boundary as healthy.
+ *
+ * Both are reported rather than failed by default, because both are usually
+ * "the other side moved and you have not caught up yet" rather than "this is
+ * broken right now".
+ *
+ * # Deliberate limits
+ *
+ * Unions and records are walked into but not audited for unknown keys: for a
+ * union there is no single declared shape to diff against, and for a record the
+ * keys are data, so an "undeclared" key is meaningless. Those subtrees are
+ * counted in `opaqueSubtrees` so a report can say what it did not look at
+ * instead of implying clean coverage.
+ */
+
+import type { z } from "zod"
+
+export type FieldFinding = {
+  kind: "unknown-field" | "phantom-field"
+  /** Dotted path, with `[]` marking array traversal, e.g. `items[].label`. */
+  path: string
+  /** How many sampled values the judgement is based on. */
+  samples: number
+}
+
+export type ConformanceResult = {
+  /** Whether `schema.parse` accepted the body. */
+  valid: boolean
+  /** zod issues, flattened to `path: message`. Empty when `valid`. */
+  issues: Array<string>
+  /** Fields the server sent that the schema does not declare. */
+  unknownFields: Array<FieldFinding>
+  /** Optional fields the schema declares that no sampled value carried. */
+  phantomFields: Array<FieldFinding>
+  /**
+   * How many values the walk actually inspected. Zero means the response was
+   * an empty collection and the field findings prove nothing — reported so an
+   * empty result is not mistaken for a clean one.
+   */
+  sampleCount: number
+  /** Paths skipped because their schema has no single declared shape. */
+  opaqueSubtrees: Array<string>
+}
+
+/*
+ * Reading zod's runtime structure.
+ *
+ * These read schemas as plain values rather than casting to a mirror of zod's
+ * internal types. The property names (`def.type`, `shape`, `element`) are the
+ * stable, documented introspection surface; the layout underneath them is not.
+ * Narrowing with `in` means an unexpected shape degrades into "cannot see
+ * inside this node" and the walk simply reports less, instead of throwing on a
+ * cast that turned out to be a lie.
+ */
+
+type SchemaDef = { type: string; innerType: unknown }
+
+function readDef(schema: unknown): SchemaDef | undefined {
+  if (typeof schema !== "object" || schema === null || !("def" in schema)) {
+    return undefined
+  }
+  const { def } = schema
+  if (typeof def !== "object" || def === null || !("type" in def)) {
+    return undefined
+  }
+  const { type } = def
+  if (typeof type !== "string") return undefined
+  return { type, innerType: "innerType" in def ? def.innerType : undefined }
+}
+
+function readShape(
+  schema: unknown
+): ReadonlyArray<readonly [string, unknown]> | undefined {
+  if (typeof schema !== "object" || schema === null || !("shape" in schema)) {
+    return undefined
+  }
+  const { shape } = schema
+  if (typeof shape !== "object" || shape === null) return undefined
+  return Object.keys(shape).map((key): readonly [string, unknown] => [
+    key,
+    Object.getOwnPropertyDescriptor(shape, key)?.value,
+  ])
+}
+
+function readElement(schema: unknown): unknown {
+  if (typeof schema !== "object" || schema === null || !("element" in schema)) {
+    return undefined
+  }
+  return schema.element
+}
+
+const WRAPPERS_MAKING_OPTIONAL = new Set(["optional", "default", "prefault"])
+const TRANSPARENT_WRAPPERS = new Set([
+  "nullable",
+  "readonly",
+  "catch",
+  "nonoptional",
+  "lazy",
+])
+
+type Peeled = { node: unknown; optional: boolean }
+
+/**
+ * Strips wrapper types down to the schema that actually describes structure,
+ * remembering whether anything on the way made the value omittable.
+ */
+function peel(schema: unknown): Peeled {
+  let node = schema
+  let optional = false
+
+  // Bounded rather than `while (true)`: a self-referential lazy schema would
+  // otherwise spin here, and a stack overflow is a worse diagnostic than a
+  // slightly incomplete walk.
+  for (let depth = 0; depth < 32; depth += 1) {
+    const def = readDef(node)
+    if (def?.innerType === undefined) break
+
+    if (WRAPPERS_MAKING_OPTIONAL.has(def.type)) {
+      optional = true
+      node = def.innerType
+      continue
+    }
+    if (TRANSPARENT_WRAPPERS.has(def.type)) {
+      node = def.innerType
+      continue
+    }
+    break
+  }
+
+  return { node, optional }
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+type Walker = {
+  /** For each declared-optional path: how often looked for, how often found. */
+  declaredOptional: Map<string, { seen: number; present: number }>
+  /** For each undeclared path the server sent: how many times seen. */
+  unknown: Map<string, number>
+  opaque: Set<string>
+}
+
+function walk(
+  schema: unknown,
+  value: unknown,
+  path: string,
+  acc: Walker
+): void {
+  const { node } = peel(schema)
+  const type = readDef(node)?.type
+
+  if (type === "object") {
+    if (!isPlainObject(value)) return
+
+    const shape = readShape(node) ?? []
+    const declared = new Set(shape.map(([key]) => key))
+
+    for (const [key, child] of shape) {
+      const childPath = path === "" ? key : `${path}.${key}`
+      const present = Object.hasOwn(value, key)
+
+      if (peel(child).optional) {
+        const stat = acc.declaredOptional.get(childPath) ?? {
+          seen: 0,
+          present: 0,
+        }
+        stat.seen += 1
+        if (present) stat.present += 1
+        acc.declaredOptional.set(childPath, stat)
+      }
+
+      if (present) walk(child, value[key], childPath, acc)
+    }
+
+    for (const key of Object.keys(value)) {
+      if (declared.has(key)) continue
+      const childPath = path === "" ? key : `${path}.${key}`
+      acc.unknown.set(childPath, (acc.unknown.get(childPath) ?? 0) + 1)
+    }
+    return
+  }
+
+  if (type === "array") {
+    if (!Array.isArray(value)) return
+    const element = readElement(node)
+    if (element === undefined) return
+    for (const item of value) walk(element, item, `${path}[]`, acc)
+    return
+  }
+
+  if (type === "union" || type === "record" || type === "tuple") {
+    // No single declared shape to diff against — see the module note.
+    if (isPlainObject(value) || Array.isArray(value)) {
+      acc.opaque.add(path === "" ? "<root>" : path)
+    }
+  }
+}
+
+/** How many top-level values a result represents, for honest sample counts. */
+function countSamples(schema: unknown, value: unknown): number {
+  const { node } = peel(schema)
+  if (readDef(node)?.type === "array" && Array.isArray(value)) {
+    return value.length
+  }
+  return value === undefined || value === null ? 0 : 1
+}
+
+export function checkConformance<T>(
+  schema: z.ZodType<T>,
+  body: unknown
+): ConformanceResult {
+  const parsed = schema.safeParse(body)
+
+  const issues = parsed.success
+    ? []
+    : parsed.error.issues.map((issue) => {
+        const where = issue.path.length > 0 ? issue.path.join(".") : "<root>"
+        return `${where}: ${issue.message}`
+      })
+
+  const acc: Walker = {
+    declaredOptional: new Map(),
+    unknown: new Map(),
+    opaque: new Set(),
+  }
+
+  // Walk the raw body, not the parsed one — parsing is what strips the unknown
+  // keys this is trying to find. Runs even when validation failed, since a
+  // renamed field shows up as both a violation and an unknown key, and seeing
+  // the pair together is what makes the rename obvious.
+  walk(schema, body, "", acc)
+
+  const sampleCount = countSamples(schema, body)
+
+  const phantomFields: Array<FieldFinding> = [...acc.declaredOptional.entries()]
+    .filter(([, stat]) => stat.seen > 0 && stat.present === 0)
+    .map(([path, stat]) => ({
+      kind: "phantom-field" as const,
+      path,
+      samples: stat.seen,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path))
+
+  const unknownFields: Array<FieldFinding> = [...acc.unknown.entries()]
+    .map(([path, samples]) => ({
+      kind: "unknown-field" as const,
+      path,
+      samples,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path))
+
+  return {
+    valid: parsed.success,
+    issues,
+    unknownFields,
+    phantomFields,
+    sampleCount,
+    opaqueSubtrees: [...acc.opaque].sort(),
+  }
+}

--- a/packages/contract-harness/src/contract.test.ts
+++ b/packages/contract-harness/src/contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import {
+  acceptedStatuses,
+  bindPath,
+  defineContract,
+  fullPath,
+  requestUrl,
+  schemaStatuses,
+} from "./contract"
+
+describe("fullPath", () => {
+  it("prefixes versioned routes", () => {
+    expect(fullPath({ path: "/mood_events" })).toBe("/api/v1/mood_events")
+  })
+
+  it("leaves the unversioned exceptions alone", () => {
+    expect(fullPath({ path: "/health", versioned: false })).toBe("/health")
+  })
+})
+
+describe("bindPath", () => {
+  it("substitutes placeholders", () => {
+    const bound = bindPath("/api/v1/mood_events/:id", { id: 42 })
+    expect(bound.path).toBe("/api/v1/mood_events/42")
+    expect(bound.unbound).toEqual([])
+    expect(bound.unused).toEqual([])
+  })
+
+  it("handles several placeholders in one template", () => {
+    const bound = bindPath("/api/v1/gdrive/write/:folder_id/:name", {
+      folder_id: "abc",
+      name: "seed.json",
+    })
+    expect(bound.path).toBe("/api/v1/gdrive/write/abc/seed.json")
+  })
+
+  it("reports a placeholder nobody bound, rather than requesting it literally", () => {
+    // This is the failure mode the client's own layering invites: apiUrl()
+    // returns a URL still carrying ':id', and substitution happens elsewhere.
+    const bound = bindPath("/api/v1/mood_events/:id", {})
+    expect(bound.unbound).toEqual(["id"])
+    expect(bound.path).toBe("/api/v1/mood_events/:id")
+  })
+
+  it("reports a binding that matches no placeholder", () => {
+    const bound = bindPath("/api/v1/mood_events", { id: 1 })
+    expect(bound.unused).toEqual(["id"])
+  })
+
+  it("encodes values so a slash cannot forge a path segment", () => {
+    const bound = bindPath("/api/v1/tabs/:tab_id", { tab_id: "a/b" })
+    expect(bound.path).toBe("/api/v1/tabs/a%2Fb")
+  })
+})
+
+describe("requestUrl", () => {
+  it("appends query parameters", () => {
+    const url = requestUrl("http://localhost:3000", "/api/v1/search_audio", {
+      q: "bass",
+      limit: 5,
+    })
+    expect(url.toString()).toBe(
+      "http://localhost:3000/api/v1/search_audio?q=bass&limit=5"
+    )
+  })
+})
+
+describe("status helpers", () => {
+  const contract = defineContract({
+    id: "x.y",
+    module: "m",
+    method: "GET",
+    path: "/p",
+    summary: "s",
+    expect: { status: [200, 404], schemaFor: 200, schema: z.object({}) },
+  })
+
+  it("accepts every declared status", () => {
+    expect(acceptedStatuses(contract)).toEqual([200, 404])
+  })
+
+  it("applies the schema only to the statuses it describes", () => {
+    expect(schemaStatuses(contract)).toEqual([200])
+  })
+
+  it("defaults schema statuses to all accepted statuses", () => {
+    const simple = defineContract({
+      id: "x.z",
+      module: "m",
+      method: "GET",
+      path: "/p",
+      summary: "s",
+      expect: { status: 200, schema: z.object({}) },
+    })
+    expect(schemaStatuses(simple)).toEqual([200])
+  })
+})

--- a/packages/contract-harness/src/contract.ts
+++ b/packages/contract-harness/src/contract.ts
@@ -1,0 +1,185 @@
+/**
+ * @module contract
+ *
+ * The vocabulary for writing down a boundary handshake.
+ *
+ * A `Contract` is one statement of the form "when I send *this*, I expect
+ * *that* back". It is deliberately not derived from either side: not generated
+ * from the Rust types, and not inferred from the client's call sites. Both of
+ * those would make the check circular — a generated expectation agrees with
+ * the thing it was generated from by construction, which is precisely the
+ * property you do not want in an oracle.
+ *
+ * So contracts are written by hand, and they encode what the *client* believes.
+ * The runner's job is to find out whether the server agrees.
+ */
+
+import type { z } from "zod"
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+
+/**
+ * What to do about fields the server sends that the contract does not declare.
+ *
+ * `report` is the default and the interesting one. zod strips unknown keys
+ * silently, so a server that grows a field is invisible to ordinary schema
+ * validation — the client keeps passing while drifting further from the truth.
+ * Reporting surfaces the growth without failing the run.
+ *
+ * `reject` treats an undeclared field as a failure. Use it on endpoints where
+ * the payload shape is the contract (a stable public response), not on ones
+ * that are expected to accrete fields.
+ */
+export type UnknownFieldPolicy = "report" | "reject" | "ignore"
+
+export type ContractRequest = {
+  /**
+   * Bindings for `:name` segments in the path template. Every placeholder must
+   * get a value and every value must correspond to a placeholder — the runner
+   * reports both directions, because a silently unbound `:id` produces a
+   * request for the literal path `/mood_events/:id`, which the server answers
+   * with a 404 that looks like a missing route rather than a client bug.
+   */
+  path?: Readonly<Record<string, string | number>>
+  query?: Readonly<Record<string, string | number>>
+  body?: unknown
+  headers?: Readonly<Record<string, string>>
+}
+
+export type ContractExpectation<TResponse> = {
+  /** Accepted status code(s). A response outside this set is a finding. */
+  status: number | ReadonlyArray<number>
+  /**
+   * The shape the client believes it receives. Omit for endpoints where the
+   * body is not JSON (audio streams, images) — the runner then checks only
+   * transport and status.
+   */
+  schema?: z.ZodType<TResponse>
+  /**
+   * Which of the accepted statuses `schema` describes. Defaults to all of them,
+   * which is right for single-status contracts and wrong the moment a contract
+   * accepts both a success and a miss: a 404 body is an error envelope, and
+   * checking it against the success schema would report a violation that says
+   * nothing about the boundary.
+   */
+  schemaFor?: number | ReadonlyArray<number>
+  /** Defaults to `report`. */
+  unknownFields?: UnknownFieldPolicy
+}
+
+export type Contract<TResponse = unknown> = {
+  /** Stable identifier, `module.operation`. Used to select and to report. */
+  id: string
+  /** Must match a `module` in the server's route inventory. */
+  module: string
+  method: HttpMethod
+  /**
+   * Path template as the server registers it — no `/api/v1` prefix, axum
+   * `:name` parameter syntax. Kept in the server's own notation so drift
+   * checking is a string comparison rather than a translation with its own
+   * bugs.
+   */
+  path: string
+  /** Whether the server nests this under `/api/v1`. Defaults to `true`. */
+  versioned?: boolean
+  /** One line on what handshake this pins down. Shown in reports. */
+  summary: string
+  request?: ContractRequest
+  expect: ContractExpectation<TResponse>
+  /**
+   * Marks a contract that writes. Skipped unless `--include-mutations` is
+   * passed, so the default run is safe to point at a server you care about.
+   */
+  mutates?: boolean
+  /** Set to a reason to skip. The contract still appears in the report. */
+  skip?: string
+}
+
+/**
+ * Identity function that exists for inference: it pins `TResponse` to the
+ * schema so `expect.schema` and the declared response type cannot drift apart
+ * within a single contract.
+ */
+export function defineContract<TResponse>(
+  contract: Contract<TResponse>
+): Contract<TResponse> {
+  return contract
+}
+
+export const API_V1_PREFIX = "/api/v1"
+
+/** The path a client actually requests, prefix resolved. */
+export function fullPath(
+  contract: Pick<Contract, "path" | "versioned">
+): string {
+  return contract.versioned === false
+    ? contract.path
+    : `${API_V1_PREFIX}${contract.path}`
+}
+
+const PLACEHOLDER = /:([A-Za-z_][A-Za-z0-9_]*)/g
+
+export type PathBinding = {
+  /** Path with placeholders substituted, ready to request. */
+  path: string
+  /** Placeholders in the template that no binding was supplied for. */
+  unbound: Array<string>
+  /** Bindings supplied that match no placeholder in the template. */
+  unused: Array<string>
+}
+
+/**
+ * Substitutes `:name` segments.
+ *
+ * This is modelled as a first-class step rather than folded into URL
+ * construction on purpose. In the client, `apiUrl()` returns a URL still
+ * carrying its `:id` placeholder and substitution happens later inside
+ * `createQueryHook`, which means the path a request actually uses is not
+ * knowable where the endpoint is declared. A contract that captured a `URL`
+ * would therefore only ever be able to describe parameterless routes. Keeping
+ * template and bindings separate lets a contract describe a parameterised
+ * route and lets the runner report a binding mistake as a binding mistake.
+ */
+export function bindPath(
+  template: string,
+  params: Readonly<Record<string, string | number>> = {}
+): PathBinding {
+  const seen = new Set<string>()
+
+  const path = template.replace(PLACEHOLDER, (match, name: string) => {
+    seen.add(name)
+    const value = params[name]
+    if (value === undefined) return match
+    return encodeURIComponent(String(value))
+  })
+
+  const unbound = [...seen].filter((name) => params[name] === undefined)
+  const unused = Object.keys(params).filter((name) => !seen.has(name))
+
+  return { path, unbound, unused }
+}
+
+/** Builds the request URL, query string included. */
+export function requestUrl(
+  baseUrl: string,
+  boundPath: string,
+  query: Readonly<Record<string, string | number>> = {}
+): URL {
+  const url = new URL(boundPath, baseUrl)
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.append(key, String(value))
+  }
+  return url
+}
+
+export function acceptedStatuses(contract: Contract): Array<number> {
+  const { status } = contract.expect
+  return typeof status === "number" ? [status] : [...status]
+}
+
+/** Statuses whose body the declared schema is expected to describe. */
+export function schemaStatuses(contract: Contract): Array<number> {
+  const { schemaFor } = contract.expect
+  if (schemaFor === undefined) return acceptedStatuses(contract)
+  return typeof schemaFor === "number" ? [schemaFor] : [...schemaFor]
+}

--- a/packages/contract-harness/src/drift.test.ts
+++ b/packages/contract-harness/src/drift.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest"
+
+import type { Contract } from "./contract"
+import { defineContract } from "./contract"
+import type { RouteInventory } from "./drift"
+import {
+  checkDrift,
+  InventoryShapeError,
+  InventoryVersionError,
+  parseInventory,
+} from "./drift"
+
+const inventory = (
+  overrides: Partial<RouteInventory> = {}
+): RouteInventory => ({
+  schema_version: 1,
+  api_base_path: "/api/v1",
+  server_version: "0.0.0",
+  routes: [
+    {
+      method: "GET",
+      path: "/mood_events",
+      full_path: "/api/v1/mood_events",
+      versioned: true,
+      module: "mood_events",
+    },
+    {
+      method: "GET",
+      path: "/health",
+      full_path: "/health",
+      versioned: false,
+      module: "health",
+    },
+  ],
+  ...overrides,
+})
+
+const listMoodEvents: Contract = defineContract({
+  id: "mood_events.list",
+  module: "mood_events",
+  method: "GET",
+  path: "/mood_events",
+  summary: "all mood events",
+  expect: { status: 200 },
+})
+
+describe("checkDrift", () => {
+  it("passes when every contract targets a real route", () => {
+    const report = checkDrift([listMoodEvents], inventory())
+    expect(report.findings.filter((f) => f.severity === "fail")).toEqual([])
+    expect(report.covered).toBe(1)
+    expect(report.total).toBe(2)
+  })
+
+  it("fails when the server no longer serves the path a contract targets", () => {
+    const renamed = inventory({
+      routes: [
+        {
+          method: "GET",
+          path: "/moods",
+          full_path: "/api/v1/moods",
+          versioned: true,
+          module: "mood_events",
+        },
+      ],
+    })
+
+    const report = checkDrift([listMoodEvents], renamed)
+    const failures = report.findings.filter((f) => f.code === "missing-route")
+
+    expect(failures).toHaveLength(1)
+    expect(failures[0]?.message).toContain("GET /api/v1/mood_events")
+  })
+
+  it("fails when the method moved but the path did not", () => {
+    const asPost = inventory({
+      routes: [
+        {
+          method: "POST",
+          path: "/mood_events",
+          full_path: "/api/v1/mood_events",
+          versioned: true,
+          module: "mood_events",
+        },
+      ],
+    })
+
+    const report = checkDrift([listMoodEvents], asPost)
+    expect(report.findings.some((f) => f.code === "missing-route")).toBe(true)
+  })
+
+  it("names an API version bump once instead of failing every contract separately", () => {
+    const bumped = inventory({ api_base_path: "/api/v2" })
+    const report = checkDrift([listMoodEvents], bumped)
+
+    expect(report.findings.some((f) => f.code === "base-path-mismatch")).toBe(
+      true
+    )
+  })
+
+  it("warns when a contract is filed under a different module than the server uses", () => {
+    const misfiled = defineContract({ ...listMoodEvents, module: "hopium" })
+    const report = checkDrift([misfiled], inventory())
+
+    expect(report.findings.some((f) => f.code === "module-mismatch")).toBe(true)
+  })
+
+  it("reports routes no contract covers, as information rather than failure", () => {
+    const report = checkDrift([listMoodEvents], inventory())
+    const uncovered = report.findings.filter(
+      (f) => f.code === "uncovered-route"
+    )
+
+    expect(uncovered).toHaveLength(1)
+    expect(uncovered[0]?.severity).toBe("info")
+    expect(uncovered[0]?.message).toContain("/health")
+  })
+
+  it("refuses a snapshot shape it does not understand", () => {
+    expect(() => checkDrift([], inventory({ schema_version: 99 }))).toThrow(
+      InventoryVersionError
+    )
+  })
+})
+
+describe("parseInventory", () => {
+  it("accepts a well-formed snapshot", () => {
+    const parsed = parseInventory(JSON.parse(JSON.stringify(inventory())))
+    expect(parsed.routes).toHaveLength(2)
+  })
+
+  it("rejects a truncated snapshot rather than reading it as empty", () => {
+    // The realistic failure: a half-copied file between two repos. Reading this
+    // optimistically would report "no drift" for the worst possible reason.
+    expect(() => parseInventory({ schema_version: 1 })).toThrow(
+      InventoryShapeError
+    )
+  })
+
+  it("rejects a route entry missing its method", () => {
+    expect(() =>
+      parseInventory({
+        schema_version: 1,
+        api_base_path: "/api/v1",
+        server_version: "0.0.0",
+        routes: [
+          { path: "/x", full_path: "/x", versioned: false, module: "m" },
+        ],
+      })
+    ).toThrow(InventoryShapeError)
+  })
+
+  it("still enforces the version after the shape checks out", () => {
+    expect(() =>
+      parseInventory(
+        JSON.parse(JSON.stringify(inventory({ schema_version: 7 })))
+      )
+    ).toThrow(InventoryVersionError)
+  })
+})

--- a/packages/contract-harness/src/drift.ts
+++ b/packages/contract-harness/src/drift.ts
@@ -1,0 +1,190 @@
+/**
+ * @module drift
+ *
+ * Compares the contracts against the server's own description of its route
+ * surface, without talking to a server.
+ *
+ * This is the cheap half of the check and it catches the failure that is
+ * hardest to see from here: a route that was renamed or removed on the server.
+ * Behaviourally that shows up as a 404, which is indistinguishable from a
+ * hundred other causes. Structurally it shows up as "the path this contract
+ * targets is not in the surface the server says it serves", which names the
+ * problem precisely.
+ *
+ * The snapshot is produced by the server repo's `dump-routes` binary and
+ * checked in here. Refreshing it is the moment the two sides are married: the
+ * diff on `routes.server.json` is the reviewable record of what moved.
+ */
+
+import { z } from "zod"
+
+import type { Contract } from "./contract"
+import { API_V1_PREFIX, fullPath } from "./contract"
+
+/** Mirrors `RouteEntry` in the server's `routes/inventory.rs`. */
+export type RouteEntry = {
+  method: string
+  path: string
+  full_path: string
+  versioned: boolean
+  module: string
+}
+
+export type RouteInventory = {
+  schema_version: number
+  api_base_path: string
+  server_version: string
+  routes: Array<RouteEntry>
+}
+
+/**
+ * The snapshot is parsed rather than trusted. It arrives as a file copied
+ * between two repositories by hand, which is exactly the kind of input that is
+ * occasionally truncated, half-written, or from the wrong branch — and a
+ * harness that read a malformed snapshot optimistically would answer "no drift"
+ * for the most confident possible wrong reason.
+ */
+export const RouteInventorySchema = z.object({
+  schema_version: z.number(),
+  api_base_path: z.string(),
+  server_version: z.string(),
+  routes: z.array(
+    z.object({
+      method: z.string(),
+      path: z.string(),
+      full_path: z.string(),
+      versioned: z.boolean(),
+      module: z.string(),
+    })
+  ),
+})
+
+/** Parses and version-checks a raw snapshot. */
+export function parseInventory(raw: unknown): RouteInventory {
+  const result = RouteInventorySchema.safeParse(raw)
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+      .join("; ")
+    throw new InventoryShapeError(`route inventory is malformed — ${detail}`)
+  }
+  assertSupportedInventory(result.data)
+  return result.data
+}
+
+/** Inventory shapes this harness knows how to read. */
+export const SUPPORTED_SCHEMA_VERSION = 1
+
+export type DriftFinding = {
+  code:
+    | "missing-route"
+    | "module-mismatch"
+    | "uncovered-route"
+    | "base-path-mismatch"
+  severity: "fail" | "warn" | "info"
+  message: string
+  detail?: string
+}
+
+export type DriftReport = {
+  findings: Array<DriftFinding>
+  /** Routes in the inventory that at least one contract targets. */
+  covered: number
+  total: number
+  serverVersion: string
+}
+
+const key = (method: string, path: string): string =>
+  `${method.toUpperCase()} ${path}`
+
+export class InventoryVersionError extends Error {}
+export class InventoryShapeError extends Error {}
+
+/**
+ * Validates the snapshot is one this harness understands. A newer snapshot is
+ * refused rather than read optimistically — misreading the server's own
+ * description of itself would produce confident, wrong findings, which is worse
+ * than no findings.
+ */
+export function assertSupportedInventory(
+  inventory: RouteInventory
+): asserts inventory is RouteInventory {
+  if (inventory.schema_version !== SUPPORTED_SCHEMA_VERSION) {
+    throw new InventoryVersionError(
+      `routes.server.json declares schema_version ${inventory.schema_version}, but this harness reads ${SUPPORTED_SCHEMA_VERSION}. Update @some-ui/contract-harness before regenerating the snapshot.`
+    )
+  }
+}
+
+export function checkDrift(
+  contracts: ReadonlyArray<Contract>,
+  inventory: RouteInventory
+): DriftReport {
+  assertSupportedInventory(inventory)
+
+  const findings: Array<DriftFinding> = []
+
+  // A bumped API version invalidates every versioned contract at once, so it
+  // is worth naming directly rather than letting it surface as 39 separate
+  // missing routes.
+  if (inventory.api_base_path !== API_V1_PREFIX) {
+    findings.push({
+      code: "base-path-mismatch",
+      severity: "fail",
+      message: `server nests versioned routes under ${inventory.api_base_path}, the client builds ${API_V1_PREFIX}`,
+      detail:
+        "Update API_V1_PREFIX in packages/fetch-kit/src/lib/api-config and in this harness together.",
+    })
+  }
+
+  const byKey = new Map<string, RouteEntry>()
+  for (const route of inventory.routes) {
+    byKey.set(key(route.method, route.full_path), route)
+  }
+
+  const touched = new Set<string>()
+
+  for (const contract of contracts) {
+    const target = key(contract.method, fullPath(contract))
+    const route = byKey.get(target)
+
+    if (route === undefined) {
+      findings.push({
+        code: "missing-route",
+        severity: "fail",
+        message: `contract "${contract.id}" targets ${target}, which the server does not serve`,
+        detail:
+          "The route was renamed or removed. Update the contract, or regenerate routes.server.json if the snapshot is stale.",
+      })
+      continue
+    }
+
+    touched.add(target)
+
+    if (route.module !== contract.module) {
+      findings.push({
+        code: "module-mismatch",
+        severity: "warn",
+        message: `contract "${contract.id}" claims module "${contract.module}", server groups it under "${route.module}"`,
+      })
+    }
+  }
+
+  for (const route of inventory.routes) {
+    const target = key(route.method, route.full_path)
+    if (touched.has(target)) continue
+    findings.push({
+      code: "uncovered-route",
+      severity: "info",
+      message: `no contract covers ${target}`,
+      detail: `module: ${route.module}`,
+    })
+  }
+
+  return {
+    findings,
+    covered: touched.size,
+    total: inventory.routes.length,
+    serverVersion: inventory.server_version,
+  }
+}

--- a/packages/contract-harness/src/index.ts
+++ b/packages/contract-harness/src/index.ts
@@ -1,0 +1,56 @@
+export type { ConformanceResult, FieldFinding } from "./conformance"
+export { checkConformance } from "./conformance"
+
+export type {
+  Contract,
+  ContractExpectation,
+  ContractRequest,
+  HttpMethod,
+  PathBinding,
+  UnknownFieldPolicy,
+} from "./contract"
+export {
+  acceptedStatuses,
+  API_V1_PREFIX,
+  bindPath,
+  defineContract,
+  fullPath,
+  requestUrl,
+  schemaStatuses,
+} from "./contract"
+
+export type {
+  DriftFinding,
+  DriftReport,
+  RouteEntry,
+  RouteInventory,
+} from "./drift"
+export {
+  assertSupportedInventory,
+  checkDrift,
+  InventoryShapeError,
+  InventoryVersionError,
+  parseInventory,
+  RouteInventorySchema,
+  SUPPORTED_SCHEMA_VERSION,
+} from "./drift"
+
+export type {
+  ContractOutcome,
+  Finding,
+  OutcomeStatus,
+  ProbeOptions,
+  Severity,
+} from "./probe"
+export { probeContract } from "./probe"
+
+export { allContracts, assertUniqueIds, selectContracts } from "./registry"
+
+export type { RunReport, RunSummary } from "./report"
+export {
+  exitCode,
+  renderDrift,
+  renderOutcomes,
+  renderSummary,
+  summarize,
+} from "./report"

--- a/packages/contract-harness/src/probe.ts
+++ b/packages/contract-harness/src/probe.ts
@@ -1,0 +1,278 @@
+/**
+ * @module probe
+ *
+ * Executes one contract against a running server and turns the result into
+ * findings.
+ *
+ * Everything here goes through plain `fetch` from Node rather than a browser.
+ * That is a deliberate choice, not a convenience: several route groups pin CORS
+ * to a single origin (`routes/db/tab.rs` and `routes/db/hopium.rs` allow only
+ * `http://nixos.local:6006`), so a browser-origin runner would be blocked from
+ * most of the surface and would be reporting on the CORS policy as much as on
+ * the handshake. A server-to-server request sees the payload the server
+ * actually produces.
+ */
+
+import type { ConformanceResult } from "./conformance"
+import { checkConformance } from "./conformance"
+import type { Contract } from "./contract"
+import {
+  acceptedStatuses,
+  bindPath,
+  fullPath,
+  requestUrl,
+  schemaStatuses,
+} from "./contract"
+
+export type Severity = "fail" | "warn" | "info"
+
+export type Finding = {
+  code: string
+  severity: Severity
+  message: string
+  detail?: string
+}
+
+export type OutcomeStatus =
+  | "passed"
+  | "failed"
+  | "warned"
+  | "skipped"
+  | "errored"
+
+export type ContractOutcome = {
+  id: string
+  module: string
+  summary: string
+  method: string
+  /** Path actually requested, placeholders resolved. */
+  path: string
+  status: OutcomeStatus
+  httpStatus?: number
+  durationMs?: number
+  findings: Array<Finding>
+  conformance?: ConformanceResult
+}
+
+export type ProbeOptions = {
+  baseUrl: string
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000
+
+function rollUp(findings: ReadonlyArray<Finding>): OutcomeStatus {
+  if (findings.some((finding) => finding.severity === "fail")) return "failed"
+  if (findings.some((finding) => finding.severity === "warn")) return "warned"
+  return "passed"
+}
+
+/** Truncates a response body for reporting without hiding that it was cut. */
+function preview(text: string, limit = 300): string {
+  return text.length <= limit
+    ? text
+    : `${text.slice(0, limit)}… (+${text.length - limit} bytes)`
+}
+
+export async function probeContract(
+  contract: Contract,
+  options: ProbeOptions
+): Promise<ContractOutcome> {
+  const template = fullPath(contract)
+  const base: Omit<ContractOutcome, "status" | "findings"> = {
+    id: contract.id,
+    module: contract.module,
+    summary: contract.summary,
+    method: contract.method,
+    path: template,
+  }
+
+  if (contract.skip !== undefined) {
+    return {
+      ...base,
+      status: "skipped",
+      findings: [{ code: "skipped", severity: "info", message: contract.skip }],
+    }
+  }
+
+  const binding = bindPath(template, contract.request?.path)
+  const findings: Array<Finding> = []
+
+  if (binding.unbound.length > 0) {
+    // Not sent. A request carrying a literal `:id` returns a 404 that reads
+    // like a missing route, which would send whoever debugs it to the wrong
+    // side of the boundary entirely.
+    return {
+      ...base,
+      status: "failed",
+      findings: [
+        {
+          code: "unbound-path-param",
+          severity: "fail",
+          message: `contract declares ${binding.unbound.length} unbound path parameter(s); request not sent`,
+          detail: `unbound: ${binding.unbound.join(", ")}`,
+        },
+      ],
+    }
+  }
+
+  if (binding.unused.length > 0) {
+    findings.push({
+      code: "unused-path-param",
+      severity: "warn",
+      message: "request supplies path parameters the template has no place for",
+      detail: `unused: ${binding.unused.join(", ")}`,
+    })
+  }
+
+  const url = requestUrl(options.baseUrl, binding.path, contract.request?.query)
+  const hasBody = contract.request?.body !== undefined
+
+  const startedAt = performance.now()
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: contract.method,
+      headers: {
+        accept: "application/json",
+        ...(hasBody ? { "content-type": "application/json" } : {}),
+        ...contract.request?.headers,
+      },
+      body: hasBody ? JSON.stringify(contract.request?.body) : undefined,
+      signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    })
+  } catch (error) {
+    return {
+      ...base,
+      path: binding.path,
+      status: "errored",
+      durationMs: Math.round(performance.now() - startedAt),
+      findings: [
+        {
+          code: "transport-error",
+          severity: "fail",
+          message: "request did not complete",
+          detail: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    }
+  }
+
+  const durationMs = Math.round(performance.now() - startedAt)
+  const bodyText = await response.text()
+  const accepted = acceptedStatuses(contract)
+
+  if (!accepted.includes(response.status)) {
+    findings.push({
+      code: "status-mismatch",
+      severity: "fail",
+      message: `expected ${accepted.join(" or ")}, got ${response.status}`,
+      detail: preview(bodyText),
+    })
+  }
+
+  let conformance: ConformanceResult | undefined
+  const schemaApplies = schemaStatuses(contract).includes(response.status)
+
+  if (contract.expect.schema !== undefined && schemaApplies) {
+    let parsedBody: unknown
+    try {
+      parsedBody = bodyText === "" ? undefined : JSON.parse(bodyText)
+    } catch {
+      findings.push({
+        code: "non-json-body",
+        severity: "fail",
+        message: "contract declares a schema but the body is not JSON",
+        detail: preview(bodyText),
+      })
+      return {
+        ...base,
+        path: binding.path,
+        status: "failed",
+        httpStatus: response.status,
+        durationMs,
+        findings,
+      }
+    }
+
+    conformance = checkConformance(contract.expect.schema, parsedBody)
+
+    if (!conformance.valid) {
+      findings.push({
+        code: "schema-violation",
+        severity: "fail",
+        message: `response does not match the declared schema (${conformance.issues.length} issue(s))`,
+        detail: conformance.issues.join("\n"),
+      })
+    }
+
+    const policy = contract.expect.unknownFields ?? "report"
+    if (policy !== "ignore" && conformance.unknownFields.length > 0) {
+      findings.push({
+        code: "unknown-field",
+        severity: policy === "reject" ? "fail" : "warn",
+        message: `server sent ${conformance.unknownFields.length} field(s) the contract does not declare`,
+        detail: conformance.unknownFields
+          .map((field) => `${field.path} (in ${field.samples} sample(s))`)
+          .join("\n"),
+      })
+    }
+
+    if (conformance.phantomFields.length > 0) {
+      findings.push({
+        code: "phantom-field",
+        severity: "warn",
+        message: `contract declares ${conformance.phantomFields.length} optional field(s) the server never sent`,
+        detail: conformance.phantomFields
+          .map(
+            (field) =>
+              `${field.path} (absent from all ${field.samples} sample(s))`
+          )
+          .join("\n"),
+      })
+    }
+
+    if (conformance.sampleCount === 0) {
+      findings.push({
+        code: "no-samples",
+        severity: "info",
+        message:
+          "response carried no values, so field-level checks proved nothing — seed data and re-run",
+      })
+    }
+
+    if (conformance.opaqueSubtrees.length > 0) {
+      findings.push({
+        code: "opaque-subtree",
+        severity: "info",
+        message:
+          "some subtrees have no single declared shape and were not audited for unknown fields",
+        detail: conformance.opaqueSubtrees.join(", "),
+      })
+    }
+  }
+
+  if (
+    contract.expect.schema !== undefined &&
+    !schemaApplies &&
+    accepted.includes(response.status)
+  ) {
+    // Surfaced rather than passed over silently: a contract that only ever sees
+    // its non-schema status is green while checking nothing about the payload.
+    findings.push({
+      code: "schema-not-applicable",
+      severity: "info",
+      message: `server answered ${response.status}; the declared schema covers ${schemaStatuses(contract).join(", ")}, so the body was not checked`,
+    })
+  }
+
+  return {
+    ...base,
+    path: binding.path,
+    status: rollUp(findings),
+    httpStatus: response.status,
+    durationMs,
+    findings,
+    conformance,
+  }
+}

--- a/packages/contract-harness/src/registry.ts
+++ b/packages/contract-harness/src/registry.ts
@@ -1,0 +1,48 @@
+/**
+ * @module registry
+ *
+ * Every contract the harness knows about, in one list.
+ *
+ * Contracts are enumerated explicitly rather than discovered by globbing the
+ * directory. Globbing would mean a contract file that fails to load simply
+ * vanishes from the run, and the report would show a smaller, entirely green
+ * suite — the worst possible failure mode for a tool whose only job is to tell
+ * you when something is missing.
+ */
+
+import { contracts as healthContracts } from "../contracts/health.contract"
+import { contracts as moodEventContracts } from "../contracts/mood-events.contract"
+import { contracts as tabContracts } from "../contracts/tabs.contract"
+import type { Contract } from "./contract"
+
+export const allContracts: ReadonlyArray<Contract> = [
+  ...healthContracts,
+  ...moodEventContracts,
+  ...tabContracts,
+]
+
+/** Fails loudly on duplicate ids — two contracts sharing one id would make the
+ * report ambiguous and `--only` non-deterministic. */
+export function assertUniqueIds(contracts: ReadonlyArray<Contract>): void {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+  for (const contract of contracts) {
+    if (seen.has(contract.id)) duplicates.add(contract.id)
+    seen.add(contract.id)
+  }
+  if (duplicates.size > 0) {
+    throw new Error(`duplicate contract id(s): ${[...duplicates].join(", ")}`)
+  }
+}
+
+/** Selects by exact contract id or by module name. */
+export function selectContracts(
+  contracts: ReadonlyArray<Contract>,
+  selector: string | undefined
+): ReadonlyArray<Contract> {
+  if (selector === undefined || selector === "") return contracts
+  const wanted = new Set(selector.split(",").map((part) => part.trim()))
+  return contracts.filter(
+    (contract) => wanted.has(contract.id) || wanted.has(contract.module)
+  )
+}

--- a/packages/contract-harness/src/report.ts
+++ b/packages/contract-harness/src/report.ts
@@ -1,0 +1,158 @@
+/**
+ * @module report
+ *
+ * Renders a run for a human reading a terminal.
+ *
+ * The organising principle is that a green run should be one screen and a red
+ * run should lead with what broke. Findings carry their detail indented under
+ * the line that names them, so scanning down the left edge gives the summary
+ * and reading right gives the evidence.
+ */
+
+import type { DriftReport } from "./drift"
+import type { ContractOutcome, Finding, OutcomeStatus } from "./probe"
+
+const MARKERS: Record<OutcomeStatus, string> = {
+  passed: "PASS",
+  failed: "FAIL",
+  warned: "WARN",
+  skipped: "SKIP",
+  errored: "ERR ",
+}
+
+const SEVERITY_MARKERS = { fail: "✗", warn: "!", info: "·" } as const
+
+export type RunReport = {
+  drift: DriftReport
+  outcomes: Array<ContractOutcome>
+  baseUrl: string | undefined
+  /** Whether contract probes ran at all. */
+  probed: boolean
+}
+
+function renderFinding(finding: Finding, indent: string): Array<string> {
+  const lines = [
+    `${indent}${SEVERITY_MARKERS[finding.severity]} ${finding.code}: ${finding.message}`,
+  ]
+  if (finding.detail !== undefined && finding.detail !== "") {
+    for (const line of finding.detail.split("\n")) {
+      lines.push(`${indent}    ${line}`)
+    }
+  }
+  return lines
+}
+
+export function renderDrift(
+  drift: DriftReport,
+  showUncovered: boolean
+): string {
+  const lines: Array<string> = []
+  lines.push("Route drift")
+  lines.push("───────────")
+  lines.push(
+    `  server ${drift.serverVersion} · ${drift.covered}/${drift.total} routes covered by a contract`
+  )
+
+  const actionable = drift.findings.filter(
+    (finding) => finding.code !== "uncovered-route"
+  )
+  const uncovered = drift.findings.filter(
+    (finding) => finding.code === "uncovered-route"
+  )
+
+  if (actionable.length === 0) {
+    lines.push("  ✓ every contract targets a route the server actually serves")
+  } else {
+    for (const finding of actionable) {
+      lines.push(...renderFinding({ ...finding, detail: finding.detail }, "  "))
+    }
+  }
+
+  if (showUncovered && uncovered.length > 0) {
+    lines.push("")
+    lines.push(
+      `  Uncovered routes (${uncovered.length}) — not failures, just unwritten contracts:`
+    )
+    for (const finding of uncovered) {
+      lines.push(`    · ${finding.message.replace("no contract covers ", "")}`)
+    }
+  } else if (uncovered.length > 0) {
+    lines.push(
+      `  · ${uncovered.length} route(s) have no contract yet (--show-uncovered to list)`
+    )
+  }
+
+  return lines.join("\n")
+}
+
+export function renderOutcomes(
+  outcomes: ReadonlyArray<ContractOutcome>
+): string {
+  const lines: Array<string> = []
+  lines.push("Contract conformance")
+  lines.push("────────────────────")
+
+  for (const outcome of outcomes) {
+    const timing =
+      outcome.durationMs === undefined ? "" : ` ${outcome.durationMs}ms`
+    const http =
+      outcome.httpStatus === undefined ? "" : ` ${outcome.httpStatus}`
+    lines.push(
+      `  ${MARKERS[outcome.status]}  ${outcome.id}  ${outcome.method} ${outcome.path}${http}${timing}`
+    )
+    const notable = outcome.findings.filter(
+      (finding) => finding.severity !== "info" || outcome.status === "skipped"
+    )
+    for (const finding of notable) {
+      lines.push(...renderFinding(finding, "        "))
+    }
+  }
+
+  return lines.join("\n")
+}
+
+export type RunSummary = {
+  passed: number
+  failed: number
+  warned: number
+  skipped: number
+  errored: number
+  driftFailures: number
+}
+
+export function summarize(report: RunReport): RunSummary {
+  const count = (status: OutcomeStatus): number =>
+    report.outcomes.filter((outcome) => outcome.status === status).length
+
+  return {
+    passed: count("passed"),
+    failed: count("failed"),
+    warned: count("warned"),
+    skipped: count("skipped"),
+    errored: count("errored"),
+    driftFailures: report.drift.findings.filter(
+      (finding) => finding.severity === "fail"
+    ).length,
+  }
+}
+
+export function renderSummary(summary: RunSummary, probed: boolean): string {
+  const parts = [`${summary.driftFailures} drift failure(s)`]
+  if (probed) {
+    parts.push(
+      `${summary.passed} passed`,
+      `${summary.warned} warned`,
+      `${summary.failed} failed`,
+      `${summary.errored} errored`,
+      `${summary.skipped} skipped`
+    )
+  }
+  return `Summary: ${parts.join(" · ")}`
+}
+
+/** Non-zero only for things that are actually wrong: drift failures, failed and
+ * errored probes. Warnings are drift the boundary has accumulated, which is
+ * information, not breakage. */
+export function exitCode(summary: RunSummary): number {
+  return summary.driftFailures + summary.failed + summary.errored > 0 ? 1 : 0
+}

--- a/packages/contract-harness/tests/probe.integration.test.ts
+++ b/packages/contract-harness/tests/probe.integration.test.ts
@@ -1,0 +1,355 @@
+/**
+ * End-to-end exercise of the runner against a real HTTP server.
+ *
+ * The server here is a stub, but the transport is not: these go over a socket,
+ * through `fetch`, and back. The point is to prove each detector fires on a
+ * concrete divergence, because a drift detector nobody has watched fail is just
+ * a green light with extra steps.
+ *
+ * Every case is a scenario that has actually happened to somebody: a field
+ * renamed on the server, a type widened, a route moved, a field the client
+ * still believes in that nothing sends any more.
+ */
+
+import { createServer, type Server } from "node:http"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { defineContract } from "../src/contract"
+import { probeContract } from "../src/probe"
+
+/** Routes the stub answers, keyed by `METHOD path`. */
+const ROUTES: Record<
+  string,
+  { status: number; body: string; contentType?: string }
+> = {
+  "GET /api/v1/mood_events": {
+    status: 200,
+    body: JSON.stringify([
+      {
+        id: 1,
+        index: 0,
+        week: 3,
+        label: "l",
+        description: "d",
+        team: "t",
+        category: "c",
+        delta: -2,
+        mood: 4,
+      },
+    ]),
+  },
+  "GET /api/v1/grown": {
+    status: 200,
+    body: JSON.stringify({ id: 1, added_later: "surprise" }),
+  },
+  "GET /api/v1/retyped": {
+    status: 200,
+    body: JSON.stringify({ id: "123", prompt: "p" }),
+  },
+  "GET /api/v1/renamed_field": {
+    status: 200,
+    body: JSON.stringify({ tabId: 7 }),
+  },
+  "GET /api/v1/not_json": {
+    status: 200,
+    body: "<html>nope</html>",
+    contentType: "text/html",
+  },
+  "GET /api/v1/empty": { status: 200, body: "[]" },
+  "GET /api/v1/tabs/42": {
+    status: 200,
+    body: JSON.stringify({ tab_id: 42, url: "u" }),
+  },
+}
+
+let server: Server
+let baseUrl: string
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const key = `${req.method ?? "GET"} ${req.url ?? ""}`
+    const route = ROUTES[key]
+    if (route === undefined) {
+      res.writeHead(404, { "content-type": "application/json" })
+      res.end(JSON.stringify({ error: "not found" }))
+      return
+    }
+    res.writeHead(route.status, {
+      "content-type": route.contentType ?? "application/json",
+    })
+    res.end(route.body)
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const address = server.address()
+  if (address === null || typeof address === "string") {
+    throw new Error("stub server did not bind a TCP port")
+  }
+  baseUrl = `http://127.0.0.1:${address.port}`
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+})
+
+const MoodEventSchema = z.object({
+  id: z.number(),
+  index: z.number(),
+  week: z.number(),
+  label: z.string(),
+  description: z.string(),
+  team: z.string(),
+  category: z.string(),
+  delta: z.number(),
+  mood: z.number(),
+  time: z.string().optional(),
+})
+
+const base = { module: "test", summary: "s" } as const
+
+describe("probeContract against a live server", () => {
+  it("warns on the real MoodEvent phantom field, and does not fail", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "mood_events.list",
+        method: "GET",
+        path: "/mood_events",
+        expect: { status: 200, schema: z.array(MoodEventSchema) },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.httpStatus).toBe(200)
+    expect(outcome.status).toBe("warned")
+    expect(outcome.findings.map((f) => f.code)).toContain("phantom-field")
+    expect(outcome.conformance?.valid).toBe(true)
+    expect(outcome.conformance?.phantomFields[0]?.path).toBe("[].time")
+  })
+
+  it("warns when the server grew a field the contract does not declare", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "grown",
+        method: "GET",
+        path: "/grown",
+        expect: { status: 200, schema: z.object({ id: z.number() }) },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("warned")
+    const finding = outcome.findings.find((f) => f.code === "unknown-field")
+    expect(finding?.detail).toContain("added_later")
+  })
+
+  it("fails on an undeclared field when the contract opts into strictness", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "grown.strict",
+        method: "GET",
+        path: "/grown",
+        expect: {
+          status: 200,
+          schema: z.object({ id: z.number() }),
+          unknownFields: "reject",
+        },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("failed")
+  })
+
+  it("fails when a field changes type — the case unit tests on both sides miss", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "retyped",
+        method: "GET",
+        path: "/retyped",
+        expect: {
+          status: 200,
+          schema: z.object({ id: z.number(), prompt: z.string() }),
+        },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("failed")
+    expect(outcome.findings.map((f) => f.code)).toContain("schema-violation")
+  })
+
+  it("shows a renamed field as a violation and an unknown key together", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "renamed",
+        method: "GET",
+        path: "/renamed_field",
+        expect: { status: 200, schema: z.object({ tab_id: z.number() }) },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("failed")
+    const codes = outcome.findings.map((f) => f.code)
+    expect(codes).toContain("schema-violation")
+    expect(codes).toContain("unknown-field")
+  })
+
+  it("fails when the route is gone", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "moved",
+        method: "GET",
+        path: "/route_that_moved",
+        expect: { status: 200, schema: z.object({}) },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("failed")
+    expect(outcome.findings[0]?.code).toBe("status-mismatch")
+    expect(outcome.findings[0]?.message).toContain("404")
+  })
+
+  it("fails when a JSON contract gets a non-JSON body", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "not_json",
+        method: "GET",
+        path: "/not_json",
+        expect: { status: 200, schema: z.object({}) },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("failed")
+    expect(outcome.findings.map((f) => f.code)).toContain("non-json-body")
+  })
+
+  it("says an empty collection proved nothing rather than reporting it clean", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "empty",
+        method: "GET",
+        path: "/empty",
+        expect: {
+          status: 200,
+          schema: z.array(z.object({ time: z.string().optional() })),
+        },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.findings.map((f) => f.code)).toContain("no-samples")
+  })
+
+  it("binds path parameters and reaches the parameterised route", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "tabs.get",
+        method: "GET",
+        path: "/tabs/:tab_id",
+        request: { path: { tab_id: 42 } },
+        expect: {
+          status: 200,
+          schema: z.object({ tab_id: z.number(), url: z.string() }),
+        },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.path).toBe("/api/v1/tabs/42")
+    expect(outcome.status).toBe("passed")
+  })
+
+  it("refuses to send a request with an unbound path parameter", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "tabs.unbound",
+        method: "GET",
+        path: "/tabs/:tab_id",
+        expect: { status: 200, schema: z.object({}) },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("failed")
+    expect(outcome.findings[0]?.code).toBe("unbound-path-param")
+    // Never left the process, so there is no status to report.
+    expect(outcome.httpStatus).toBeUndefined()
+  })
+
+  it("reports an unreachable server as a transport error, not a contract failure", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "offline",
+        method: "GET",
+        path: "/mood_events",
+        expect: { status: 200, schema: z.object({}) },
+      }),
+      // Port 1 is reserved and nothing listens there.
+      { baseUrl: "http://127.0.0.1:1", timeoutMs: 2000 }
+    )
+
+    expect(outcome.status).toBe("errored")
+    expect(outcome.findings[0]?.code).toBe("transport-error")
+  })
+
+  it("does not check a success schema against a 404 body", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "tolerant",
+        method: "GET",
+        path: "/tabs/:tab_id",
+        request: { path: { tab_id: 999 } },
+        expect: {
+          status: [200, 404],
+          schemaFor: 200,
+          schema: z.object({ tab_id: z.number() }),
+        },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.httpStatus).toBe(404)
+    expect(outcome.findings.map((f) => f.code)).not.toContain(
+      "schema-violation"
+    )
+    expect(outcome.findings.map((f) => f.code)).toContain(
+      "schema-not-applicable"
+    )
+  })
+
+  it("skips a contract that declares a skip reason", async () => {
+    const outcome = await probeContract(
+      defineContract({
+        ...base,
+        id: "skipped",
+        method: "GET",
+        path: "/mood_events",
+        skip: "needs seeded data",
+        expect: { status: 200 },
+      }),
+      { baseUrl }
+    )
+
+    expect(outcome.status).toBe("skipped")
+  })
+})

--- a/packages/contract-harness/tsconfig.json
+++ b/packages/contract-harness/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@some-ui/tsconfig/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true,
+    "types": ["node"],
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "contracts",
+    "tests",
+    "eslint.config.js",
+    "vitest.config.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/contract-harness/vitest.config.ts
+++ b/packages/contract-harness/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,6 +708,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.5
     devDependencies:
+      '@some-ui/eslint-kit':
+        specifier: workspace:*
+        version: link:../eslint
       '@some-ui/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -718,8 +721,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.5
-        version: 3.2.7(@types/node@26.0.1)(happy-dom@20.10.6)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(happy-dom@20.10.6)(jsdom@26.0.0)(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/core-utils:
     dependencies:
@@ -5546,22 +5549,8 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@3.2.7':
-    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
-
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
-
-  '@vitest/mocker@3.2.7':
-    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
 
   '@vitest/mocker@4.1.10':
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
@@ -5577,20 +5566,11 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@3.2.7':
-    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
-
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@3.2.7':
-    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
-
   '@vitest/runner@4.1.10':
     resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
-
-  '@vitest/snapshot@3.2.7':
-    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
   '@vitest/snapshot@4.1.10':
     resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
@@ -5598,17 +5578,11 @@ packages:
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@3.2.7':
-    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
-
   '@vitest/spy@4.1.10':
     resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
-
-  '@vitest/utils@3.2.7':
-    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
@@ -5981,10 +5955,6 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -6737,9 +6707,6 @@ packages:
   es-iterator-helpers@1.3.3:
     resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
@@ -7878,9 +7845,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.15.0:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
@@ -9334,9 +9298,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -9455,9 +9416,6 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -9599,10 +9557,6 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
-
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -9955,11 +9909,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-plugin-dts@5.0.3:
     resolution: {integrity: sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==}
     peerDependencies:
@@ -10065,34 +10014,6 @@ packages:
       tsx:
         optional: true
       yaml:
-        optional: true
-
-  vitest@3.2.7:
-    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.7
-      '@vitest/ui': 3.2.7
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/debug':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@4.1.10:
@@ -13890,14 +13811,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@3.2.7':
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.7
-      '@vitest/utils': 3.2.7
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
-
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -13906,14 +13819,6 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.7
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -13927,29 +13832,13 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@3.2.7':
-    dependencies:
-      tinyrainbow: 2.0.0
-
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.7':
-    dependencies:
-      '@vitest/utils': 3.2.7
-      pathe: 2.0.3
-      strip-literal: 3.1.0
-
   '@vitest/runner@4.1.10':
     dependencies:
       '@vitest/utils': 4.1.10
-      pathe: 2.0.3
-
-  '@vitest/snapshot@3.2.7':
-    dependencies:
-      '@vitest/pretty-format': 3.2.7
-      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.10':
@@ -13963,21 +13852,11 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/spy@3.2.7':
-    dependencies:
-      tinyspy: 4.0.4
-
   '@vitest/spy@4.1.10': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
-
-  '@vitest/utils@3.2.7':
-    dependencies:
-      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -14410,8 +14289,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
-
-  cac@6.7.14: {}
 
   cac@7.0.0: {}
 
@@ -15213,8 +15090,6 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
-
-  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.3.0: {}
 
@@ -16532,8 +16407,6 @@ snapshots:
   jose@5.9.6: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   js-yaml@3.15.0:
     dependencies:
@@ -18113,8 +17986,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
   std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -18287,10 +18158,6 @@ snapshots:
   strip-json-comments@5.0.1: {}
 
   strip-json-comments@5.0.3: {}
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
 
   stubborn-fs@2.0.0:
     dependencies:
@@ -18472,8 +18339,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-
-  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
@@ -18827,27 +18692,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vite-node@3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -18927,49 +18771,6 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
-
-  vitest@3.2.7(@types/node@26.0.1)(happy-dom@20.10.6)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 3.2.7
-      '@vitest/runner': 3.2.7
-      '@vitest/snapshot': 3.2.7
-      '@vitest/spy': 3.2.7
-      '@vitest/utils': 3.2.7
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.17
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 26.0.1
-      happy-dom: 20.10.6
-      jsdom: 26.0.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(happy-dom@20.10.6)(jsdom@26.0.0)(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,25 @@ importers:
         specifier: ^3.23.1
         version: 3.23.2
 
+  packages/contract-harness:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.0.5
+    devDependencies:
+      '@some-ui/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.7(@types/node@26.0.1)(happy-dom@20.10.6)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
   packages/core-utils:
     dependencies:
       clsx:
@@ -5527,8 +5546,22 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.10':
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
@@ -5544,11 +5577,20 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
   '@vitest/runner@4.1.10':
     resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
   '@vitest/snapshot@4.1.10':
     resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
@@ -5556,11 +5598,17 @@ packages:
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
   '@vitest/spy@4.1.10':
     resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
@@ -5933,6 +5981,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -6685,6 +6737,9 @@ packages:
   es-iterator-helpers@1.3.3:
     resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
@@ -7823,6 +7878,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.15.0:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
@@ -9276,6 +9334,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -9394,6 +9455,9 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -9535,6 +9599,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -9887,6 +9955,11 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-plugin-dts@5.0.3:
     resolution: {integrity: sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==}
     peerDependencies:
@@ -9992,6 +10065,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.1.10:
@@ -13789,6 +13890,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -13797,6 +13906,14 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -13810,13 +13927,29 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.1.10':
     dependencies:
       '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.10':
@@ -13830,11 +13963,21 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.10': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -14267,6 +14410,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  cac@6.7.14: {}
 
   cac@7.0.0: {}
 
@@ -15068,6 +15213,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.3.0: {}
 
@@ -16385,6 +16532,8 @@ snapshots:
   jose@5.9.6: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.15.0:
     dependencies:
@@ -17964,6 +18113,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  std-env@3.10.0: {}
+
   std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -18136,6 +18287,10 @@ snapshots:
   strip-json-comments@5.0.1: {}
 
   strip-json-comments@5.0.3: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   stubborn-fs@2.0.0:
     dependencies:
@@ -18317,6 +18472,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
@@ -18670,6 +18827,27 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vite-node@3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -18749,6 +18927,49 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
+
+  vitest@3.2.7(@types/node@26.0.1)(happy-dom@20.10.6)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.3(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.0.1
+      happy-dom: 20.10.6
+      jsdom: 26.0.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(happy-dom@20.10.6)(jsdom@26.0.0)(vite@8.1.5(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Description

Introduces `@some-ui/contract-harness`, a new package that provides an oracle for the client/server boundary. This tool allows developers to verify that client expectations match actual server behavior without manual testing.

The harness performs two layers of validation:

1. **Route Drift** - Compares contracts against the server's route inventory (no server needed)
2. **Conformance** - Sends real requests to a running server and validates responses, detecting:
   - Unknown fields the server sends that the contract doesn't declare
   - Phantom fields the contract declares as optional but the server never sends

This addresses a real gap in integration testing: standard schema validation misses both of these divergence patterns, allowing silent drift between client and server expectations.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## What's Included

- **Core modules:**
  - `contract.ts` - Vocabulary for declaring boundary handshakes
  - `conformance.ts` - Response validation with unknown/phantom field detection
  - `probe.ts` - Executes contracts against a running server
  - `drift.ts` - Compares contracts against server route inventory
  - `cli.ts` - Command-line interface for running the full suite
  - `report.ts` - Human-readable terminal output

- **Contract definitions:**
  - `health.contract.ts` - Health check endpoint
  - `mood-events.contract.ts` - Mood event API endpoints
  - `tabs.contract.ts` - Tab capture handshakes

- **Tests:**
  - Unit tests for conformance detection, drift checking, and path binding
  - Integration tests against a live HTTP stub server covering real failure scenarios

- **Configuration:**
  - `routes.server.json` - Server route inventory snapshot
  - TypeScript, ESLint, and Vitest configuration

- **Documentation:**
  - Comprehensive README explaining the workflow and usage

## How to Use

```sh
# Run both drift and conformance checks
pnpm contract

# Drift only (no server needed)
pnpm contract --drift-only

# Against a specific server
pnpm contract --base-url http://localhost:3000

# Include mutating contracts
pnpm contract --include-mutations

# Show uncovered routes
pnpm contract --show-uncovered
```

## Test Plan

- Unit tests pass for conformance detection, drift checking, and contract utilities
- Integration tests verify the harness correctly identifies real divergence scenarios:
  - Field renames (shows as both unknown and phantom)
  - Type changes (schema violations)
  - Server field growth (unknown fields)
  - Optional fields never sent (phantom fields)
  - Non-JSON responses
  - Missing routes
- CLI argument parsing and report generation tested

https://claude.ai/code/session_01FRA1DBALHzfo5tZL9ipoaw