### PR TITLE
fix(www): pin Docker build's pnpm to the packageManager version

### DIFF
--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -9,9 +9,10 @@ FROM node:24-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="${PNPM_HOME}:${PATH}"
 
-RUN npm install -g pnpm turbo
-
 WORKDIR /app
+
+COPY package.json ./package.json
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1]")" turbo
 
 # ------------------------------------------------------------
 # Stage 1: Prune workspace


### PR DESCRIPTION
## Description

The `apps/www` Docker build was failing at the `pnpm install --frozen-lockfile` step in the `deps` stage:

```
[ERROR] Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it is missing from pnpm-lock.yaml.
```

`RUN npm install -g pnpm turbo` was always fetching the latest npm-published pnpm (11.20.0 at the time of the failing run), while `package.json` pins `"packageManager": "pnpm@10.11.1"`. pnpm 11 added a self-verification step that expects `@pnpm/exe.*` lockfile entries the pnpm-10-generated lockfile doesn't have, so the frozen-lockfile install failed.

The fix installs the exact pnpm version declared in `packageManager` instead of whatever is latest on npm, keeping the Docker build's pnpm in sync with the lockfile it was generated with.

Failing run: https://github.com/paulgsc/some-ui/actions/runs/31237204476/job/93051954469

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes (no docker daemon available in this sandbox to build-verify; change is a one-line version pin)

## Screenshots

N/A — build-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DAFDhRc6R4SY2addEhrpE8)_