### PR TITLE
[INTENT-KIT] Sealed intent typestate — union, error vocabulary, React binding, presentation policy

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -35,6 +35,7 @@
     "@some-ui/content-registry": "workspace:*",
     "@some-ui/fetch-kit": "workspace:*",
     "@some-ui/honeycomb": "workspace:*",
+    "@some-ui/intent-kit": "workspace:*",
     "@some-ui/shared": "workspace:*",
     "@some-ui/slideshow": "workspace:*",
     "@some-ui/speech": "workspace:*",

--- a/apps/www/src/lib/intent/__type-fixtures__/ambient-still-exhaustive.fixtures.ts
+++ b/apps/www/src/lib/intent/__type-fixtures__/ambient-still-exhaustive.fixtures.ts
@@ -1,0 +1,59 @@
+/**
+ * #944/S4's own acceptance criterion: "An ambient intent still requires all
+ * four arms. Verified by a fixture, because this is the property most
+ * likely to be 'simplified away' by a future reader who reasonably
+ * concludes that ambient means optional."
+ *
+ * There is nothing presentation-specific in `matchIntent`'s signature -
+ * `presentation` lives alongside `state` on `UseIntentResult`, never inside
+ * `Intent` itself (see `use-intent.ts`), so there is no way for it to relax
+ * the eliminator. This file proves that by construction rather than by
+ * assertion: the same missing-arm `@ts-expect-error` that
+ * `@some-ui/intent-kit`'s own fixtures exercise, repeated here against an
+ * intent explicitly obtained through an `ambient`-presentation `useIntent`
+ * call.
+ *
+ * Not a `*.test.ts` - part of the ordinary `tsc --noEmit` run, not vitest;
+ * see `@some-ui/intent-kit`'s own fixture file for the same convention and
+ * why "unused '@ts-expect-error' directive" is the actual enforcement
+ * mechanism.
+ */
+
+import { matchIntent } from "@some-ui/intent-kit"
+
+import type { UseIntentResult } from "../use-intent"
+
+// A type-only stand-in for what `useIntent(mutation, { presentation:
+// "ambient" })` returns - calling the real hook is unavailable here (it is
+// a React Hook, and this file is not a component or a custom hook), and
+// the type is all this fixture needs: proof that `ambientIntent.state`'s
+// shape is exactly `Intent<T>`, with no presentation-conditional relaxation
+// of `matchIntent`'s required arms.
+declare const ambientIntent: UseIntentResult<string, string> & {
+  readonly presentation: "ambient"
+}
+
+// Missing the `failed` arm - still a compile error for an ambient-presentation
+// intent, exactly as it is for an interactive one. "Ambient" describes what
+// the arm is allowed to *render*, never whether it has to exist.
+// @ts-expect-error - missing the required `failed` arm, ambient or not
+const missingArm = matchIntent(ambientIntent.state, {
+  idle: () => null,
+  working: () => null,
+  succeeded: () => null,
+})
+void missingArm
+
+// Sanity: a deliberately-quiet `failed` arm (`() => null`) is fine - the
+// content is the author's choice, only the arm's presence is not.
+const wellFormedQuiet = matchIntent(ambientIntent.state, {
+  idle: () => null,
+  working: () => null,
+  succeeded: () => null,
+  // A real ambient renderer would still decide something here (log it, set
+  // a status flag) - `null` stands in for "renders nothing visually",
+  // which is a legitimate ambient choice per presentation.ts's policy,
+  // distinct from not handling the arm at all.
+  failed: () => null,
+})
+void wellFormedQuiet

--- a/apps/www/src/lib/intent/compose.test.tsx
+++ b/apps/www/src/lib/intent/compose.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The #933 flow itself: create a session, then activate it. Proves #943's
+ * acceptance criterion directly - a failure in the second step never
+ * reverts or re-triggers the first, and retrying only re-runs the step that
+ * actually failed.
+ */
+
+import type { JSX, ReactNode } from "react"
+import { matchIntent } from "@some-ui/intent-kit"
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+} from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { composeSequentialIntents } from "./compose"
+import { useIntent } from "./use-intent"
+import { useIntentEffect } from "./use-intent-effect"
+
+function withQueryClient(): {
+  wrapper: (props: { children: ReactNode }) => JSX.Element
+} {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  return {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  }
+}
+
+function summarize(state: ReturnType<typeof composeSequentialIntents>): string {
+  return matchIntent(state, {
+    idle: () => "idle",
+    working: (step) => `working:${step ?? "?"}`,
+    succeeded: (value) => `succeeded:${JSON.stringify(value)}`,
+    failed: (error) => `failed:${error.kind}`,
+  })
+}
+
+function useSaveAndPlayChain(
+  createFn: (name: string) => Promise<string>,
+  activateFn: (sessionId: string) => Promise<string>
+): {
+  start: (name: string) => void
+  retryComposite: () => void
+  composite: ReturnType<typeof composeSequentialIntents>
+} {
+  const create = useIntent(useMutation({ mutationFn: createFn }), {
+    presentation: "interactive",
+  })
+  const activate = useIntent(useMutation({ mutationFn: activateFn }), {
+    presentation: "interactive",
+  })
+  // The chain: activate starts automatically once create succeeds - the
+  // shape session-composer.tsx's onSuccess-nested-in-onSuccess produces
+  // today, expressed through useIntentEffect instead of a render-phase
+  // side effect (see that module's header for why the difference matters).
+  useIntentEffect(create.state, (createdSessionId) => {
+    activate.start(createdSessionId)
+  })
+
+  const composite = composeSequentialIntents(create.state, activate.state, {
+    first: "create",
+    second: "activate",
+  })
+
+  const retryComposite = (): void => {
+    matchIntent(composite, {
+      idle: () => undefined,
+      working: () => undefined,
+      succeeded: () => undefined,
+      failed: (_error, retry) => retry(),
+    })
+  }
+
+  return { start: create.start, retryComposite, composite }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("composeSequentialIntents (the Save & Play chain)", () => {
+  it("create-succeeded-then-activate-failed does not revert or re-run create, and retry only re-runs activate", async () => {
+    const { wrapper } = withQueryClient()
+    // eslint-disable-next-line @typescript-eslint/require-await -- mutationFn's contract is Promise<T>; async is the plainest way to satisfy it for a stub with nothing to actually await.
+    const createFn = vi.fn(async (name: string) => `session:${name}`)
+    let rejectActivate = true
+    // eslint-disable-next-line @typescript-eslint/require-await -- see createFn above
+    const activateFn = vi.fn(async (sessionId: string) => {
+      if (rejectActivate) throw new Error("activate failed")
+      return `active:${sessionId}`
+    })
+
+    const { result } = renderHook(
+      () => useSaveAndPlayChain(createFn, activateFn),
+      { wrapper }
+    )
+
+    expect(summarize(result.current.composite)).toBe("idle")
+
+    act(() => {
+      result.current.start("my-session")
+    })
+
+    // Working, through both steps, then failed - on activate's error, not
+    // create's, because create genuinely succeeded.
+    await waitFor(() => {
+      expect(summarize(result.current.composite)).toBe("failed:unknown")
+    })
+
+    expect(createFn.mock.calls).toHaveLength(1)
+    expect(createFn.mock.calls[0]?.[0]).toBe("my-session")
+    expect(activateFn.mock.calls).toHaveLength(1)
+    expect(activateFn.mock.calls[0]?.[0]).toBe("session:my-session")
+
+    // Retry: activate is allowed to succeed this time.
+    rejectActivate = false
+    act(() => {
+      result.current.retryComposite()
+    })
+
+    await waitFor(() => {
+      expect(summarize(result.current.composite)).toBe(
+        'succeeded:"active:session:my-session"'
+      )
+    })
+
+    // The whole point: create was never called again (no duplicate
+    // session), and activate was called exactly twice - the original
+    // failure and the retry, both for the same session id create already
+    // produced.
+    expect(createFn.mock.calls).toHaveLength(1)
+    expect(activateFn.mock.calls).toHaveLength(2)
+    expect(activateFn.mock.calls[1]?.[0]).toBe("session:my-session")
+  })
+})

--- a/apps/www/src/lib/intent/compose.ts
+++ b/apps/www/src/lib/intent/compose.ts
@@ -1,0 +1,64 @@
+/**
+ * Two `useIntent`s, sequenced into one composite intent - the shape
+ * `session-composer.tsx:241`'s "Save & Play" needs (`createSession` then
+ * `updateSession`, one gesture, two round-trips), per #943/S3's acceptance
+ * criterion: "The chain shape handles create-succeeded-then-start-failed
+ * without reverting the created session and without a retry producing a
+ * duplicate."
+ *
+ * This works *because* `working`'s `step` field exists (see
+ * `@some-ui/intent-kit`'s `intent.ts`) rather than because of anything new:
+ * composing is just `matchIntent` nested inside `matchIntent`. No new union
+ * member, no new state - #943's own recommendation, proven here rather than
+ * only asserted.
+ *
+ * The critical property this buys: once the first intent has `succeeded`,
+ * this function never looks at it again. A failure in the second stays a
+ * failure of *only* the second - its `retry` closure is the second
+ * mutation's own, so retrying re-runs only that step. The first result
+ * (already created) is never reverted and never re-created, because nothing
+ * here has a way to re-trigger the first intent once composition has moved
+ * past it.
+ */
+
+import type { Intent } from "@some-ui/intent-kit"
+import {
+  failed,
+  idle,
+  matchIntent,
+  succeeded,
+  working,
+} from "@some-ui/intent-kit"
+
+export type SequentialSteps<TStep extends string> = {
+  /** Shown while the first intent is in flight. */
+  readonly first: TStep
+  /** Shown once the first has succeeded and the second is either not yet
+   * started or in flight - "saved, starting..." rather than a state with no
+   * label. */
+  readonly second: TStep
+}
+
+export function composeSequentialIntents<TFirst, TSecond, TStep extends string>(
+  first: Intent<TFirst>,
+  second: Intent<TSecond>,
+  steps: SequentialSteps<TStep>
+): Intent<TSecond, TStep> {
+  return matchIntent<TFirst, Intent<TSecond, TStep>>(first, {
+    idle: () => idle(),
+    working: () => working(steps.first),
+    failed: (error, retry) => failed(error, retry),
+    succeeded: () =>
+      matchIntent<TSecond, Intent<TSecond, TStep>>(second, {
+        // The first has already succeeded; the second hasn't been asked to
+        // run yet (a caller triggers it from the first's own succeeded arm,
+        // typically via useIntentEffect). Still "working" from the
+        // composite's point of view - there is no user-facing distinction
+        // between "about to start step two" and "running step two".
+        idle: () => working(steps.second),
+        working: () => working(steps.second),
+        succeeded: (value) => succeeded(value),
+        failed: (error, retry) => failed(error, retry),
+      }),
+  })
+}

--- a/apps/www/src/lib/intent/errors.test.ts
+++ b/apps/www/src/lib/intent/errors.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { FileHostUnreachableError } from "@/lib/file-host-config"
+import {
+  FileHostNotConfiguredError,
+  FileHostResponseError,
+} from "@/lib/file-host-config/client"
+
+import { mapFileHostError } from "./errors"
+
+describe("mapFileHostError", () => {
+  // #942's acceptance criterion: every error class reachable from apps/www's
+  // write paths maps to exactly one kind, enumerated here rather than
+  // asserted in prose.
+  it.each([
+    [
+      "FileHostUnreachableError",
+      new FileHostUnreachableError(
+        "/sessions",
+        new TypeError("Failed to fetch")
+      ),
+      "unreachable",
+      true,
+    ],
+    [
+      "FileHostNotConfiguredError",
+      new FileHostNotConfiguredError("/push/vapid-key"),
+      "unavailable",
+      false,
+    ],
+    [
+      "FileHostResponseError (5xx)",
+      new FileHostResponseError(500, "/sessions", "internal_error"),
+      "rejected",
+      true,
+    ],
+    [
+      "FileHostResponseError (4xx)",
+      new FileHostResponseError(404, "/sessions/abc", "not_found"),
+      "rejected",
+      false,
+    ],
+  ] as const)(
+    "%s -> kind %s, retryable %s",
+    (_label, error, kind, retryable) => {
+      const result = mapFileHostError(error)
+      expect(result.kind).toBe(kind)
+      expect(result.retryable).toBe(retryable)
+      expect(result.cause).toBe(error)
+      expect(result.summary.length).toBeGreaterThan(0)
+    }
+  )
+
+  it("falls back to intent-kit's generic normalizer for anything else, rather than throwing", () => {
+    const inputs: ReadonlyArray<unknown> = [
+      new Error("some unrelated failure"),
+      new TypeError("Failed to fetch"),
+      undefined,
+      "a bare string",
+      { not: "an error at all" },
+    ]
+
+    for (const input of inputs) {
+      expect(() => mapFileHostError(input)).not.toThrow()
+      const result = mapFileHostError(input)
+      expect(result.kind).toBe("unknown")
+      expect(result.retryable).toBe(true)
+    }
+  })
+
+  it("retains file_host's own error code on cause for a developer, without putting it in summary", () => {
+    const error = new FileHostResponseError(500, "/sessions", "internal_error")
+    const result = mapFileHostError(error)
+
+    expect(result.cause).toBe(error)
+    // `cause` is `unknown` by design (see intent-kit's IntentError) - `error`
+    // itself, still in scope, is the typed handle; asserting through it
+    // avoids narrowing `result.cause` back down with a type assertion.
+    expect(error.code).toBe("internal_error")
+    expect(result.summary).not.toMatch(/internal_error/)
+  })
+})

--- a/apps/www/src/lib/intent/errors.ts
+++ b/apps/www/src/lib/intent/errors.ts
@@ -1,0 +1,106 @@
+/**
+ * The one place `apps/www` turns a `file_host` failure into what a person
+ * needs to hear. `@some-ui/intent-kit` must not know `file_host` exists —
+ * see that package's own `intent-error.ts` header — so this module owns the
+ * mapping from the three `FileHost*Error` classes
+ * (`lib/file-host-config/{index,client}.ts`) to `IntentError`.
+ *
+ * ## Who authors `summary`
+ *
+ * The normalizer supplies a default per `kind`, written for the general
+ * case ("the study server isn't answering"). A call site with sharper
+ * context can override it — `IntentError` is a plain readonly object, so
+ * `{ ...mapFileHostError(error), summary: "Couldn't start the session" }`
+ * is the whole mechanism; no separate override parameter exists because
+ * none is needed. Precise, call-site copy beats generic normalizer copy
+ * when it's available; the normalizer default exists so the other sixteen
+ * sites that don't bother to write their own don't invent sixteen
+ * different phrasings of the same failure.
+ *
+ * ## `unauthorized` is absent
+ *
+ * `file_host` has no auth layer today. Per #942/#935's own recommendation,
+ * an error kind with no producer is dropped rather than kept as a
+ * placeholder — a `kind` a `matchIntent`-style caller must handle but can
+ * never actually receive teaches that arms are decorative. Add it back the
+ * day `file_host` grows an auth layer that can produce one.
+ */
+
+import type { IntentError } from "@some-ui/intent-kit"
+import { toIntentError as toGenericIntentError } from "@some-ui/intent-kit"
+
+import { FileHostUnreachableError } from "../file-host-config"
+import {
+  FileHostNotConfiguredError,
+  FileHostResponseError,
+} from "../file-host-config/client"
+
+/** A non-2xx in the 5xx range is the server's own admission that the
+ * request was fine and it failed anyway - the same request could succeed
+ * on a retry. A 4xx says the request itself was the problem; retrying an
+ * unchanged request against an unchanged server doesn't fix that. */
+function isRetryableStatus(status: number): boolean {
+  return status >= 500
+}
+
+/**
+ * `FileHostUnreachableError` → `apps/www`'s own attempt at this request
+ * never reached a server at all (dead LAN box, mixed content, a proxy with
+ * nothing behind it). The transport itself said nothing yet, so retrying is
+ * the correct default.
+ */
+function fromUnreachable(error: FileHostUnreachableError): IntentError {
+  return {
+    kind: "unreachable",
+    retryable: true,
+    summary:
+      "The study server isn't answering. Check your connection and try again.",
+    cause: error,
+  }
+}
+
+/**
+ * `FileHostNotConfiguredError` → this deployment has no such feature and
+ * never will without reconfiguration (`client.ts`'s own doc comment: "this
+ * server will never answer this, stop asking and fall back"). A retry
+ * button on this is a button that cannot work.
+ */
+function fromNotConfigured(error: FileHostNotConfiguredError): IntentError {
+  return {
+    kind: "unavailable",
+    retryable: false,
+    summary: "This feature isn't available on this deployment.",
+    cause: error,
+  }
+}
+
+/**
+ * `FileHostResponseError` → a real answer, with a real reason. `file_host`'s
+ * own error code rides along on `cause` for a developer; a person gets the
+ * status-derived summary because `error.code` values (`not_found`,
+ * `internal_error`, …) are not written for a human to read cold.
+ */
+function fromResponseError(error: FileHostResponseError): IntentError {
+  return {
+    kind: "rejected",
+    retryable: isRetryableStatus(error.status),
+    summary: isRetryableStatus(error.status)
+      ? "The study server had a problem on its end. Try again in a moment."
+      : "That request couldn't be completed.",
+    cause: error,
+  }
+}
+
+/**
+ * Total, never throws - the failure path is not where a normalizer is
+ * allowed to fail. Anything that isn't one of the three known `FileHost*Error`
+ * classes falls back to `@some-ui/intent-kit`'s generic `toIntentError`,
+ * which lands on `kind: "unknown"`, `retryable: true`.
+ */
+export function mapFileHostError(error: unknown): IntentError {
+  if (error instanceof FileHostUnreachableError) return fromUnreachable(error)
+  if (error instanceof FileHostNotConfiguredError)
+    return fromNotConfigured(error)
+  if (error instanceof FileHostResponseError) return fromResponseError(error)
+  return toGenericIntentError(error)
+}

--- a/apps/www/src/lib/intent/presentation.test.ts
+++ b/apps/www/src/lib/intent/presentation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import { presentationPolicyFor } from "./presentation"
+
+describe("presentationPolicyFor", () => {
+  it("interactive: may interrupt, requires a visible retry, never silent", () => {
+    const policy = presentationPolicyFor("interactive")
+    expect(policy.mayInterruptOnFailure).toBe(true)
+    expect(policy.requiresVisibleRetryAffordance).toBe(true)
+    expect(policy.failureMayBeSilent).toBe(false)
+    expect(policy.failureMustSurviveNavigation).toBe(false)
+  })
+
+  it("ambient: never interrupts, no forced retry affordance, never silent", () => {
+    const policy = presentationPolicyFor("ambient")
+    expect(policy.mayInterruptOnFailure).toBe(false)
+    expect(policy.requiresVisibleRetryAffordance).toBe(false)
+    expect(policy.failureMayBeSilent).toBe(false)
+    expect(policy.failureMustSurviveNavigation).toBe(false)
+  })
+
+  it("ambient-durable: never interrupts, but a failure must survive navigation - the autosave verdict", () => {
+    const policy = presentationPolicyFor("ambient-durable")
+    expect(policy.mayInterruptOnFailure).toBe(false)
+    expect(policy.failureMayBeSilent).toBe(false)
+    expect(policy.failureMustSurviveNavigation).toBe(true)
+  })
+
+  it("failureMayBeSilent is false for every mode - not a per-mode choice", () => {
+    const modes = ["interactive", "ambient", "ambient-durable"] as const
+    for (const mode of modes) {
+      expect(presentationPolicyFor(mode).failureMayBeSilent).toBe(false)
+    }
+  })
+
+  it("only ambient-durable requires a failure to survive navigation", () => {
+    expect(
+      presentationPolicyFor("interactive").failureMustSurviveNavigation
+    ).toBe(false)
+    expect(presentationPolicyFor("ambient").failureMustSurviveNavigation).toBe(
+      false
+    )
+    expect(
+      presentationPolicyFor("ambient-durable").failureMustSurviveNavigation
+    ).toBe(true)
+  })
+})

--- a/apps/www/src/lib/intent/presentation.ts
+++ b/apps/www/src/lib/intent/presentation.ts
@@ -1,0 +1,122 @@
+/**
+ * #944/S4: what each presentation mode *permits*. `@some-ui/intent-kit`
+ * gains at most the `IntentPresentation` enum itself - everything about
+ * what a mode allows a renderer to do lives here, in `apps/www`, because it
+ * has an opinion about toasts and status surfaces that the shared package
+ * must not have.
+ *
+ * ## The rule this whole story exists to state
+ *
+ * The exhaustive match is **always** required, in every mode. An ambient
+ * intent still has four arms to fill in - what differs is the *content*
+ * those arms are allowed to render, not whether they exist. `working: () =>
+ * null` written deliberately, for an ambient intent, is a decision on the
+ * record; a missing arm is not possible at all, by construction (see
+ * `__type-fixtures__/ambient-still-exhaustive.fixtures.ts`). The trap named
+ * in #944's own issue body: "ambient intents may render nothing" and
+ * "intents may be silent" read as the same sentence, and #933's whole
+ * thesis is that the second is forbidden. `failureMayBeSilent` below is
+ * `false` in every mode for exactly this reason - it is not a per-mode
+ * choice.
+ *
+ * ## Ambient surface: a status affordance, not a toast
+ *
+ * `apps/www` already has an editorial position on this, stated in two
+ * places independently before this story existed:
+ * `components/audio/audio-activity-notice.tsx`'s header ("Inline rather
+ * than a toast, because a toast that teaches a feature is a toast that
+ * gets missed") and `providers/tts.tsx`'s ("A toast on initial mount
+ * is..."). The same reasoning applies to ambient failures: a transient
+ * toast for something the person never asked for and may not be looking at
+ * is a toast they can miss entirely, with no way to check later whether it
+ * fired. The recommendation is a persistent, low-prominence status
+ * surface (a dot, a small inline note near the feature) that stays until
+ * acknowledged or resolved, rather than `sonner`'s existing toast queue
+ * (mounted once in `providers/index.tsx`, and exactly right for
+ * `interactive` failures, which *are* something the person is waiting on).
+ * Building that surface is not this story - see the epic's non-goals - this
+ * is the recommendation the surface should follow when #936 builds it.
+ *
+ * ## Advisory, not enforced
+ *
+ * `useIntent`'s `presentation` option is read by whatever renders `state`;
+ * nothing in the type system stops an `interactive`-shaped renderer from
+ * receiving an `ambient` intent. Enforcing that would mean encoding "this
+ * component may only render ambient intents" in the type system - a real
+ * investment, and one this app's single-renderer-population doesn't yet
+ * justify (the same Doctrine reasoning `@some-ui/intent-kit`'s own
+ * package-shape test exists to keep honest). If #936 finds the advisory
+ * version actually leaking - an interactive failure rendered as a quiet
+ * status dot nobody notices - that is the signal to revisit this decision,
+ * not a reason to have preempted it here.
+ *
+ * ## The autosave verdict
+ *
+ * #934's census found one producer a two-way split can't express honestly:
+ * the debounced layout autosave. Not interactive (the person didn't ask for
+ * it, so interrupting is wrong) and not safely `ambient` either (a silent
+ * failure loses arrangement work they just authored, which plain `ambient`
+ * permits). `"ambient-durable"` (defined in `@some-ui/intent-kit`) is the
+ * third value: progress may still be quiet
+ * (`mayInterruptOnFailure: false`), but the failure has to survive the
+ * person navigating away - `failureMustSurviveNavigation: true` is this
+ * policy's answer, and is true for no other mode.
+ */
+
+import type { IntentPresentation } from "@some-ui/intent-kit"
+
+export type PresentationPolicy = {
+  /** May a `failed` arm interrupt the person (a modal, a toast that steals
+   * focus), or must it resolve to something passive and glanceable? */
+  readonly mayInterruptOnFailure: boolean
+  /** Must a `retryable` failure show a retry control at or near the
+   * control that started the intent? Never required for a mode that may
+   * not interrupt in the first place - there is no "near the control" for
+   * an intent nobody clicked. */
+  readonly requiresVisibleRetryAffordance: boolean
+  /** Always `false`. Not a per-mode choice - see this module's header. A
+   * `failed` arm may render quietly; it may never render nothing. */
+  readonly failureMayBeSilent: false
+  /** Must a failure be recorded somewhere that survives the person
+   * navigating away from whatever triggered it? True only for
+   * `ambient-durable` - see the autosave verdict above. */
+  readonly failureMustSurviveNavigation: boolean
+}
+
+function assertNever(_mode: never): never {
+  throw new Error("unhandled IntentPresentation")
+}
+
+export function presentationPolicyFor(
+  mode: IntentPresentation
+): PresentationPolicy {
+  switch (mode) {
+    case "interactive": {
+      return {
+        mayInterruptOnFailure: true,
+        requiresVisibleRetryAffordance: true,
+        failureMayBeSilent: false,
+        failureMustSurviveNavigation: false,
+      }
+    }
+    case "ambient": {
+      return {
+        mayInterruptOnFailure: false,
+        requiresVisibleRetryAffordance: false,
+        failureMayBeSilent: false,
+        failureMustSurviveNavigation: false,
+      }
+    }
+    case "ambient-durable": {
+      return {
+        mayInterruptOnFailure: false,
+        requiresVisibleRetryAffordance: false,
+        failureMayBeSilent: false,
+        failureMustSurviveNavigation: true,
+      }
+    }
+    default: {
+      return assertNever(mode)
+    }
+  }
+}

--- a/apps/www/src/lib/intent/use-intent-effect.test.tsx
+++ b/apps/www/src/lib/intent/use-intent-effect.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { JSX, ReactNode } from "react"
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+} from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useIntent } from "./use-intent"
+import { useIntentEffect } from "./use-intent-effect"
+
+function withQueryClient(): {
+  wrapper: (props: { children: ReactNode }) => JSX.Element
+} {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  return {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useIntentEffect", () => {
+  it("fires once when the intent transitions to succeeded, and #933's own navigate-on-success shape works", async () => {
+    const { wrapper } = withQueryClient()
+    const onSucceeded = vi.fn()
+    // eslint-disable-next-line @typescript-eslint/require-await -- mutationFn's contract is Promise<T>; async is the plainest way to satisfy it for a stub with nothing to actually await.
+    const mutationFn = vi.fn(async (input: string) => `created:${input}`)
+
+    const { result, rerender } = renderHook(
+      () => {
+        const intent = useIntent(useMutation({ mutationFn }), {
+          presentation: "interactive",
+        })
+        useIntentEffect(intent.state, onSucceeded)
+        return intent
+      },
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.start("session-a")
+    })
+
+    await waitFor(() => {
+      expect(onSucceeded).toHaveBeenCalledTimes(1)
+    })
+    expect(onSucceeded).toHaveBeenCalledWith("created:session-a")
+
+    // Re-rendering while still succeeded (the parent component re-rendering
+    // for an unrelated reason, say) must not re-fire the effect - this is
+    // the whole point of comparing the carried value rather than the
+    // Intent's own object identity, which is fresh every render.
+    rerender()
+    rerender()
+    expect(onSucceeded).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire for idle, working, or failed", async () => {
+    const { wrapper } = withQueryClient()
+    const onSucceeded = vi.fn()
+    const mutationFn = vi
+      .fn<(input: string) => Promise<string>>()
+      .mockRejectedValue(new Error("boom"))
+
+    const { result } = renderHook(
+      () => {
+        const intent = useIntent(useMutation({ mutationFn }), {
+          presentation: "interactive",
+        })
+        useIntentEffect(intent.state, onSucceeded)
+        return intent
+      },
+      { wrapper }
+    )
+
+    // idle
+    expect(onSucceeded).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.start("session-a")
+    })
+    // working, briefly, then failed
+    await waitFor(() => {
+      expect(mutationFn).toHaveBeenCalled()
+    })
+
+    expect(onSucceeded).not.toHaveBeenCalled()
+  })
+
+  it("fires again for a genuinely new success after a prior one", async () => {
+    const { wrapper } = withQueryClient()
+    const onSucceeded = vi.fn()
+    // eslint-disable-next-line @typescript-eslint/require-await -- mutationFn's contract is Promise<T>; async is the plainest way to satisfy it for a stub with nothing to actually await.
+    const mutationFn = vi.fn(async (input: string) => `created:${input}`)
+
+    const { result } = renderHook(
+      () => {
+        const intent = useIntent(useMutation({ mutationFn }), {
+          presentation: "interactive",
+        })
+        useIntentEffect(intent.state, onSucceeded)
+        return intent
+      },
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.start("first")
+    })
+    await waitFor(() => {
+      expect(onSucceeded).toHaveBeenCalledTimes(1)
+    })
+
+    act(() => {
+      result.current.reset()
+    })
+    act(() => {
+      result.current.start("second")
+    })
+
+    await waitFor(() => {
+      expect(onSucceeded).toHaveBeenCalledTimes(2)
+    })
+    expect(onSucceeded).toHaveBeenNthCalledWith(1, "created:first")
+    expect(onSucceeded).toHaveBeenNthCalledWith(2, "created:second")
+  })
+})

--- a/apps/www/src/lib/intent/use-intent-effect.ts
+++ b/apps/www/src/lib/intent/use-intent-effect.ts
@@ -1,0 +1,62 @@
+/**
+ * The navigate-on-success shape #943/S3 asks for explicitly: `void
+ * navigate(...)` inside a render-phase `succeeded` arm of `matchIntent` is a
+ * side effect during render, the same class of bug React's strict mode
+ * exists to catch. `session-composer.tsx`'s current `onSuccess: (session) =>
+ * navigate(...)` callbacks are exactly this effect, just run from inside
+ * TanStack's own success callback instead of from render - #936 needs this
+ * six-plus times when it migrates them.
+ *
+ * `useIntentEffect` fires `onSucceeded` from a real `useEffect`, and exactly
+ * once per *new* terminal transition rather than once per render while the
+ * intent happens to still read `succeeded` - `useIntent` builds a fresh
+ * `Intent` object every render, so identity-comparing `intent` itself would
+ * fire on every render; this compares the carried `value` instead, which
+ * TanStack keeps referentially stable between renders until a new mutation
+ * actually resolves.
+ *
+ * Deliberately implemented through `matchIntent` rather than reading
+ * `intent.status` directly - the eliminator has to be sufficient for this
+ * use case too, not just for rendering.
+ */
+
+import { useEffect, useRef } from "react"
+import type { Intent } from "@some-ui/intent-kit"
+import { matchIntent } from "@some-ui/intent-kit"
+
+const NOT_YET_SEEN: unique symbol = Symbol(
+  "useIntentEffect: no success observed yet"
+)
+
+export function useIntentEffect<T, TStep extends string = never>(
+  intent: Intent<T, TStep>,
+  onSucceeded: (value: T) => void
+): void {
+  const lastValueRef = useRef<T | typeof NOT_YET_SEEN>(NOT_YET_SEEN)
+  const onSucceededRef = useRef(onSucceeded)
+
+  // A ref's `.current` may not be written during render (React 19 enforces
+  // this) - kept current via its own effect instead, declared before the
+  // one that reads it so it has already run by the time that one does:
+  // React fires a component's effects in declaration order on every commit.
+  useEffect(() => {
+    onSucceededRef.current = onSucceeded
+  })
+
+  // No dependency array, deliberately: `intent` is a fresh object every
+  // render (see this module's header), so it can't usefully gate the
+  // effect - the ref comparison below is what makes this fire once per
+  // transition instead of once per render.
+  useEffect(() => {
+    matchIntent(intent, {
+      idle: () => undefined,
+      working: () => undefined,
+      failed: () => undefined,
+      succeeded: (value) => {
+        if (Object.is(lastValueRef.current, value)) return
+        lastValueRef.current = value
+        onSucceededRef.current(value)
+      },
+    })
+  })
+}

--- a/apps/www/src/lib/intent/use-intent.test.tsx
+++ b/apps/www/src/lib/intent/use-intent.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { JSX, ReactNode } from "react"
+import type { Intent } from "@some-ui/intent-kit"
+import { matchIntent } from "@some-ui/intent-kit"
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+} from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useIntent } from "./use-intent"
+
+function withQueryClient(): {
+  wrapper: (props: { children: ReactNode }) => JSX.Element
+} {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  return {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  }
+}
+
+/** Reads the current state through the sealed accessor, the same way a
+ * real consumer would - never `.state.status` directly. */
+function summarize<T>(state: Intent<T>): string {
+  return matchIntent(state, {
+    idle: () => "idle",
+    working: () => "working",
+    succeeded: (value) => `succeeded:${JSON.stringify(value)}`,
+    failed: (error) => `failed:${error.kind}`,
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useIntent", () => {
+  it("starts idle, and the sequence idle -> working -> succeeded matches the real mutation", async () => {
+    const { wrapper } = withQueryClient()
+    // Held open under the test's own control rather than a fixed delay: a
+    // timer-based delay races against however TanStack's mutation observer
+    // happens to schedule its own notifications, which is exactly what made
+    // this assertion flaky before. A promise that only resolves when the
+    // test says so makes "working" a stable state to observe, not a window
+    // to get lucky catching.
+    let resolveMutation: ((value: string) => void) | undefined
+    const mutationFn = vi.fn(
+      (input: string) =>
+        new Promise<string>((resolve) => {
+          resolveMutation = (): void => {
+            resolve(`created:${input}`)
+          }
+        })
+    )
+
+    const { result } = renderHook(
+      () =>
+        useIntent(useMutation({ mutationFn }), { presentation: "interactive" }),
+      { wrapper }
+    )
+
+    expect(summarize(result.current.state)).toBe("idle")
+
+    act(() => {
+      result.current.start("session-a")
+    })
+
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe("working")
+    })
+
+    act(() => {
+      resolveMutation?.("session-a")
+    })
+
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe(
+        'succeeded:"created:session-a"'
+      )
+    })
+
+    expect(mutationFn.mock.calls).toHaveLength(1)
+    expect(mutationFn.mock.calls[0]?.[0]).toBe("session-a")
+  })
+
+  it("maps a rejected mutation to a failed intent carrying a working retry", async () => {
+    const { wrapper } = withQueryClient()
+    const mutationFn = vi
+      .fn<(input: string) => Promise<string>>()
+      .mockRejectedValue(new Error("boom"))
+
+    const { result } = renderHook(
+      () =>
+        useIntent(useMutation({ mutationFn }), { presentation: "interactive" }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.start("session-a")
+    })
+
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe("failed:unknown")
+    })
+
+    mutationFn.mockClear()
+    mutationFn.mockResolvedValueOnce("recovered")
+
+    matchIntent(result.current.state, {
+      idle: () => undefined,
+      working: () => undefined,
+      succeeded: () => undefined,
+      failed: (_error, retry) => {
+        act(() => {
+          retry()
+        })
+      },
+    })
+
+    // retry() re-ran with the original variables ("session-a"), not
+    // something re-derived or lost - #943's own named regression risk.
+    // (TanStack's mutationFn also receives an internal context object as a
+    // second argument; only the caller-supplied variable is asserted here.)
+    await waitFor(() => {
+      expect(mutationFn.mock.calls).toHaveLength(1)
+    })
+    expect(mutationFn.mock.calls[0]?.[0]).toBe("session-a")
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe('succeeded:"recovered"')
+    })
+  })
+
+  it("uses a custom mapError when supplied, instead of the file_host default", async () => {
+    const { wrapper } = withQueryClient()
+    const mutationFn = vi
+      .fn<(input: string) => Promise<string>>()
+      .mockRejectedValue(new Error("domain-specific failure"))
+
+    const { result } = renderHook(
+      () =>
+        useIntent(useMutation({ mutationFn }), {
+          presentation: "interactive",
+          mapError: () => ({
+            kind: "rejected",
+            retryable: false,
+            summary: "custom summary",
+            cause: "custom cause",
+          }),
+        }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.start("x")
+    })
+
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe("failed:rejected")
+    })
+  })
+
+  it("reset() returns a succeeded intent to idle", async () => {
+    const { wrapper } = withQueryClient()
+    // eslint-disable-next-line @typescript-eslint/require-await -- mutationFn's contract is Promise<T>; async is the plainest way to satisfy it for a stub with nothing to actually await.
+    const mutationFn = vi.fn(async (_input: string) => "done")
+
+    const { result } = renderHook(
+      () =>
+        useIntent(useMutation({ mutationFn }), { presentation: "interactive" }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.start("x")
+    })
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe('succeeded:"done"')
+    })
+
+    act(() => {
+      result.current.reset()
+    })
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe("idle")
+    })
+  })
+
+  it("exposes the presentation option unchanged, for the renderer to read", () => {
+    const { wrapper } = withQueryClient()
+    // eslint-disable-next-line @typescript-eslint/require-await -- mutationFn's contract is Promise<T>; async is the plainest way to satisfy it for a stub with nothing to actually await.
+    const mutationFn = vi.fn(async () => "done")
+
+    const { result } = renderHook(
+      () => useIntent(useMutation({ mutationFn }), { presentation: "ambient" }),
+      { wrapper }
+    )
+
+    expect(result.current.presentation).toBe("ambient")
+  })
+
+  it("does not expose a raw status or isPending - only `state` and `presentation` are on the result", () => {
+    const { wrapper } = withQueryClient()
+    // eslint-disable-next-line @typescript-eslint/require-await -- mutationFn's contract is Promise<T>; async is the plainest way to satisfy it for a stub with nothing to actually await.
+    const mutationFn = vi.fn(async () => "done")
+
+    const { result } = renderHook(
+      () =>
+        useIntent(useMutation({ mutationFn }), { presentation: "interactive" }),
+      { wrapper }
+    )
+
+    expect(Object.keys(result.current).sort()).toEqual([
+      "presentation",
+      "reset",
+      "start",
+      "state",
+    ])
+  })
+
+  it("leaves the underlying mutation's own onMutate/onSuccess/onSettled behaviour untouched", async () => {
+    const { wrapper } = withQueryClient()
+    const calls: Array<string> = []
+    // eslint-disable-next-line @typescript-eslint/require-await -- mutationFn's contract is Promise<T>; async is the plainest way to satisfy it for a stub with nothing to actually await.
+    const mutationFn = vi.fn(async (input: string) => `created:${input}`)
+
+    const { result } = renderHook(
+      () =>
+        useIntent(
+          useMutation({
+            mutationFn,
+            onMutate: (variables) => {
+              calls.push(`onMutate:${variables}`)
+            },
+            onSuccess: (data) => {
+              calls.push(`onSuccess:${data}`)
+            },
+            onSettled: () => {
+              calls.push("onSettled")
+            },
+          }),
+          { presentation: "interactive" }
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.start("session-a")
+    })
+
+    await waitFor(() => {
+      expect(summarize(result.current.state)).toBe(
+        'succeeded:"created:session-a"'
+      )
+    })
+
+    expect(calls).toEqual([
+      "onMutate:session-a",
+      "onSuccess:created:session-a",
+      "onSettled",
+    ])
+  })
+})

--- a/apps/www/src/lib/intent/use-intent.ts
+++ b/apps/www/src/lib/intent/use-intent.ts
@@ -1,0 +1,137 @@
+/**
+ * The React binding over `UseMutationResult` — per #935's Pushback 1, a
+ * projection, not a replacement. The mutation still runs through TanStack
+ * exactly as `lib/tenant/hooks.ts` defines it: `queryClient.invalidateQueries`
+ * on success, `useUpdateSession`'s `onMutate` snapshot for optimistic
+ * rollback, `reportSessionTransition` firing from `onSuccess`. None of that
+ * moves. What changes is the accessor: `UseMutationResult.status` is a bare
+ * string on an object with twenty other fields, and reading it is optional -
+ * which is why #934's census found it unread at every one of 17 call sites.
+ * `useIntent` returns a value whose only accessor is `matchIntent`.
+ *
+ * ## What this deliberately does not do
+ *
+ * `start` wraps `mutate` but does not re-expose per-call `onSuccess`/
+ * `onError`. That escape hatch is today's actual pattern (see
+ * `session-composer.tsx`'s inline `onSuccess` callbacks), and a boundary
+ * with a bypass is not a boundary. A success continuation belongs in the
+ * `succeeded` arm of `matchIntent`, or - for a side effect that must not
+ * run during render, like `navigate(...)` - in `useIntentEffect` (see that
+ * module). This is expected to be the friction point when #936 migrates
+ * `session-composer.tsx`'s `void navigate(...)`-in-`onSuccess` call sites;
+ * that friction is the point, not a bug to route around.
+ *
+ * ## The double-terminal case
+ *
+ * TanStack keeps `status: "success"` (and the intent stays `succeeded`)
+ * until something changes it. There is no automatic reversion to `idle` -
+ * for a form that can be legitimately re-submitted, gate the control the
+ * same way `SettingsForm`/`ProfileForm` already do (`disabled={!isDirty}`),
+ * so a fresh edit is what makes `succeeded` stop being shown, not a timer.
+ * Call `reset()` explicitly when the intent itself needs to return to
+ * `idle` without a new edit prompting it (e.g. navigating away and back to
+ * the same form instance).
+ */
+
+import { useCallback } from "react"
+import type {
+  Intent,
+  IntentError,
+  IntentPresentation,
+} from "@some-ui/intent-kit"
+import { failed, idle, succeeded, working } from "@some-ui/intent-kit"
+import type { UseMutationResult } from "@tanstack/react-query"
+
+import { mapFileHostError } from "./errors"
+
+export type UseIntentOptions = {
+  /**
+   * Required, not defaulted - #944/S4's own point: a default here is a
+   * decision nobody made, and whether a failure may interrupt someone is
+   * exactly the decision that must not be made by omission.
+   */
+  presentation: IntentPresentation
+  /** Overrides the default `file_host` mapping. Most call sites don't need
+   * this; it exists for a mutation whose failures don't come from
+   * `file_host` at all. */
+  mapError?: (error: unknown) => IntentError
+}
+
+export type UseIntentResult<TVariables, TData, TStep extends string = never> = {
+  readonly state: Intent<TData, TStep>
+  readonly presentation: IntentPresentation
+  /** Wraps `mutate`. No per-call `onSuccess`/`onError` - see this module's
+   * header for why. */
+  readonly start: (variables: TVariables) => void
+  /** Returns the intent to `idle`, discarding the last result. See this
+   * module's header on the double-terminal case for when to call it. */
+  readonly reset: () => void
+}
+
+function assertNever(_value: never): never {
+  throw new Error("unhandled UseMutationResult status")
+}
+
+/**
+ * Wraps one `UseMutationResult`. `TVariables`/`TData` are inferred from the
+ * mutation; the mutation's own `mutationFn`, `onMutate`, `onSuccess`,
+ * `onSettled` are untouched and still fire exactly as `lib/tenant/hooks.ts`
+ * defines them - `useIntent` only reads `status`/`data`/`error`/`variables`
+ * off the result TanStack already computed.
+ */
+export function useIntent<TVariables, TData, TStep extends string = never>(
+  mutation: UseMutationResult<TData, unknown, TVariables>,
+  options: UseIntentOptions
+): UseIntentResult<TVariables, TData, TStep> {
+  const mapError = options.mapError ?? mapFileHostError
+  const { mutate, variables, reset: mutationReset } = mutation
+
+  const retry = useCallback((): void => {
+    // TanStack retains the variables from the last `mutate()` call on the
+    // result itself; re-deriving them locally would risk disagreeing with
+    // what actually ran. Nothing to retry with means nothing to do - not a
+    // state `matchIntent`'s `failed` arm should ever actually observe,
+    // since `retry` only exists once a mutation has already run once.
+    if (variables === undefined) return
+    mutate(variables)
+  }, [mutate, variables])
+
+  const start = useCallback(
+    (nextVariables: TVariables): void => {
+      mutate(nextVariables)
+    },
+    [mutate]
+  )
+
+  const reset = useCallback((): void => {
+    mutationReset()
+  }, [mutationReset])
+
+  const state = ((): Intent<TData, TStep> => {
+    // Switching on the destructured status (rather than `mutation.status`
+    // inline) so the compiler narrows a plain string literal in the default
+    // arm - narrowing `mutation.status` directly narrows `mutation` itself
+    // to `never` once every case is covered, and `never` has no `.status`
+    // to read at all.
+    const { status } = mutation
+    switch (status) {
+      case "idle": {
+        return idle()
+      }
+      case "pending": {
+        return working()
+      }
+      case "success": {
+        return succeeded(mutation.data)
+      }
+      case "error": {
+        return failed(mapError(mutation.error), retry)
+      }
+      default: {
+        return assertNever(status)
+      }
+    }
+  })()
+
+  return { state, presentation: options.presentation, start, reset }
+}

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "ignore": ["**/bindings-contract.ts", "apps/www/public/sw.js"],
+  "ignore": [
+    "**/bindings-contract.ts",
+    "apps/www/public/sw.js",
+    "**/__type-fixtures__/**"
+  ],
   "workspaces": {
     "apps/www": {
       "ignoreDependencies": ["@some-ui/resume"]

--- a/packages/intent-kit/eslint.config.js
+++ b/packages/intent-kit/eslint.config.js
@@ -1,0 +1,3 @@
+import someUIEslint from "@some-ui/eslint-kit"
+
+export default someUIEslint

--- a/packages/intent-kit/package.json
+++ b/packages/intent-kit/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@some-ui/intent-kit",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "The sealed intent typestate: a four-arm union and an exhaustive eliminator for what a user-initiated effect can be doing right now.",
+  "license": "MIT",
+  "homepage": "https://pgdev.maishatu.com/?tab=github",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paulgsc/some-ui"
+  },
+  "bugs": {
+    "url": "https://github.com/paulgsc/some-ui/issues"
+  },
+  "keywords": [],
+  "main": "./dist/@some-ui/intent-kit.cjs.js",
+  "module": "./dist/@some-ui/intent-kit.es.js",
+  "types": "./dist/@some-ui/intent-kit.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/@some-ui/intent-kit.d.ts",
+      "import": "./dist/@some-ui/intent-kit.es.js",
+      "require": "./dist/@some-ui/intent-kit.cjs.js",
+      "default": "./dist/@some-ui/intent-kit.es.js"
+    },
+    "./style.css": "./dist/intent-kit.css"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {},
+  "devDependencies": {
+    "@some-ui/tsconfig": "workspace:*",
+    "@some-ui/vite-config": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && vite build",
+    "build:tsc-alias": "tsc-alias -p tsconfig.json",
+    "clean": "rimraf .turbo && rimraf node_modules && rimraf .eslintcache && pnpm clean:build",
+    "clean:build": "rimraf ./dist && rimraf tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
+    "knip": "knip --directory \"$(git rev-parse --show-toplevel)\" --workspace \"$(git rev-parse --show-prefix | sed 's:/*$::')\"",
+    "lint": "pnpm lint:js && pnpm prettier && pnpm typecheck",
+    "lint:js": "cross-env NODE_OPTIONS='--max_old_space_size=4096' eslint \"**/*.{js,mjs,ts,tsx}\" --cache",
+    "prettier": "prettier . --ignore-path $(git rev-parse --show-toplevel)/.prettierignore --check --cache",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "style": "./dist/intent-kit.css",
+  "sideEffects": [
+    "*.css"
+  ]
+}

--- a/packages/intent-kit/src/__type-fixtures__/matchIntent.fixtures.ts
+++ b/packages/intent-kit/src/__type-fixtures__/matchIntent.fixtures.ts
@@ -1,0 +1,67 @@
+/**
+ * Type-level proof that `matchIntent`'s exhaustiveness is a compiler
+ * guarantee, not a convention. Every `@ts-expect-error` below has to be
+ * lying about a real error one line down, or TypeScript's own
+ * "unused '@ts-expect-error' directive" diagnostic turns red — which is
+ * exactly the mechanism S1's acceptance criterion asks for: weaken
+ * `IntentArms` (make an arm optional, add a `default`) and the fixture that
+ * exercises it stops erroring, and its directive itself becomes the
+ * failure.
+ *
+ * Not a `*.test.ts` - it must be part of the ordinary `tsc --noEmit` run
+ * (excluded from the build via tsconfig.build.json), not something that
+ * only runs under vitest. Nothing here executes; `void` on every binding
+ * exists only to satisfy `noUnusedLocals`.
+ */
+
+import { failed, idle, matchIntent } from "../intent"
+import type { Intent } from "../intent"
+import { toIntentError } from "../intent-error"
+
+const anIntent: Intent<number> = idle()
+
+// Missing arm: `failed` is required by `IntentArms`.
+// @ts-expect-error - missing the required `failed` arm
+const missingArm = matchIntent(anIntent, {
+  idle: () => null,
+  working: () => null,
+  succeeded: () => null,
+})
+void missingArm
+
+// Extra arm: `cancelled` isn't part of the sealed vocabulary - see intent.ts's
+// header for why there is no fifth state to handle. The excess-property
+// error TypeScript reports is anchored on the offending property itself,
+// not the call - the directive has to sit immediately above that line.
+const extraArm = matchIntent(anIntent, {
+  idle: () => null,
+  working: () => null,
+  succeeded: () => null,
+  failed: () => null,
+  // @ts-expect-error - `cancelled` is not a key of IntentArms
+  cancelled: () => null,
+})
+void extraArm
+
+// Reading a field off an unnarrowed union: `.value` only exists on the
+// `succeeded` member, and there is no `.status` switch exposed to narrow it
+// with outside of `matchIntent` itself.
+// @ts-expect-error - `.value` does not exist on every member of Intent<number>
+const unnarrowedValue = anIntent.value
+void unnarrowedValue
+
+// Constructing `failed` without a retry: a failed intent with nothing to
+// retry is the dead-button defect this whole vocabulary exists to prevent.
+// @ts-expect-error - `failed` requires a `retry` callback
+const noRetry = failed(toIntentError(new Error("boom")))
+void noRetry
+
+// Sanity: the well-formed call compiles with no errors, so the fixtures
+// above are proven against real code, not a typo.
+const wellFormed = matchIntent(anIntent, {
+  idle: () => 0,
+  working: () => 0,
+  succeeded: (value) => value,
+  failed: () => 0,
+})
+void wellFormed

--- a/packages/intent-kit/src/index.ts
+++ b/packages/intent-kit/src/index.ts
@@ -1,0 +1,7 @@
+export type { Intent, IntentArms } from "./intent"
+export { failed, idle, matchIntent, succeeded, working } from "./intent"
+
+export type { IntentError, IntentErrorKind } from "./intent-error"
+export { toIntentError } from "./intent-error"
+
+export type { IntentPresentation } from "./presentation"

--- a/packages/intent-kit/src/intent-error.test.ts
+++ b/packages/intent-kit/src/intent-error.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import { toIntentError } from "./intent-error"
+
+describe("toIntentError", () => {
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["a string", "network exploded"],
+    ["a number", 42],
+    ["a plain object", { message: "not an Error instance" }],
+    ["a real Error", new Error("boom")],
+    [
+      "a DOMException (an aborted fetch)",
+      new DOMException("aborted", "AbortError"),
+    ],
+    ["an array", [1, 2, 3]],
+  ])(
+    "never throws for %s, and returns a valid IntentError",
+    (_label, input): void => {
+      const result = toIntentError(input)
+
+      expect(result.kind).toBe("unknown")
+      expect(result.retryable).toBe(true)
+      expect(typeof result.summary).toBe("string")
+      expect(result.summary.length).toBeGreaterThan(0)
+      // cause is required, and is the original value untouched - the
+      // diagnostic channel this vocabulary exists to keep separate from the
+      // one a person actually sees.
+      expect(result.cause).toBe(input)
+    }
+  )
+
+  it("is total: calling it in a loop over an adversarial input set never throws", () => {
+    const adversarial: ReadonlyArray<unknown> = [
+      undefined,
+      null,
+      0,
+      Number.NaN,
+      "",
+      Symbol("x"),
+      new Response(null, { status: 500 }),
+      (): never => {
+        throw new Error("should never be called")
+      },
+    ]
+
+    for (const input of adversarial) {
+      expect(() => toIntentError(input)).not.toThrow()
+    }
+  })
+})

--- a/packages/intent-kit/src/intent-error.ts
+++ b/packages/intent-kit/src/intent-error.ts
@@ -1,0 +1,76 @@
+/**
+ * The user-facing projection of whatever actually failed.
+ *
+ * This is not a fourth parallel error taxonomy — `apps/www/src/lib/file-host-config/client.ts`'s
+ * three `FileHost*Error` classes and `@some-ui/fetch-kit`'s `ApiError` stay
+ * exactly as they are; this is what they get mapped *to* at the boundary
+ * that actually knows what a person needs to hear. `intent-kit` itself
+ * knows nothing about HTTP, `file_host`, or any other transport — the
+ * mapping lives with whichever app or package owns the transport (see
+ * `apps/www/src/lib/intent/errors.ts`).
+ *
+ * `unauthorized` is deliberately absent from `kind`. Nothing in this
+ * workspace has an auth layer that can produce one today, and an
+ * unreachable arm in a union whose entire value is exhaustiveness teaches
+ * every reader that arms are decorative. Add it back the day something
+ * actually produces it.
+ */
+
+/**
+ * - `unreachable` — the transport is down (a dead LAN box, mixed content, a
+ *   process that isn't running). Usually retryable: the request never
+ *   landed anywhere.
+ * - `rejected` — a real answer came back and said no (a non-2xx with a
+ *   server-side reason). Retryable depends on whether the reason is
+ *   transient.
+ * - `unavailable` — the feature the caller wants doesn't exist on this
+ *   deployment and never will without reconfiguration. Not retryable: no
+ *   number of retries changes an absent capability.
+ * - `unknown` — anything this boundary didn't recognise. `toIntentError`
+ *   always lands here rather than throwing; a normalizer that can fail is a
+ *   new silent-failure family, which is exactly what this vocabulary exists
+ *   to close off.
+ */
+export type IntentErrorKind =
+  | "unreachable"
+  | "rejected"
+  | "unavailable"
+  | "unknown"
+
+export type IntentError = {
+  readonly kind: IntentErrorKind
+  /** Whether re-running the same intent could plausibly succeed. Derived
+   * from the error class by the boundary's own mapper, never hand-set per
+   * call site — see `apps/www/src/lib/intent/errors.ts`'s header for why. */
+  readonly retryable: boolean
+  /** For a person. Plain text, no markup, safe to render as-is. */
+  readonly summary: string
+  /**
+   * For a developer. Never rendered — required rather than optional so the
+   * diagnostic channel and the signal channel can't drift apart by one
+   * being forgotten. Log it, attach it to a report; do not put it in the
+   * DOM.
+   */
+  readonly cause: unknown
+}
+
+const GENERIC_SUMMARY = "Something didn't work. You can try again."
+
+/**
+ * The fallback normalizer: total, and never throws. Anything this function
+ * doesn't recognise still produces a valid `IntentError` — `kind: "unknown"`,
+ * `retryable: true`, because the safer default for a failure this boundary
+ * can't name is to let a person try again rather than to tell them not to.
+ *
+ * App/package boundaries that know about a specific transport (file_host,
+ * a REST client, …) should normalize first and fall back to this only for
+ * what they don't recognise — see `apps/www/src/lib/intent/errors.ts`.
+ */
+export function toIntentError(error: unknown): IntentError {
+  return {
+    kind: "unknown",
+    retryable: true,
+    summary: GENERIC_SUMMARY,
+    cause: error,
+  }
+}

--- a/packages/intent-kit/src/intent.test.ts
+++ b/packages/intent-kit/src/intent.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { failed, idle, matchIntent, succeeded, working } from "./intent"
+import type { Intent } from "./intent"
+import { toIntentError } from "./intent-error"
+
+describe("matchIntent", () => {
+  it("dispatches idle", () => {
+    const result = matchIntent(idle(), {
+      idle: () => "idle",
+      working: () => "working",
+      succeeded: () => "succeeded",
+      failed: () => "failed",
+    })
+    expect(result).toBe("idle")
+  })
+
+  it("dispatches working, passing through an omitted step", () => {
+    const seenSteps: Array<string | undefined> = []
+    matchIntent(working(), {
+      idle: () => undefined,
+      working: (step) => {
+        seenSteps.push(step)
+      },
+      succeeded: () => undefined,
+      failed: () => undefined,
+    })
+    expect(seenSteps).toEqual([undefined])
+  })
+
+  it("dispatches working with a composite step", () => {
+    const seenSteps: Array<string | undefined> = []
+    const intent: Intent<never, "create" | "activate"> = working("activate")
+    matchIntent(intent, {
+      idle: () => undefined,
+      working: (step) => {
+        seenSteps.push(step)
+      },
+      succeeded: () => undefined,
+      failed: () => undefined,
+    })
+    expect(seenSteps).toEqual(["activate"])
+  })
+
+  it("dispatches succeeded, handing the value to its arm", () => {
+    const result = matchIntent(succeeded(42), {
+      idle: () => 0,
+      working: () => 0,
+      succeeded: (value) => value,
+      failed: () => 0,
+    })
+    expect(result).toBe(42)
+  })
+
+  it("dispatches failed, handing the error and a working retry to its arm", () => {
+    const retry = vi.fn()
+    const error = toIntentError(new Error("boom"))
+    let seenError: unknown
+    let seenRetry: (() => void) | undefined
+
+    matchIntent(failed(error, retry), {
+      idle: () => undefined,
+      working: () => undefined,
+      succeeded: () => undefined,
+      failed: (err, retryFn) => {
+        seenError = err
+        seenRetry = retryFn
+      },
+    })
+
+    expect(seenError).toBe(error)
+    seenRetry?.()
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  it("is total over every status the constructors can produce", () => {
+    // Programmatically enumerated so a fifth constructor added later without
+    // a matching arm fails this test even in plain JS, not only under tsc -
+    // the runtime backstop to the @ts-expect-error fixtures.
+    const retry = vi.fn()
+    const error = toIntentError(new Error("boom"))
+    const sample: ReadonlyArray<Intent<number>> = [
+      idle(),
+      working(),
+      succeeded(1),
+      failed(error, retry),
+    ]
+
+    for (const intent of sample) {
+      expect(() =>
+        matchIntent(intent, {
+          idle: () => null,
+          working: () => null,
+          succeeded: () => null,
+          failed: () => null,
+        })
+      ).not.toThrow()
+    }
+  })
+
+  it("throws rather than silently returning for an unrecognised status (defensive, not reachable through the constructors)", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- deliberately constructing a status this module's own constructors cannot produce, to exercise the assertNever fallback.
+    const bogus = { status: "bogus" } as unknown as Intent<number>
+    expect(() =>
+      matchIntent(bogus, {
+        idle: () => null,
+        working: () => null,
+        succeeded: () => null,
+        failed: () => null,
+      })
+    ).toThrow(/unhandled Intent status/)
+  })
+})
+
+describe("constructors", () => {
+  it("build object literals a hand-written one could smuggle a bad shape past", () => {
+    expect(idle()).toEqual({ status: "idle" })
+    expect(working()).toEqual({ status: "working", step: undefined })
+    expect(succeeded("x")).toEqual({ status: "succeeded", value: "x" })
+
+    const retry = (): void => undefined
+    const error = toIntentError("nope")
+    expect(failed(error, retry)).toEqual({ status: "failed", error, retry })
+  })
+})

--- a/packages/intent-kit/src/intent.ts
+++ b/packages/intent-kit/src/intent.ts
@@ -1,0 +1,136 @@
+/**
+ * The invariant, in #933's own words: every user-initiated effect must
+ * terminate in a state a person can observe, and the *only* way to read
+ * that state is to handle all of it. `TanStack Query`'s `UseMutationResult`
+ * already carries the full lifecycle (`status`, `data`, `error`) — the
+ * problem #934's census found was never a missing state, it was that
+ * reading the state is optional: `status` sits on a result object with
+ * twenty other fields, and nothing forces a consumer to look at it. All 17
+ * call sites in that census simply didn't.
+ *
+ * `Intent` is a projection of that lifecycle, not a replacement for it —
+ * see `apps/www/src/lib/intent/use-intent.ts` for the `UseMutationResult`
+ * adapter. This module is the sealed part: a value that cannot be read
+ * except through `matchIntent`, which cannot be called without an arm for
+ * every state.
+ *
+ * ## Four states, not five
+ *
+ * `Idle | Working | Succeeded | Failed`. No `Cancelled`: nothing in
+ * `apps/www` today threads an `AbortController` through a mutation, every
+ * write is `mutations: { retry: false }` (a single immediate attempt), and
+ * the longest observed one is a `POST` to a LAN service — #934's S3
+ * classification confirmed no intent in the population needs it. Adding
+ * `cancelled` in advance of a real caller means all 17 migrated call sites
+ * render a dead arm (`() => null`) for a state that cannot occur, which
+ * teaches every future reader that arms are ceremony rather than a
+ * decision. When a genuinely cancellable intent lands (a long upload, a
+ * streamed generation), adding the state will force a deliberate audit of
+ * every consumer — which is the correct moment to pay that cost, not now.
+ *
+ * `idle` stays even though it is the one arguably-redundant state, because
+ * it is reachable at every call site from first render and is where the
+ * "not yet clicked" affordance lives.
+ */
+
+import type { IntentError } from "./intent-error"
+
+/**
+ * `working`'s optional `step` is for a composite intent — the
+ * create→update→navigate chain in `session-composer.tsx:241` is one
+ * intent, not three, and "saved, but couldn't start" needs to be
+ * expressible without inventing a fifth top-level state. `TStep` is
+ * `never` by default so a simple, non-composite intent's `working` arm
+ * takes no argument and callers don't pay for a feature they don't use.
+ */
+export type Intent<T, TStep extends string = never> =
+  | { readonly status: "idle" }
+  | { readonly status: "working"; readonly step?: TStep }
+  | { readonly status: "succeeded"; readonly value: T }
+  | {
+      readonly status: "failed"
+      readonly error: IntentError
+      readonly retry: () => void
+    }
+
+/**
+ * Every arm required, no `default`, no `Partial<>`. Each escape hatch this
+ * signature could offer is the invariant being opted out of by exactly the
+ * people most likely to need it — see the package README and the
+ * `@ts-expect-error` fixtures in `src/__type-fixtures__/`.
+ */
+export type IntentArms<T, R, TStep extends string = never> = {
+  idle: () => R
+  working: (step?: TStep) => R
+  succeeded: (value: T) => R
+  failed: (error: IntentError, retry: () => void) => R
+}
+
+function assertNever(_value: never): never {
+  // `_value` is `never` at every real call site - the only way to reach this
+  // at runtime is a status this module doesn't know about, which is exactly
+  // the defensive case `matchIntent`'s own test exercises directly. No safe,
+  // assertion-free way to read `.status` off a `never`-typed value, so the
+  // message stays generic rather than reaching for one.
+  throw new Error(
+    "unhandled Intent status - a status matchIntent's callers cannot have constructed through this module's own constructors"
+  )
+}
+
+/**
+ * The only way to read an `Intent`. There is deliberately no `.status`
+ * switch exposed at the call site and no way to read `.value` or `.error`
+ * without going through the matching arm — see the `@ts-expect-error`
+ * fixtures for what that actually blocks.
+ */
+export function matchIntent<T, R, TStep extends string = never>(
+  intent: Intent<T, TStep>,
+  arms: IntentArms<T, R, TStep>
+): R {
+  switch (intent.status) {
+    case "idle": {
+      return arms.idle()
+    }
+    case "working": {
+      return arms.working(intent.step)
+    }
+    case "succeeded": {
+      return arms.succeeded(intent.value)
+    }
+    case "failed": {
+      return arms.failed(intent.error, intent.retry)
+    }
+    default: {
+      return assertNever(intent)
+    }
+  }
+}
+
+/**
+ * Constructors. Consumers should build an `Intent` through these rather
+ * than an object literal — a hand-built literal is where a fifth state (or
+ * a `failed` with no `retry`) gets smuggled in without either the compiler
+ * or a reviewer skimming a diff noticing.
+ */
+export function idle<T, TStep extends string = never>(): Intent<T, TStep> {
+  return { status: "idle" }
+}
+
+export function working<T, TStep extends string = never>(
+  step?: TStep
+): Intent<T, TStep> {
+  return { status: "working", step }
+}
+
+export function succeeded<T, TStep extends string = never>(
+  value: T
+): Intent<T, TStep> {
+  return { status: "succeeded", value }
+}
+
+export function failed<T, TStep extends string = never>(
+  error: IntentError,
+  retry: () => void
+): Intent<T, TStep> {
+  return { status: "failed", error, retry }
+}

--- a/packages/intent-kit/src/package-shape.test.ts
+++ b/packages/intent-kit/src/package-shape.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The mechanical half of #935's Pushback 3 / Doctrine split: this package
+ * clears the Shared-Workspace Doctrine's prongs 2 and 3 (a rarely-churning,
+ * orthogonal contract) but not prong 1 (a second genuine consumer, today) —
+ * see the epic body's own note about deliberately overriding the `-4` line.
+ * What keeps that override honest is that the package stays *actually*
+ * dependency-free, and that is invisible to a reviewer skimming a diff. A
+ * test that reads the manifest is not.
+ */
+
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PACKAGE_JSON_PATH = resolve(HERE, "../package.json")
+
+type PackageManifest = {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+function readManifest(): PackageManifest {
+  const raw: unknown = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8"))
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- parsing package.json into a typed shape has no assertion-free alternative.
+  return raw as PackageManifest
+}
+
+const FORBIDDEN_SUBSTRINGS = ["react", "tanstack", "zod"]
+
+describe("package.json stays dependency-free", () => {
+  it("has no runtime dependencies at all", () => {
+    const manifest = readManifest()
+    expect(manifest.dependencies ?? {}).toEqual({})
+  })
+
+  it("has no devDependency or peerDependency on React, TanStack Query, or zod", () => {
+    const manifest = readManifest()
+    const names = [
+      ...Object.keys(manifest.devDependencies ?? {}),
+      ...Object.keys(manifest.peerDependencies ?? {}),
+    ]
+
+    for (const name of names) {
+      const lower = name.toLowerCase()
+      for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+        expect(
+          lower.includes(forbidden),
+          `${name} in devDependencies/peerDependencies looks like it pulls in ${forbidden} - packages/intent-kit must not know what HTTP, React, or a query cache is (see #935 Pushback 3)`
+        ).toBe(false)
+      }
+    }
+  })
+
+  it("has no peerDependencies at all - nothing here needs runtime injection", () => {
+    const manifest = readManifest()
+    expect(manifest.peerDependencies ?? {}).toEqual({})
+  })
+})

--- a/packages/intent-kit/src/presentation.ts
+++ b/packages/intent-kit/src/presentation.ts
@@ -1,0 +1,20 @@
+/**
+ * At most the enum — per S4/#944's own acceptance criterion, `intent-kit`
+ * "gains at most the presentation enum, and nothing that knows how anything
+ * is rendered." What each mode *permits*, what surface an ambient failure
+ * gets, and the advisory-vs-enforced decision all live in
+ * `apps/www/src/lib/intent/presentation.ts`, because all of that has an
+ * opinion about a design system this package must not know exists.
+ *
+ * Three values, not two. #934's census found one producer — the debounced
+ * layout autosave (`components/player/use-live-layout-editor.ts:64,81,112`)
+ * — that a two-way interactive/ambient split cannot express honestly: the
+ * person did not ask for the save, so interrupting them is wrong
+ * (ambient), but a silent failure loses arrangement work they just
+ * authored, which plain "ambient" would allow (see the census's own
+ * `layout-autosave` row and its justification). `"ambient-durable"` names
+ * that third case: progress may still be quiet, but a failure must survive
+ * the tab — it cannot resolve to nothing the way a pure `"ambient"`
+ * failure is allowed to.
+ */
+export type IntentPresentation = "interactive" | "ambient" | "ambient-durable"

--- a/packages/intent-kit/tsconfig.build.json
+++ b/packages/intent-kit/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/__type-fixtures__/**"]
+}

--- a/packages/intent-kit/tsconfig.json
+++ b/packages/intent-kit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@some-ui/tsconfig/rollupconfig.json",
+  "compilerOptions": {
+    "declarationDir": "./",
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {
+      "@intent-kit/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "build", "dist"]
+}

--- a/packages/intent-kit/vite.config.ts
+++ b/packages/intent-kit/vite.config.ts
@@ -1,0 +1,10 @@
+import { resolve } from "path"
+import { createViteConfig } from "@some-ui/vite-config"
+
+export default createViteConfig({
+  packageName: "@some-ui/intent-kit",
+  libraryName: "SomeIntentKit",
+  alias: {
+    "@intent-kit": resolve(__dirname, "src"),
+  },
+})

--- a/packages/intent-kit/vitest.config.ts
+++ b/packages/intent-kit/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    // Pure logic - no React, no DOM. A test needing jsdom here would be the
+    // Doctrine §1/Pushback 3 split (packages/SHARED_WORKSPACE_DOCTRINE.md)
+    // having been violated; see the package's own tsconfig/package.json
+    // tests for the mechanical check.
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.{ts,tsx}"],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       '@some-ui/honeycomb':
         specifier: workspace:*
         version: link:../../packages/ui/honeycomb
+      '@some-ui/intent-kit':
+        specifier: workspace:*
+        version: link:../../packages/intent-kit
       '@some-ui/shared':
         specifier: workspace:*
         version: link:../../packages/ui/shared
@@ -853,6 +856,15 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.0.5
+
+  packages/intent-kit:
+    devDependencies:
+      '@some-ui/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@some-ui/vite-config':
+        specifier: workspace:*
+        version: link:../some-vite-config
 
   packages/some-content:
     devDependencies:


### PR DESCRIPTION
## Description

Lands all four stories of #935, the INTENT-KIT epic: a new dependency-free `packages/intent-kit`, its error vocabulary, a React binding over `UseMutationResult`, and a presentation policy — the signal vocabulary #933 asked every effect to terminate in. Consumes #934's census/classification directly (the `Cancelled`-deferral and `ambient-durable` decisions both cite specific census rows). Per the epic's non-goals, **no UI, nothing wired into a live component** — that migration is #936.

### S1 — `packages/intent-kit` (#941)

`Intent<T, TStep>`: a four-state discriminated union (`idle`/`working`/`succeeded`/`failed`, no `Cancelled` — #934's S3 verdict found no intent in `apps/www` needs it today) plus `matchIntent`, an eliminator with no `default`, no `Partial<>`. Exhaustiveness is proven two ways: `@ts-expect-error` fixtures wired into `pnpm typecheck` (weaken a required arm and the fixture's own directive goes unused, which is itself a compile error — verified by temporarily doing exactly that), and a runtime totality test. The package has `dependencies: {}` and no React/TanStack/zod anywhere in `devDependencies`/`peerDependencies`, checked by a test that reads the manifest rather than left to review — the mechanical half of the epic's own Pushback 3 (Doctrine §1 override, recorded in-source for the next census to re-score).

### S2 — `IntentError` and normalizers (#942)

`IntentError` (`kind`/`retryable`/`summary`/`cause`) and a generic `toIntentError` fallback live in `intent-kit`. The `file_host`-specific mapping (`FileHostUnreachableError`→`unreachable`, `FileHostNotConfiguredError`→`unavailable`/not retryable, `FileHostResponseError`→`rejected`) lives in `apps/www/src/lib/intent/errors.ts`, keeping the shared package ignorant of what `file_host` is. Every reachable error class is enumerated in a test. `unauthorized` is dropped from the vocabulary per the issue's own recommendation — no producer exists today.

### S3 — `useIntent` (#943)

Wraps one `UseMutationResult` without touching its `onMutate`/`onSuccess`/`onSettled` — covered by a test asserting exactly that (cache invalidation, optimistic rollback, and a `reportSessionTransition`-shaped side effect all still fire). No per-call `onSuccess`/`onError` re-exposed; `useIntentEffect` handles the navigate-on-success shape instead, firing once per genuine terminal transition rather than during render. `composeSequentialIntents` proves the #933 flow itself (create → activate) end to end: a second-step failure never reverts or re-triggers the first, and `retry()` only re-runs the step that actually failed — the exact acceptance criterion the issue names.

### S4 — Presentation policy (#944)

`IntentPresentation` gains a third value, `ambient-durable`, for the one producer #934's census found a two-way split couldn't express honestly: the debounced layout autosave (silent progress is fine; a silently lost edit is not). `presentationPolicyFor` documents what each mode permits — advisory, not type-enforced, per the same Doctrine reasoning that scopes the shared package. A fixture proves presentation metadata never relaxes `matchIntent`'s required arms, ambient or not.

## Type of Change

- [x] New feature (non-breaking — nothing existing imports this yet)
- [x] This change requires a documentation update (module-level docs throughout; no `docs/` file, per the epic's own scope)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (`lint`, `typecheck`, `knip` clean in both `packages/intent-kit` and `apps/www`)
- [x] I have added tests that prove my fix is effective or that my feature works (type fixtures + runtime tests throughout, including the composite create/activate chain)
- [x] New and existing unit tests pass locally with my changes (`apps/www`: 33 files, 229 passed + 10 expected-fail unrelated from #934; `packages/intent-kit`: 3 files, 20 passed)

## Screenshots

N/A — no UI changes.

---

Closes #941
Closes #942
Closes #943
Closes #944
Closes #935


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWh4d6TVUT2KHgyDsyXPpj)_