### PR TITLE
Fix warm-up test timeout handling and test duration

### DIFF
--- a/packages/ui/leetype/src/components/typing-game/leetype/index.test.tsx
+++ b/packages/ui/leetype/src/components/typing-game/leetype/index.test.tsx
@@ -338,12 +338,9 @@ describe("the warm-up", () => {
     expect(passageLength).toBeGreaterThan(0)
 
     typeStep(input, passageLength)
-    await waitFor(
-      () => screen.findByText("Step 0."),
-      { timeout: 10000 } // Increase timeout for warm-up completion
-    )
+    await screen.findByText("Step 0.", {}, { timeout: 10000 })
     expect(screen.queryByText(/Warm up/i)).not.toBeInTheDocument()
-  })
+  }, 15000)
 
   it("is skipped entirely once a baseline is stored", async () => {
     seedBaseline()


### PR DESCRIPTION
## Description

This PR fixes the warm-up test in the typing game component by correcting the timeout configuration and extending the test timeout duration.

### Changes Made

1. **Fixed `findByText` timeout syntax**: Changed from `waitFor` with timeout option to the correct `findByText` API signature with timeout parameter
2. **Extended test timeout**: Increased the test timeout from the default to 15000ms to allow sufficient time for warm-up completion

The previous code was using an incorrect `waitFor` pattern that didn't properly apply the timeout. The corrected approach uses `screen.findByText` directly with the timeout option, which is the proper Testing Library API.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

The warm-up test now properly waits for completion with adequate timeout. Existing unit tests pass with these corrections.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes

https://claude.ai/code/session_01V19Qpa6DhFX6okSnuZLBRb